### PR TITLE
Enhance TLS setup and add JFR reporting with GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,6 +53,17 @@ jobs:
       - name: Build & Run TCK Verification
         run: mvn clean verify -B -e
 
+      - name: Upload TCK JFR recordings
+        if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-tck-${{ github.run_number }}
+          path: |
+            exeris-kernel-*/target/*.jfr
+            exeris-kernel-*/target/jfr-reports/*.jfr
+          if-no-files-found: warn
+          retention-days: 14
+
       # Publish to GitHub Packages only on push to main (not on PRs).
       # Enterprise repo consumes SPI, Core, TCK, and BOM from here.
       - name: Publish to GitHub Packages
@@ -106,6 +117,15 @@ jobs:
             -DexcludedGroups= \
             test -B -e
 
+      - name: Upload persistence JFR recordings
+        if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-persistence-${{ github.run_number }}
+          path: exeris-kernel-community/target/*.jfr
+          if-no-files-found: warn
+          retention-days: 14
+
   benchmarks:
     name: JMH Benchmarks (Community + Core)
     # TODO: point runs-on to a dedicated bare-metal runner when available
@@ -151,6 +171,7 @@ jobs:
             -Dbenchmark.iterations=5 \
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
+            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jmh-recording.jfr,dumponexit=true,settings=default \
             verify -B -e
           mvn -pl exeris-kernel-core -P benchmarks \
             -Dbenchmark.forks=1 \
@@ -158,6 +179,7 @@ jobs:
             -Dbenchmark.iterations=5 \
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
+            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jmh-recording.jfr,dumponexit=true,settings=default \
             verify -B -e
 
       - name: Upload Community benchmark results
@@ -174,4 +196,115 @@ jobs:
           path: exeris-kernel-core/target/jmh-results.json
           if-no-files-found: warn
 
+      - name: Upload Community benchmark JFR
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-benchmarks-community-${{ github.run_number }}
+          path: exeris-kernel-community/target/jmh-recording.jfr
+          if-no-files-found: warn
+          retention-days: 14
 
+      - name: Upload Core benchmark JFR
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-benchmarks-core-${{ github.run_number }}
+          path: exeris-kernel-core/target/jmh-recording.jfr
+          if-no-files-found: warn
+          retention-days: 14
+
+  parse-jfr-to-json:
+    name: Parse JFR → Lab JSON
+    runs-on: ubuntu-latest
+    needs: build-and-verify
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache JDK tarball
+        id: jdk-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/jdk.tar.gz
+          key: ${{ env.JDK_CACHE_KEY }}
+
+      - name: Fetch JDK
+        if: steps.jdk-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          wget -q -O ${{ runner.temp }}/jdk.tar.gz ${{ env.JDK_URL }}
+          echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
+
+      - name: Inject JDK into Runner
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'jdkfile'
+          jdkFile: ${{ runner.temp }}/jdk.tar.gz
+          java-version: ${{ env.JDK_VER }}
+          architecture: x64
+          cache: maven
+
+      - name: Build JFR Reporter
+        run: mvn -f tools/jfr-reporter/pom.xml clean package -q
+
+      - name: Download TCK JFR recordings
+        uses: actions/download-artifact@v4
+        with:
+          name: jfr-tck-${{ github.run_number }}
+          path: .
+
+      - name: Run JFR Reporter
+        run: |
+          java -jar tools/jfr-reporter/target/jfr-reporter-1.0.0.jar \
+            --core      exeris-kernel-core/target/jfr-reports/ \
+            --community exeris-kernel-community/target/jfr-reports/ \
+            --commit    ${{ github.sha }} \
+            --branch    ${{ github.ref_name }} \
+            --out       build/jfr-report/
+
+      - name: Upload Lab JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-lab-json-${{ github.run_number }}
+          path: build/jfr-report/
+          if-no-files-found: warn
+          retention-days: 30
+
+  publish-gh-pages-data:
+    name: Publish JFR Data → GH Pages
+    runs-on: ubuntu-latest
+    needs: parse-jfr-to-json
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Lab JSON
+        uses: actions/download-artifact@v4
+        with:
+          name: jfr-lab-json-${{ github.run_number }}
+          path: build/jfr-report/
+
+      - name: Publish latest to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/jfr-report/
+          destination_dir: data/jfr/latest
+          keep_files: true
+
+      - name: Publish run snapshot to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/jfr-report/
+          destination_dir: data/jfr/${{ github.run_number }}
+          keep_files: true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -165,13 +165,14 @@ jobs:
       - name: Run JMH Benchmarks
         run: |
           mvn -pl exeris-kernel-community,exeris-kernel-core -am install -DskipTests -B -e
+          mkdir -p exeris-kernel-community/target/jfr-reports exeris-kernel-core/target/jfr-reports
           mvn -pl exeris-kernel-community -P benchmarks \
             -Dbenchmark.forks=1 \
             -Dbenchmark.warmup=3 \
             -Dbenchmark.iterations=5 \
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
-            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jmh-recording.jfr,dumponexit=true,settings=default \
+            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jfr-reports/jmh-benchmarks.jfr,dumponexit=true,settings=default \
             verify -B -e
           mvn -pl exeris-kernel-core -P benchmarks \
             -Dbenchmark.forks=1 \
@@ -179,7 +180,7 @@ jobs:
             -Dbenchmark.iterations=5 \
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
-            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jmh-recording.jfr,dumponexit=true,settings=default \
+            -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jfr-reports/jmh-benchmarks.jfr,dumponexit=true,settings=default \
             verify -B -e
 
       - name: Upload Community benchmark results
@@ -201,7 +202,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jfr-benchmarks-community-${{ github.run_number }}
-          path: exeris-kernel-community/target/jmh-recording.jfr
+          path: exeris-kernel-community/target/jfr-reports/jmh-benchmarks.jfr
           if-no-files-found: warn
           retention-days: 14
 
@@ -210,7 +211,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jfr-benchmarks-core-${{ github.run_number }}
-          path: exeris-kernel-core/target/jmh-recording.jfr
+          path: exeris-kernel-core/target/jfr-reports/jmh-benchmarks.jfr
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -276,7 +276,11 @@ jobs:
 
       - name: Run JFR Reporter
         run: |
-          jar=$(ls tools/jfr-reporter/target/jfr-reporter-*.jar | grep -v original | head -1)
+          jar=$(ls tools/jfr-reporter/target/jfr-reporter-*.jar 2>/dev/null | grep -v original | head -1)
+          if [ -z "$jar" ]; then
+            echo "ERROR: jfr-reporter shaded JAR not found in tools/jfr-reporter/target/" >&2
+            exit 1
+          fi
           java -jar "$jar" \
             --core      exeris-kernel-core/target/jfr-reports/ \
             --community exeris-kernel-community/target/jfr-reports/ \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -260,7 +260,8 @@ jobs:
 
       - name: Run JFR Reporter
         run: |
-          java -jar tools/jfr-reporter/target/jfr-reporter-1.0.0.jar \
+          jar=$(ls tools/jfr-reporter/target/jfr-reporter-*.jar | grep -v original | head -1)
+          java -jar "$jar" \
             --core      exeris-kernel-core/target/jfr-reports/ \
             --community exeris-kernel-community/target/jfr-reports/ \
             --commit    ${{ github.sha }} \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,7 +60,7 @@ jobs:
           name: jfr-tck-${{ github.run_number }}
           path: |
             exeris-kernel-*/target/*.jfr
-            exeris-kernel-*/target/jfr-reports/*.jfr
+            exeris-kernel-*/target/jfr-reports/**/*.jfr
           if-no-files-found: warn
           retention-days: 14
 
@@ -217,7 +217,7 @@ jobs:
   parse-jfr-to-json:
     name: Parse JFR → Lab JSON
     runs-on: ubuntu-latest
-    needs: build-and-verify
+    needs: [build-and-verify, persistence-rls-gate, benchmarks]
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -257,6 +257,21 @@ jobs:
         with:
           name: jfr-tck-${{ github.run_number }}
           path: .
+
+      - name: Download persistence JFR recordings
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: jfr-persistence-${{ github.run_number }}
+          path: .
+
+      - name: Download benchmark JFR recordings
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: jfr-benchmarks-*-${{ github.run_number }}
+          path: .
+          merge-multiple: true
 
       - name: Run JFR Reporter
         run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -282,8 +282,8 @@ jobs:
             exit 1
           fi
           java -jar "$jar" \
-            --core      exeris-kernel-core/target/jfr-reports/ \
-            --community exeris-kernel-community/target/jfr-reports/ \
+            --core      exeris-kernel-core/target/ \
+            --community exeris-kernel-community/target/ \
             --commit    ${{ github.sha }} \
             --branch    ${{ github.ref_name }} \
             --out       build/jfr-report/

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -185,7 +185,7 @@
                 <benchmark.iterationstime>2s</benchmark.iterationstime>
                 <benchmark.jvm.gc>-XX:+UseZGC</benchmark.jvm.gc>
                 <benchmark.jvmArgs></benchmark.jvmArgs>
-                <benchmark.jvmArgsAppend>-Dexeris.jfr=false</benchmark.jvmArgsAppend>
+                <benchmark.jvmArgsAppend/>
                 <excludedGroups>flamegraph</excludedGroups>
             </properties>
             <build>

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -185,6 +185,7 @@
                 <benchmark.iterationstime>2s</benchmark.iterationstime>
                 <benchmark.jvm.gc>-XX:+UseZGC</benchmark.jvm.gc>
                 <benchmark.jvmArgs></benchmark.jvmArgs>
+                <benchmark.jvmArgsAppend>-Dexeris.jfr=false</benchmark.jvmArgsAppend>
                 <excludedGroups>flamegraph</excludedGroups>
             </properties>
             <build>
@@ -249,6 +250,8 @@
                                         <argument>json</argument>
                                         <argument>-rff</argument>
                                         <argument>${benchmark.output}</argument>
+                                        <argument>-jvmArgsAppend</argument>
+                                        <argument>${benchmark.jvmArgsAppend}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
@@ -320,11 +320,10 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		}
 
 		// 2) Generate a temporary self-signed cert via the openssl CLI if available.
+		Path tmpDir = Files.createTempDirectory("exeris-bench-tls-");
+		Path certFile = tmpDir.resolve("server.crt");
+		Path keyFile = tmpDir.resolve("server.key");
 		try {
-			Path tmpDir = Files.createTempDirectory("exeris-bench-tls-");
-			tempCertDir = tmpDir;
-			Path certFile = tmpDir.resolve("server.crt");
-			Path keyFile = tmpDir.resolve("server.key");
 			String opensslPath = findOnPath("openssl");
 			if (opensslPath == null) {
 				throw new java.io.IOException("openssl not found on PATH");
@@ -340,13 +339,17 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 			Process proc = pb.start();
 			int exit = proc.waitFor();
 			if (exit == 0 && Files.exists(certFile) && Files.exists(keyFile)) {
+				tempCertDir = tmpDir;
 				return new Path[]{certFile, keyFile};
 			}
-		} catch (InterruptedException interruptedException) {
+		} catch (InterruptedException ie) {
 			Thread.currentThread().interrupt();
 		} catch (java.io.IOException ignored) {
-			// openssl not available or failed — fall through to bundled certs
+			// openssl not available or failed — clean up and fall through
 		}
+		try { Files.deleteIfExists(certFile); } catch (java.io.IOException ignored) {}
+		try { Files.deleteIfExists(keyFile); } catch (java.io.IOException ignored) {}
+		try { Files.deleteIfExists(tmpDir); } catch (java.io.IOException ignored) {}
 
 		// 3) Locate certs bundled in the repository (native-libs/certs).
 		Path certsDir = locateCertsDir();

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
@@ -320,36 +320,40 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		}
 
 		// 2) Generate a temporary self-signed cert via the openssl CLI if available.
-		Path tmpDir = Files.createTempDirectory("exeris-bench-tls-");
-		Path certFile = tmpDir.resolve("server.crt");
-		Path keyFile = tmpDir.resolve("server.key");
 		try {
-			String opensslPath = findOnPath("openssl");
-			if (opensslPath == null) {
-				throw new java.io.IOException("openssl not found on PATH");
+			Path tmpDir = Files.createTempDirectory("exeris-bench-tls-");
+			Path certFile = tmpDir.resolve("server.crt");
+			Path keyFile = tmpDir.resolve("server.key");
+			try {
+				String opensslPath = findOnPath("openssl");
+				if (opensslPath == null) {
+					throw new java.io.IOException("openssl not found on PATH");
+				}
+				ProcessBuilder pb = new ProcessBuilder(
+						opensslPath, "req", "-x509", "-newkey", "rsa:2048",
+						"-keyout", keyFile.toString(),
+						"-out", certFile.toString(),
+						"-days", "1", "-nodes",
+						"-subj", "/CN=exeris-benchmark");
+				pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+				pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+				Process proc = pb.start();
+				int exit = proc.waitFor();
+				if (exit == 0 && Files.exists(certFile) && Files.exists(keyFile)) {
+					tempCertDir = tmpDir;
+					return new Path[]{certFile, keyFile};
+				}
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+			} catch (java.io.IOException ignored) {
+				// openssl not available or failed — clean up and fall through
 			}
-			ProcessBuilder pb = new ProcessBuilder(
-					opensslPath, "req", "-x509", "-newkey", "rsa:2048",
-					"-keyout", keyFile.toString(),
-					"-out", certFile.toString(),
-					"-days", "1", "-nodes",
-					"-subj", "/CN=exeris-benchmark");
-			pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-			pb.redirectError(ProcessBuilder.Redirect.DISCARD);
-			Process proc = pb.start();
-			int exit = proc.waitFor();
-			if (exit == 0 && Files.exists(certFile) && Files.exists(keyFile)) {
-				tempCertDir = tmpDir;
-				return new Path[]{certFile, keyFile};
-			}
-		} catch (InterruptedException ie) {
-			Thread.currentThread().interrupt();
+			try { Files.deleteIfExists(certFile); } catch (java.io.IOException ignored) {}
+			try { Files.deleteIfExists(keyFile); } catch (java.io.IOException ignored) {}
+			try { Files.deleteIfExists(tmpDir); } catch (java.io.IOException ignored) {}
 		} catch (java.io.IOException ignored) {
-			// openssl not available or failed — clean up and fall through
+			// createTempDirectory failed — fall through to bundled certs
 		}
-		try { Files.deleteIfExists(certFile); } catch (java.io.IOException ignored) {}
-		try { Files.deleteIfExists(keyFile); } catch (java.io.IOException ignored) {}
-		try { Files.deleteIfExists(tmpDir); } catch (java.io.IOException ignored) {}
 
 		// 3) Locate certs bundled in the repository (native-libs/certs).
 		Path certsDir = locateCertsDir();

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
@@ -129,20 +129,6 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 
 	@TearDown(Level.Trial)
 	public void tearDownTrial() {
-		if (tempCertDir != null) {
-			try (java.nio.file.DirectoryStream<Path> stream = Files.newDirectoryStream(tempCertDir)) {
-				for (Path entry : stream) {
-					Files.deleteIfExists(entry);
-				}
-			} catch (java.io.IOException ignored) {
-				// best-effort cleanup
-			}
-			try {
-				Files.deleteIfExists(tempCertDir);
-			} catch (java.io.IOException ignored) {
-				// best-effort cleanup
-			}
-		}
 		if (serverEngine != null) {
 			serverEngine.close();
 		}
@@ -181,6 +167,20 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		}
 		if (provider != null) {
 			provider.close();
+		}
+		if (tempCertDir != null) {
+			try (java.nio.file.DirectoryStream<Path> stream = Files.newDirectoryStream(tempCertDir)) {
+				for (Path entry : stream) {
+					Files.deleteIfExists(entry);
+				}
+			} catch (java.io.IOException ignored) {
+				// best-effort cleanup
+			}
+			try {
+				Files.deleteIfExists(tempCertDir);
+			} catch (java.io.IOException ignored) {
+				// best-effort cleanup
+			}
 		}
 	}
 
@@ -325,8 +325,12 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 			tempCertDir = tmpDir;
 			Path certFile = tmpDir.resolve("server.crt");
 			Path keyFile = tmpDir.resolve("server.key");
+			String opensslPath = findOnPath("openssl");
+			if (opensslPath == null) {
+				throw new java.io.IOException("openssl not found on PATH");
+			}
 			ProcessBuilder pb = new ProcessBuilder(
-					"openssl", "req", "-x509", "-newkey", "rsa:2048",
+					opensslPath, "req", "-x509", "-newkey", "rsa:2048",
 					"-keyout", keyFile.toString(),
 					"-out", certFile.toString(),
 					"-days", "1", "-nodes",
@@ -376,5 +380,17 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		} catch (Exception ignored) {
 			// benchmark teardown should be best-effort
 		}
+	}
+
+	private static String findOnPath(String executable) {
+		String pathEnv = System.getenv("PATH");
+		if (pathEnv == null) return null;
+		for (String dir : pathEnv.split(java.io.File.pathSeparator)) {
+			java.io.File candidate = new java.io.File(dir, executable);
+			if (candidate.isFile() && candidate.canExecute()) {
+				return candidate.getAbsolutePath();
+			}
+		}
+		return null;
 	}
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/crypto/CommunityTlsEngineGuardBenchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.net.InetSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -62,6 +63,7 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 	private LoanedBuffer clientDecrypted;
 	private LoanedBuffer serverHandshakeOutbound;
 	private LoanedBuffer clientHandshakeOutbound;
+	private Path tempCertDir;
 
 	private static final byte[] ROUNDTRIP_PAYLOAD =
 			"exeris-community-tls-roundtrip-payload".getBytes();
@@ -82,12 +84,13 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		plaintext = allocator.allocate(AllocationHint.MEDIUM);
 		ciphertext = allocator.allocate(AllocationHint.MEDIUM);
 
-		Path cwd = Path.of("").toAbsolutePath().normalize();
-		Path moduleDir = "exeris-kernel-community".equals(String.valueOf(cwd.getFileName()))
-				? cwd
-				: cwd.resolve("exeris-kernel-community").normalize();
-		Path certPath = moduleDir.resolve("../native-libs/certs/server.crt").normalize();
-		Path keyPath = moduleDir.resolve("../native-libs/certs/server.key").normalize();
+		Path[] certAndKey = resolveCertPaths();
+		Path certPath = certAndKey[0];
+		Path keyPath = certAndKey[1];
+		if (!Files.exists(certPath) || !Files.exists(keyPath)) {
+			throw new IllegalStateException(
+					"No usable TLS cert/key found for benchmark. cert=" + certPath + " key=" + keyPath);
+		}
 
 		serverEngine = (CommunityTlsEngine) provider.createTlsEngine(
 				CryptoProviderConfig.httpsServer(certPath, keyPath));
@@ -126,6 +129,20 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 
 	@TearDown(Level.Trial)
 	public void tearDownTrial() {
+		if (tempCertDir != null) {
+			try (java.nio.file.DirectoryStream<Path> stream = Files.newDirectoryStream(tempCertDir)) {
+				for (Path entry : stream) {
+					Files.deleteIfExists(entry);
+				}
+			} catch (java.io.IOException ignored) {
+				// best-effort cleanup
+			}
+			try {
+				Files.deleteIfExists(tempCertDir);
+			} catch (java.io.IOException ignored) {
+				// best-effort cleanup
+			}
+		}
 		if (serverEngine != null) {
 			serverEngine.close();
 		}
@@ -273,6 +290,81 @@ public class CommunityTlsEngineGuardBenchmark extends AbstractExerisBenchmark {
 		if (!tlsEngine.isHandshakeComplete()) {
 			throw new IllegalStateException("TLS handshake did not complete within max steps");
 		}
+	}
+
+	/**
+	 * Resolves the TLS cert and key to use for the benchmark server engine.
+	 *
+	 * <p>Fallback sequence (first match wins):
+	 * <ol>
+	 *   <li>System properties {@code benchmark.tls.cert.path} and {@code benchmark.tls.key.path}
+	 *       when both point to existing files.</li>
+	 *   <li>Temporary self-signed cert/key generated via {@code openssl} CLI if available.
+	 *       The temp directory is stored in {@link #tempCertDir} for teardown cleanup.</li>
+	 *   <li>Certificates bundled under {@code native-libs/certs/} discovered by walking
+	 *       up the ancestor directories from the JVM working directory.</li>
+	 * </ol>
+	 *
+	 * @return two-element array: {@code [certPath, keyPath]}
+	 */
+	private Path[] resolveCertPaths() {
+		// 1) System-property override — takes precedence in CI/fork environments.
+		String propCert = System.getProperty("benchmark.tls.cert.path", "");
+		String propKey = System.getProperty("benchmark.tls.key.path", "");
+		if (!propCert.isBlank() && !propKey.isBlank()) {
+			Path certFile = Path.of(propCert);
+			Path keyFile = Path.of(propKey);
+			if (Files.exists(certFile) && Files.exists(keyFile)) {
+				return new Path[]{certFile, keyFile};
+			}
+		}
+
+		// 2) Generate a temporary self-signed cert via the openssl CLI if available.
+		try {
+			Path tmpDir = Files.createTempDirectory("exeris-bench-tls-");
+			tempCertDir = tmpDir;
+			Path certFile = tmpDir.resolve("server.crt");
+			Path keyFile = tmpDir.resolve("server.key");
+			ProcessBuilder pb = new ProcessBuilder(
+					"openssl", "req", "-x509", "-newkey", "rsa:2048",
+					"-keyout", keyFile.toString(),
+					"-out", certFile.toString(),
+					"-days", "1", "-nodes",
+					"-subj", "/CN=exeris-benchmark");
+			pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+			pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+			Process proc = pb.start();
+			int exit = proc.waitFor();
+			if (exit == 0 && Files.exists(certFile) && Files.exists(keyFile)) {
+				return new Path[]{certFile, keyFile};
+			}
+		} catch (InterruptedException interruptedException) {
+			Thread.currentThread().interrupt();
+		} catch (java.io.IOException ignored) {
+			// openssl not available or failed — fall through to bundled certs
+		}
+
+		// 3) Locate certs bundled in the repository (native-libs/certs).
+		Path certsDir = locateCertsDir();
+		return new Path[]{certsDir.resolve("server.crt"), certsDir.resolve("server.key")};
+	}
+
+	/**
+	 * Walks up from the JVM working directory until a directory containing
+	 * {@code native-libs/certs/server.crt} is found.
+	 */
+	private static Path locateCertsDir() {
+		Path dir = Path.of("").toAbsolutePath().normalize();
+		while (dir != null) {
+			Path candidate = dir.resolve("native-libs/certs/server.crt");
+			if (Files.exists(candidate)) {
+				return candidate.getParent();
+			}
+			dir = dir.getParent();
+		}
+		throw new IllegalStateException(
+				"native-libs/certs/server.crt not found in any ancestor of: "
+						+ Path.of("").toAbsolutePath());
 	}
 
 	private static void closeQuietly(AutoCloseable closeable) {

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityRowCursorThroughputBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityRowCursorThroughputBenchmark.java
@@ -21,9 +21,9 @@ import eu.exeris.kernel.tck.perf.AbstractRowCursorThroughputBenchmark;
 public class CommunityRowCursorThroughputBenchmark extends AbstractRowCursorThroughputBenchmark {
 
     private static final String CREATE_TABLE_SQL =
-            "CREATE TABLE IF NOT EXISTS benchmark_data (id BIGINT PRIMARY KEY, value VARCHAR(64), ts BIGINT)";
+            "CREATE TABLE IF NOT EXISTS benchmark_data (id BIGINT PRIMARY KEY, value_text VARCHAR(64), ts BIGINT)";
     private static final String DELETE_ROWS_SQL = "DELETE FROM benchmark_data";
-    private static final String INSERT_ROW_PREFIX = "INSERT INTO benchmark_data (id, value, ts) VALUES (";
+    private static final String INSERT_ROW_PREFIX = "INSERT INTO benchmark_data (id, value_text, ts) VALUES (";
 
     @Override
     protected PersistenceProvider getProvider() {

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -102,7 +102,7 @@
                 <benchmark.iterationstime>2s</benchmark.iterationstime>
                 <benchmark.jvm.gc>-XX:+UseZGC</benchmark.jvm.gc>
                 <benchmark.jvmArgs></benchmark.jvmArgs>
-                <benchmark.jvmArgsAppend>-Dexeris.jfr=false</benchmark.jvmArgsAppend>
+                <benchmark.jvmArgsAppend/>
                 <excludedGroups/>
             </properties>
             <build>

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -102,6 +102,7 @@
                 <benchmark.iterationstime>2s</benchmark.iterationstime>
                 <benchmark.jvm.gc>-XX:+UseZGC</benchmark.jvm.gc>
                 <benchmark.jvmArgs></benchmark.jvmArgs>
+                <benchmark.jvmArgsAppend>-Dexeris.jfr=false</benchmark.jvmArgsAppend>
                 <excludedGroups/>
             </properties>
             <build>
@@ -163,6 +164,8 @@
                                         <argument>json</argument>
                                         <argument>-rff</argument>
                                         <argument>${benchmark.output}</argument>
+                                        <argument>-jvmArgsAppend</argument>
+                                        <argument>${benchmark.jvmArgsAppend}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
@@ -66,7 +66,7 @@ import org.openjdk.jmh.infra.Blackhole;
  *     protected void prepareBenchmarkData(PersistenceEngine engine) {
  *         // Insert 1 000 rows into an in-memory H2 table
  *         try (PersistenceConnection conn = engine.openConnection()) {
- *             conn.executeUpdate("CREATE TABLE benchmark_data (id BIGINT, value VARCHAR, ts BIGINT)");
+ *             conn.executeUpdate("CREATE TABLE benchmark_data (id BIGINT, value_text VARCHAR, ts BIGINT)");
  *             for (int i = 0; i < 1_000; i++) {
  *                 conn.executeUpdate("INSERT INTO benchmark_data VALUES (" + i + ", 'v" + i + "', " + i + ")");
  *             }
@@ -86,7 +86,14 @@ public abstract class AbstractRowCursorThroughputBenchmark extends AbstractExeri
      * without overwhelming the measurement window with I/O wait time.
      */
     private static final String BENCHMARK_QUERY =
-            "SELECT id, value, ts FROM benchmark_data";
+            "SELECT id, value_text, ts FROM benchmark_data";
+
+    /**
+     * Default JDBC URL: H2 in-memory, PostgreSQL compatibility mode. Override
+     * via system property {@code benchmark.persistence.url} for real backends.
+     */
+    private static final String DEFAULT_BENCHMARK_URL =
+            "jdbc:h2:mem:benchmark;MODE=PostgreSQL;DB_CLOSE_DELAY=-1";
 
     /** The engine under test — initialised once per trial. */
     protected PersistenceEngine engine;
@@ -132,8 +139,14 @@ public abstract class AbstractRowCursorThroughputBenchmark extends AbstractExeri
      */
     @Setup(Level.Trial)
     public void setupPersistence() {
+        String rawUrl = System.getProperty("benchmark.persistence.url", "");
+        String normalized = rawUrl.strip();
+        String url = (!normalized.isBlank()
+                && normalized.toLowerCase(java.util.Locale.ROOT).startsWith("jdbc:"))
+                ? normalized
+                : DEFAULT_BENCHMARK_URL;
         this.engine = getProvider().createEngine(
-                PersistenceConfig.defaults("benchmark-db", "bench", "bench")
+                PersistenceConfig.defaults(url, "bench", "bench")
         );
 
         // Insert mock rows — implementation-specific (in-memory DB or pre-warmed buffer).

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
@@ -141,10 +141,7 @@ public abstract class AbstractRowCursorThroughputBenchmark extends AbstractExeri
     public void setupPersistence() {
         String rawUrl = System.getProperty("benchmark.persistence.url", "");
         String normalized = rawUrl.strip();
-        String url = (!normalized.isBlank()
-                && normalized.toLowerCase(java.util.Locale.ROOT).startsWith("jdbc:"))
-                ? normalized
-                : DEFAULT_BENCHMARK_URL;
+        String url = normalized.isBlank() ? DEFAULT_BENCHMARK_URL : normalized;
         String benchUser = System.getProperty("benchmark.persistence.user",
                 url.equals(DEFAULT_BENCHMARK_URL) ? "sa" : "bench");
         String benchPassword = System.getProperty("benchmark.persistence.password",

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/perf/AbstractRowCursorThroughputBenchmark.java
@@ -145,8 +145,12 @@ public abstract class AbstractRowCursorThroughputBenchmark extends AbstractExeri
                 && normalized.toLowerCase(java.util.Locale.ROOT).startsWith("jdbc:"))
                 ? normalized
                 : DEFAULT_BENCHMARK_URL;
+        String benchUser = System.getProperty("benchmark.persistence.user",
+                url.equals(DEFAULT_BENCHMARK_URL) ? "sa" : "bench");
+        String benchPassword = System.getProperty("benchmark.persistence.password",
+                url.equals(DEFAULT_BENCHMARK_URL) ? "" : "bench");
         this.engine = getProvider().createEngine(
-                PersistenceConfig.defaults(url, "bench", "bench")
+                PersistenceConfig.defaults(url, benchUser, benchPassword)
         );
 
         // Insert mock rows — implementation-specific (in-memory DB or pre-warmed buffer).

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             --enable-preview
             --enable-native-access=ALL-UNNAMED
             -XX:FlightRecorderOptions=stackdepth=256
-            -XX:StartFlightRecording=disk=true,filename=target/recording-${maven.build.timestamp}.jfr,maxsize=256m,maxage=10m,settings=profile
+            -XX:StartFlightRecording=disk=true,filename=target/jfr-reports/surefire.jfr,maxsize=256m,maxage=10m,settings=profile
         </jvm.args>
         <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             --enable-preview
             --enable-native-access=ALL-UNNAMED
             -XX:FlightRecorderOptions=stackdepth=256
-            -XX:StartFlightRecording=disk=true,filename=target/jfr-reports/surefire.jfr,maxsize=256m,maxage=10m,settings=profile
+            -XX:StartFlightRecording=disk=true,filename=target/surefire.jfr,maxsize=256m,maxage=10m,settings=profile
         </jvm.args>
         <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
     </properties>

--- a/tools/jfr-reporter/pom.xml
+++ b/tools/jfr-reporter/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.exeris.tools</groupId>
+    <artifactId>jfr-reporter</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Exeris JFR Reporter</name>
+    <description>Standalone CLI: reads .jfr recording directories and emits JSON Lab data for Angular Lab.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <jackson.version>2.17.2</jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>eu.exeris.tools.jfr.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/AllocEvent.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/AllocEvent.java
@@ -3,7 +3,7 @@ package eu.exeris.tools.jfr;
 import java.util.List;
 
 public record AllocEvent(
-        long tMillis,
+        long tEpochMillis,
         String eventType,
         String className,
         String threadName,

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/AllocEvent.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/AllocEvent.java
@@ -1,0 +1,13 @@
+package eu.exeris.tools.jfr;
+
+import java.util.List;
+
+public record AllocEvent(
+        long tMillis,
+        String eventType,
+        String className,
+        String threadName,
+        long sizeBytes,
+        List<String> stackFrames,
+        Category category
+) {}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Category.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Category.java
@@ -1,0 +1,9 @@
+package eu.exeris.tools.jfr;
+
+public enum Category {
+    production,
+    test_harness,
+    panama,
+    loom_runtime,
+    jvm_noise
+}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/EventClassifier.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/EventClassifier.java
@@ -1,0 +1,27 @@
+package eu.exeris.tools.jfr;
+
+import java.util.List;
+
+final class EventClassifier {
+
+    private EventClassifier() {}
+
+    static Category classify(String className, List<String> stackFrames) {
+        if (className.startsWith("eu.exeris.")) {
+            for (String frame : stackFrames) {
+                if (frame.contains("Test") || frame.contains("Tck")
+                        || frame.contains("Harness") || frame.contains("jmh_generated")) {
+                    return Category.test_harness;
+                }
+            }
+            return Category.production;
+        }
+        if (className.startsWith("jdk.internal.foreign")) {
+            return Category.panama;
+        }
+        if (className.contains("VirtualThread") || className.contains("Continuation")) {
+            return Category.loom_runtime;
+        }
+        return Category.jvm_noise;
+    }
+}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/EventClassifier.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/EventClassifier.java
@@ -1,6 +1,7 @@
 package eu.exeris.tools.jfr;
 
 import java.util.List;
+import java.util.Locale;
 
 final class EventClassifier {
 
@@ -8,9 +9,13 @@ final class EventClassifier {
 
     static Category classify(String className, List<String> stackFrames) {
         if (className.startsWith("eu.exeris.")) {
+            if (isTestHarnessClass(className)) {
+                return Category.test_harness;
+            }
             for (String frame : stackFrames) {
-                if (frame.contains("Test") || frame.contains("Tck")
-                        || frame.contains("Harness") || frame.contains("jmh_generated")) {
+                String lower = frame.toLowerCase(Locale.ROOT);
+                if (lower.contains("test") || lower.contains("tck")
+                        || lower.contains("harness") || lower.contains("jmh_generated")) {
                     return Category.test_harness;
                 }
             }
@@ -23,5 +28,12 @@ final class EventClassifier {
             return Category.loom_runtime;
         }
         return Category.jvm_noise;
+    }
+
+    private static boolean isTestHarnessClass(String className) {
+        String lower = className.toLowerCase(Locale.ROOT);
+        return lower.contains(".tck.") || lower.contains(".test.")
+                || lower.endsWith("test") || lower.endsWith("tck")
+                || lower.contains("harness") || lower.contains("jmh_generated");
     }
 }

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
@@ -1,0 +1,120 @@
+package eu.exeris.tools.jfr;
+
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordedThread;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+final class JfrDirectoryReader {
+
+    private static final Set<String> ALLOC_TYPES = Set.of(
+            "jdk.ObjectAllocationInNewTLAB",
+            "jdk.ObjectAllocationOutsideTLAB",
+            "jdk.ObjectAllocationSample"
+    );
+
+    private JfrDirectoryReader() {}
+
+    /**
+     * Reads all .jfr files in dir, groups events by subsystem extracted from filename.
+     * Filename pattern from JfrAllocationMonitor: {TestClass}-{Subsystem}-{yyyyMMdd}-{HHmmss}.jfr
+     */
+    static Map<String, List<AllocEvent>> readDirectory(Path dir) throws IOException {
+        Map<String, List<AllocEvent>> result = new LinkedHashMap<>();
+        try (Stream<Path> paths = Files.list(dir)) {
+            List<Path> jfrFiles = paths
+                    .filter(p -> p.getFileName().toString().endsWith(".jfr"))
+                    .sorted()
+                    .toList();
+            for (Path jfrFile : jfrFiles) {
+                String subsystem = extractSubsystem(jfrFile.getFileName().toString());
+                List<AllocEvent> events = readFile(jfrFile);
+                result.computeIfAbsent(subsystem, k -> new ArrayList<>()).addAll(events);
+                System.out.println("[jfr-reporter]   " + jfrFile.getFileName() + " → subsystem=" + subsystem + " events=" + events.size());
+            }
+        }
+        return result;
+    }
+
+    private static String extractSubsystem(String filename) {
+        String base = filename.endsWith(".jfr") ? filename.substring(0, filename.length() - 4) : filename;
+        String[] parts = base.split("-");
+        if (parts.length >= 2) {
+            return parts[1].toLowerCase(Locale.ROOT);
+        }
+        return "unknown";
+    }
+
+    private static List<AllocEvent> readFile(Path jfrFile) {
+        List<AllocEvent> events = new ArrayList<>();
+        Instant recordingStart = null;
+        try (RecordingFile rf = new RecordingFile(jfrFile)) {
+            while (rf.hasMoreEvents()) {
+                RecordedEvent e = rf.readEvent();
+                if (recordingStart == null) {
+                    recordingStart = e.getStartTime();
+                }
+                String typeName = e.getEventType().getName();
+                if (!ALLOC_TYPES.contains(typeName)) continue;
+
+                RecordedClass objClass = null;
+                try { objClass = e.getValue("objectClass"); } catch (Exception ignored) {}
+                if (objClass == null) continue;
+
+                String className = objClass.getName();
+
+                long sizeBytes = 0;
+                try { sizeBytes = e.getLong("allocationSize"); } catch (Exception ignored) {}
+                if (sizeBytes == 0) {
+                    try { sizeBytes = e.getLong("weight"); } catch (Exception ignored) {}
+                }
+
+                String threadName = "unknown";
+                RecordedThread thread = e.getThread();
+                if (thread != null && thread.getJavaName() != null) {
+                    threadName = thread.getJavaName();
+                }
+
+                List<String> frames = new ArrayList<>();
+                RecordedStackTrace stack = e.getStackTrace();
+                if (stack != null) {
+                    for (RecordedFrame frame : stack.getFrames()) {
+                        if (frame.getMethod() != null && frame.getMethod().getType() != null) {
+                            String fqn = frame.getMethod().getType().getName();
+                            int dot = fqn.lastIndexOf('.');
+                            String simpleName = dot >= 0 ? fqn.substring(dot + 1) : fqn;
+                            frames.add(fqn
+                                    + "." + frame.getMethod().getName()
+                                    + "(" + simpleName
+                                    + ".java:" + frame.getLineNumber() + ")");
+                        }
+                    }
+                }
+
+                Category category = EventClassifier.classify(className, frames);
+                long tMillis = recordingStart != null
+                        ? e.getStartTime().toEpochMilli() - recordingStart.toEpochMilli()
+                        : 0;
+
+                events.add(new AllocEvent(tMillis, typeName, className, threadName, sizeBytes, frames, category));
+            }
+        } catch (IOException ex) {
+            System.err.println("[jfr-reporter] WARN: failed to read " + jfrFile + ": " + ex.getMessage());
+        }
+        return events;
+    }
+}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
@@ -34,8 +34,9 @@ final class JfrDirectoryReader {
      */
     static Map<String, List<AllocEvent>> readDirectory(Path dir) throws IOException {
         Map<String, List<AllocEvent>> result = new LinkedHashMap<>();
-        try (Stream<Path> paths = Files.list(dir)) {
+        try (Stream<Path> paths = Files.walk(dir)) {
             List<Path> jfrFiles = paths
+                    .filter(Files::isRegularFile)
                     .filter(p -> p.getFileName().toString().endsWith(".jfr"))
                     .sorted()
                     .toList();

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
@@ -30,7 +30,7 @@ final class JfrDirectoryReader {
 
     /**
      * Reads all .jfr files in dir, groups events by subsystem extracted from filename.
-     * Filename pattern from JfrAllocationMonitor: {TestClass}-{Subsystem}-{yyyyMMdd}-{HHmmss}.jfr
+     * Filename pattern from JfrAllocationMonitor: {TestClass}-{Subsystem}-{yyyyMMdd-HHmmss}.jfr
      */
     static Map<String, List<AllocEvent>> readDirectory(Path dir) throws IOException {
         Map<String, List<AllocEvent>> result = new LinkedHashMap<>();

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/JfrDirectoryReader.java
@@ -10,7 +10,6 @@ import jdk.jfr.consumer.RecordingFile;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -61,13 +60,9 @@ final class JfrDirectoryReader {
 
     private static List<AllocEvent> readFile(Path jfrFile) {
         List<AllocEvent> events = new ArrayList<>();
-        Instant recordingStart = null;
         try (RecordingFile rf = new RecordingFile(jfrFile)) {
             while (rf.hasMoreEvents()) {
                 RecordedEvent e = rf.readEvent();
-                if (recordingStart == null) {
-                    recordingStart = e.getStartTime();
-                }
                 String typeName = e.getEventType().getName();
                 if (!ALLOC_TYPES.contains(typeName)) continue;
 
@@ -106,11 +101,9 @@ final class JfrDirectoryReader {
                 }
 
                 Category category = EventClassifier.classify(className, frames);
-                long tMillis = recordingStart != null
-                        ? e.getStartTime().toEpochMilli() - recordingStart.toEpochMilli()
-                        : 0;
+                long tEpochMillis = e.getStartTime().toEpochMilli();
 
-                events.add(new AllocEvent(tMillis, typeName, className, threadName, sizeBytes, frames, category));
+                events.add(new AllocEvent(tEpochMillis, typeName, className, threadName, sizeBytes, frames, category));
             }
         } catch (IOException ex) {
             System.err.println("[jfr-reporter] WARN: failed to read " + jfrFile + ": " + ex.getMessage());

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Main.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Main.java
@@ -1,0 +1,47 @@
+package eu.exeris.tools.jfr;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class Main {
+
+    private Main() {}
+
+    public static void main(String[] args) throws Exception {
+        Map<String, String> opts = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < args.length; i++) {
+            if (args[i].startsWith("--")) {
+                opts.put(args[i].substring(2), args[i + 1]);
+                i++;
+            }
+        }
+
+        Map<String, Path> moduleDirs = new LinkedHashMap<>();
+        addModuleDir(moduleDirs, opts, "core");
+        addModuleDir(moduleDirs, opts, "community");
+
+        if (moduleDirs.isEmpty()) {
+            System.err.println("[jfr-reporter] ERROR: no valid --core or --community directories found.");
+            System.exit(1);
+        }
+
+        Path outDir = Path.of(opts.getOrDefault("out", "build/jfr-report"));
+        String commit = opts.getOrDefault("commit", "unknown");
+        String branch = opts.getOrDefault("branch", "unknown");
+
+        Files.createDirectories(outDir);
+        new ReportGenerator(moduleDirs, commit, branch, outDir).generate();
+    }
+
+    private static void addModuleDir(Map<String, Path> moduleDirs, Map<String, String> opts, String key) {
+        if (!opts.containsKey(key)) return;
+        Path p = Path.of(opts.get(key));
+        if (Files.isDirectory(p)) {
+            moduleDirs.put(key, p);
+        } else {
+            System.err.println("[jfr-reporter] WARN: --" + key + " path not found or not a directory: " + p);
+        }
+    }
+}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Main.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/Main.java
@@ -10,12 +10,19 @@ public final class Main {
     private Main() {}
 
     public static void main(String[] args) throws Exception {
+        if (args.length % 2 != 0) {
+            System.err.println("[jfr-reporter] ERROR: each --<option> must be followed by a value.");
+            printUsage();
+            System.exit(1);
+        }
         Map<String, String> opts = new LinkedHashMap<>();
-        for (int i = 0; i + 1 < args.length; i++) {
-            if (args[i].startsWith("--")) {
-                opts.put(args[i].substring(2), args[i + 1]);
-                i++;
+        for (int i = 0; i < args.length; i += 2) {
+            if (!args[i].startsWith("--")) {
+                System.err.println("[jfr-reporter] ERROR: expected --<option> but got: " + args[i]);
+                printUsage();
+                System.exit(1);
             }
+            opts.put(args[i].substring(2), args[i + 1]);
         }
 
         Map<String, Path> moduleDirs = new LinkedHashMap<>();
@@ -43,5 +50,9 @@ public final class Main {
         } else {
             System.err.println("[jfr-reporter] WARN: --" + key + " path not found or not a directory: " + p);
         }
+    }
+
+    private static void printUsage() {
+        System.err.println("Usage: jfr-reporter [--core <dir>] [--community <dir>] --commit <sha> --branch <name> [--out <dir>]");
     }
 }

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
@@ -1,0 +1,215 @@
+package eu.exeris.tools.jfr;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class ReportGenerator {
+
+    private final Map<String, Path> moduleDirs;
+    private final String commit;
+    private final String branch;
+    private final Path outDir;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    ReportGenerator(Map<String, Path> moduleDirs, String commit, String branch, Path outDir) {
+        this.moduleDirs = moduleDirs;
+        this.commit = commit;
+        this.branch = branch;
+        this.outDir = outDir;
+    }
+
+    void generate() throws IOException {
+        System.out.println("[jfr-reporter] Generating reports → " + outDir);
+
+        Map<String, Map<String, List<AllocEvent>>> allModuleEvents = new LinkedHashMap<>();
+        for (Map.Entry<String, Path> entry : moduleDirs.entrySet()) {
+            System.out.println("[jfr-reporter] Reading module '" + entry.getKey() + "' from " + entry.getValue());
+            allModuleEvents.put(entry.getKey(), JfrDirectoryReader.readDirectory(entry.getValue()));
+        }
+
+        writeEvidence(allModuleEvents);
+
+        for (Map.Entry<String, Map<String, List<AllocEvent>>> moduleEntry : allModuleEvents.entrySet()) {
+            String module = moduleEntry.getKey();
+            Map<String, List<AllocEvent>> subsystemEvents = moduleEntry.getValue();
+            List<AllocEvent> allEvents = subsystemEvents.values().stream().flatMap(List::stream).toList();
+
+            Map<String, List<String>> stacksMap = new LinkedHashMap<>();
+            AtomicInteger stackCounter = new AtomicInteger(0);
+            Map<String, String> stackIdCache = new HashMap<>();
+
+            writeTimeline(module, allEvents, stacksMap, stackIdCache, stackCounter);
+            writeStacks(module, stacksMap);
+            writeAllocTopClasses(module, allEvents);
+        }
+
+        writeJfrSummary(allModuleEvents);
+        System.out.println("[jfr-reporter] Done.");
+    }
+
+    private void writeEvidence(Map<String, Map<String, List<AllocEvent>>> allModuleEvents) throws IOException {
+        ObjectNode root = mapper.createObjectNode();
+
+        ObjectNode meta = root.putObject("meta");
+        meta.put("generated", Instant.now().atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        meta.put("jdk", System.getProperty("java.version", "26"));
+        meta.put("commit", commit);
+        meta.put("branch", branch);
+
+        for (Map.Entry<String, Map<String, List<AllocEvent>>> moduleEntry : allModuleEvents.entrySet()) {
+            ObjectNode moduleNode = root.putObject(moduleEntry.getKey());
+            for (Map.Entry<String, List<AllocEvent>> subsysEntry : moduleEntry.getValue().entrySet()) {
+                List<AllocEvent> events = subsysEntry.getValue();
+                long totalEvents = events.size();
+                long exerisCount = events.stream()
+                        .filter(e -> e.className().startsWith("eu.exeris.")).count();
+                long productionCount = events.stream()
+                        .filter(e -> e.category() == Category.production).count();
+                long harnessCount = events.stream()
+                        .filter(e -> e.category() == Category.test_harness).count();
+
+                ObjectNode subsysNode = moduleNode.putObject(subsysEntry.getKey());
+                subsysNode.put("verdict", verdict(moduleEntry.getKey(), productionCount));
+                subsysNode.put("total_events", totalEvents);
+                subsysNode.put("exeris_alloc_count", exerisCount);
+                subsysNode.put("exeris_production_alloc_count", productionCount);
+                subsysNode.put("exeris_test_harness_count", harnessCount);
+            }
+        }
+
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(outDir.resolve("evidence.json").toFile(), root);
+        System.out.println("[jfr-reporter] Wrote evidence.json");
+    }
+
+    private String verdict(String module, long productionCount) {
+        if ("core".equals(module)) {
+            return productionCount == 0 ? "VERIFIED" : "WARNING";
+        }
+        return productionCount < 1000 ? "VERIFIED" : "WARNING";
+    }
+
+    private void writeTimeline(String module, List<AllocEvent> events,
+                               Map<String, List<String>> stacksMap,
+                               Map<String, String> stackIdCache,
+                               AtomicInteger stackCounter) throws IOException {
+        ArrayNode timeline = mapper.createArrayNode();
+        for (AllocEvent e : events) {
+            String stackId = resolveStackId(e.stackFrames(), stacksMap, stackIdCache, stackCounter);
+            ObjectNode node = timeline.addObject();
+            node.put("t", e.tMillis());
+            node.put("type", e.eventType());
+            node.put("class", e.className());
+            node.put("thread", e.threadName());
+            node.put("size", e.sizeBytes());
+            node.put("stackId", stackId);
+            node.put("category", e.category().name());
+        }
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(outDir.resolve("timeline-" + module + ".json").toFile(), timeline);
+        System.out.println("[jfr-reporter] Wrote timeline-" + module + ".json (" + events.size() + " events)");
+    }
+
+    private void writeStacks(String module, Map<String, List<String>> stacksMap) throws IOException {
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(outDir.resolve("stacks-" + module + ".json").toFile(), stacksMap);
+        System.out.println("[jfr-reporter] Wrote stacks-" + module + ".json (" + stacksMap.size() + " stacks)");
+    }
+
+    private void writeAllocTopClasses(String module, List<AllocEvent> events) throws IOException {
+        Map<String, long[]> countMap = new LinkedHashMap<>();
+        for (AllocEvent e : events) {
+            String key = e.className() + "|" + e.category().name();
+            countMap.computeIfAbsent(key, k -> new long[2]);
+            countMap.get(key)[0]++;
+            countMap.get(key)[1] += e.sizeBytes();
+        }
+
+        List<Map<String, Object>> topClasses = new ArrayList<>();
+        for (Map.Entry<String, long[]> entry : countMap.entrySet()) {
+            String[] parts = entry.getKey().split("\\|", 2);
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("class", parts[0]);
+            item.put("count", entry.getValue()[0]);
+            item.put("bytes", entry.getValue()[1]);
+            item.put("category", parts[1]);
+            topClasses.add(item);
+        }
+        topClasses.sort(Comparator.comparingLong((Map<String, Object> m) -> (long) m.get("count")).reversed());
+
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(outDir.resolve("alloc-top-classes-" + module + ".json").toFile(), topClasses);
+        System.out.println("[jfr-reporter] Wrote alloc-top-classes-" + module + ".json (" + topClasses.size() + " classes)");
+    }
+
+    private void writeJfrSummary(Map<String, Map<String, List<AllocEvent>>> allModuleEvents) throws IOException {
+        ObjectNode root = mapper.createObjectNode();
+
+        for (Map.Entry<String, Map<String, List<AllocEvent>>> moduleEntry : allModuleEvents.entrySet()) {
+            List<AllocEvent> allEvents = moduleEntry.getValue().values().stream()
+                    .flatMap(List::stream).toList();
+            ObjectNode moduleNode = root.putObject(moduleEntry.getKey());
+
+            Map<String, Long> threadCounts = new LinkedHashMap<>();
+            for (AllocEvent e : allEvents) {
+                threadCounts.merge(e.threadName(), 1L, Long::sum);
+            }
+            ArrayNode topThreads = moduleNode.putArray("topThreads");
+            threadCounts.entrySet().stream()
+                    .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                    .limit(10)
+                    .forEach(entry -> {
+                        ObjectNode t = topThreads.addObject();
+                        t.put("thread", entry.getKey());
+                        t.put("count", entry.getValue());
+                    });
+
+            Map<String, Long> classCounts = new LinkedHashMap<>();
+            for (AllocEvent e : allEvents) {
+                classCounts.merge(e.className(), 1L, Long::sum);
+            }
+            ArrayNode topClasses = moduleNode.putArray("topClasses");
+            classCounts.entrySet().stream()
+                    .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                    .limit(20)
+                    .forEach(entry -> {
+                        ObjectNode c = topClasses.addObject();
+                        c.put("class", entry.getKey());
+                        c.put("count", entry.getValue());
+                    });
+
+            moduleNode.putArray("phaseBoundaries");
+        }
+
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(outDir.resolve("jfr-summary.json").toFile(), root);
+        System.out.println("[jfr-reporter] Wrote jfr-summary.json");
+    }
+
+    private String resolveStackId(List<String> frames,
+                                  Map<String, List<String>> stacksMap,
+                                  Map<String, String> stackIdCache,
+                                  AtomicInteger counter) {
+        String fingerprint = String.join("|", frames);
+        return stackIdCache.computeIfAbsent(fingerprint, k -> {
+            String id = "stk_" + String.format("%04d", counter.incrementAndGet());
+            stacksMap.put(id, frames);
+            return id;
+        });
+    }
+}

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
@@ -112,7 +112,7 @@ final class ReportGenerator {
         for (AllocEvent e : events) {
             String stackId = resolveStackId(e.stackFrames(), stacksMap, stackIdCache, stackCounter);
             ObjectNode node = timeline.addObject();
-            node.put("t", e.tMillis());
+            node.put("t", e.tEpochMillis());
             node.put("type", e.eventType());
             node.put("class", e.className());
             node.put("thread", e.threadName());

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
@@ -150,7 +150,7 @@ final class ReportGenerator {
             item.put("category", parts[1]);
             topClasses.add(item);
         }
-        topClasses.sort(Comparator.comparingLong((Map<String, Object> m) -> (long) m.get("count")).reversed());
+        topClasses.sort(Comparator.comparingLong((Map<String, Object> m) -> ((Number) m.get("count")).longValue()).reversed());
 
         mapper.writerWithDefaultPrettyPrinter()
                 .writeValue(outDir.resolve("alloc-top-classes-" + module + ".json").toFile(), topClasses);

--- a/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
+++ b/tools/jfr-reporter/src/main/java/eu/exeris/tools/jfr/ReportGenerator.java
@@ -1,5 +1,8 @@
 package eu.exeris.tools.jfr;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -108,21 +111,28 @@ final class ReportGenerator {
                                Map<String, List<String>> stacksMap,
                                Map<String, String> stackIdCache,
                                AtomicInteger stackCounter) throws IOException {
-        ArrayNode timeline = mapper.createArrayNode();
-        for (AllocEvent e : events) {
-            String stackId = resolveStackId(e.stackFrames(), stacksMap, stackIdCache, stackCounter);
-            ObjectNode node = timeline.addObject();
-            node.put("t", e.tEpochMillis());
-            node.put("type", e.eventType());
-            node.put("class", e.className());
-            node.put("thread", e.threadName());
-            node.put("size", e.sizeBytes());
-            node.put("stackId", stackId);
-            node.put("category", e.category().name());
+        List<AllocEvent> sorted = events.stream()
+                .sorted(Comparator.comparingLong(AllocEvent::tEpochMillis))
+                .toList();
+        java.io.File outFile = outDir.resolve("timeline-" + module + ".json").toFile();
+        try (JsonGenerator gen = mapper.getFactory().createGenerator(outFile, JsonEncoding.UTF8)) {
+            gen.setPrettyPrinter(new DefaultPrettyPrinter());
+            gen.writeStartArray();
+            for (AllocEvent e : sorted) {
+                String stackId = resolveStackId(e.stackFrames(), stacksMap, stackIdCache, stackCounter);
+                gen.writeStartObject();
+                gen.writeNumberField("t", e.tEpochMillis());
+                gen.writeStringField("type", e.eventType());
+                gen.writeStringField("class", e.className());
+                gen.writeStringField("thread", e.threadName());
+                gen.writeNumberField("size", e.sizeBytes());
+                gen.writeStringField("stackId", stackId);
+                gen.writeStringField("category", e.category().name());
+                gen.writeEndObject();
+            }
+            gen.writeEndArray();
         }
-        mapper.writerWithDefaultPrettyPrinter()
-                .writeValue(outDir.resolve("timeline-" + module + ".json").toFile(), timeline);
-        System.out.println("[jfr-reporter] Wrote timeline-" + module + ".json (" + events.size() + " events)");
+        System.out.println("[jfr-reporter] Wrote timeline-" + module + ".json (" + sorted.size() + " events)");
     }
 
     private void writeStacks(String module, Map<String, List<String>> stacksMap) throws IOException {


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul to the benchmarking and profiling infrastructure, focusing on improved Java Flight Recorder (JFR) integration, enhanced artifact handling in CI, and greater configurability for benchmarks. The changes enable automatic collection, processing, and publishing of JFR recordings and results, add a standalone JFR-to-JSON reporting tool, and improve test setup flexibility. These enhancements streamline performance analysis and make it easier to run and analyze benchmarks both locally and in CI environments.

**CI/CD and Benchmarking Infrastructure Improvements:**

* Added steps in `.github/workflows/maven.yml` to automatically upload JFR recordings from TCK, persistence, and benchmark runs, process them into JSON using a new `jfr-reporter` tool, and publish results to GitHub Pages for visualization. This includes new jobs for parsing and publishing JFR data. [[1]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R56-R66) [[2]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R120-R128) [[3]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R174-R182) [[4]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R199-R310)

* Benchmarks now run with JFR enabled by default via JVM arguments, and JFR artifacts are retained for 14 days to aid in performance investigations. [[1]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R174-R182) [[2]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R199-R310)

**Benchmark Configurability and Robustness:**

* Added support for overriding benchmark database URLs and TLS certificate paths via system properties, making it easier to run benchmarks against different environments and CI setups. [[1]](diffhunk://#diff-00cef5e50e2ffbcbc3814152dd0bde83fc93a4a52a0c3dabcd6b9802dff61df1R142-R149) [[2]](diffhunk://#diff-1fe9577efe27509febc828fa8a9cac7a6cd457bf49af3bfd742ac062f709828aR295-R369)

* Improved TLS certificate resolution logic in `CommunityTlsEngineGuardBenchmark`: it now tries system properties, generates a temporary self-signed cert if possible, and finally falls back to bundled certs, with proper cleanup of temp files. [[1]](diffhunk://#diff-1fe9577efe27509febc828fa8a9cac7a6cd457bf49af3bfd742ac062f709828aR66) [[2]](diffhunk://#diff-1fe9577efe27509febc828fa8a9cac7a6cd457bf49af3bfd742ac062f709828aL85-R93) [[3]](diffhunk://#diff-1fe9577efe27509febc828fa8a9cac7a6cd457bf49af3bfd742ac062f709828aR132-R145) [[4]](diffhunk://#diff-1fe9577efe27509febc828fa8a9cac7a6cd457bf49af3bfd742ac062f709828aR295-R369)

**Schema and Query Consistency:**

* Standardized benchmark table and column names from `value` to `value_text` across the codebase and documentation to avoid ambiguity. [[1]](diffhunk://#diff-fb3d12abbff0494092d8122420c2a9ea11a8e0472bca18e2e97985383029df1dL24-R26) [[2]](diffhunk://#diff-00cef5e50e2ffbcbc3814152dd0bde83fc93a4a52a0c3dabcd6b9802dff61df1L69-R69) [[3]](diffhunk://#diff-00cef5e50e2ffbcbc3814152dd0bde83fc93a4a52a0c3dabcd6b9802dff61df1L89-R96)

**Build and Tooling Enhancements:**

* Introduced a new Maven module `tools/jfr-reporter` with a shaded CLI tool to convert JFR files to JSON for lab analysis, using Jackson for serialization. [[1]](diffhunk://#diff-0f7438542648c5d608801a395b2df8ecccf270b87a3d0c4c587626162d4e6d0cR1-R70) [[2]](diffhunk://#diff-a89d5ffaa7958d7610e9c00b63e67ca0cad657acbf8fc126d83ca0e860ce9e44R1-R13)

**Benchmark Build Configuration:**

* Added a `benchmark.jvmArgsAppend` property to both `exeris-kernel-core` and `exeris-kernel-community` Maven modules, allowing additional JVM arguments (such as disabling internal JFR) to be appended easily. [[1]](diffhunk://#diff-5dfd03fbe475def7e8f67e1a6f472a6c8d88c3fd7e30243e14ebf40e6d2d9888R188) [[2]](diffhunk://#diff-5dfd03fbe475def7e8f67e1a6f472a6c8d88c3fd7e30243e14ebf40e6d2d9888R253-R254) [[3]](diffhunk://#diff-d26d810ef0e86d5e5e0291cdf8d28a5313d05643bc9f068b4d1defbcbdddf7bcR105) [[4]](diffhunk://#diff-d26d810ef0e86d5e5e0291cdf8d28a5313d05643bc9f068b4d1defbcbdddf7bcR167-R168)