### PR TITLE
Add research framework documentation and help assets for Exeris

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mvn -pl exeris-kernel-core -am clean install
 - SPI contracts: [exeris-kernel-spi/src/main](exeris-kernel-spi/src/main)
 - Core bootstrap and orchestration: [exeris-kernel-core/src/main](exeris-kernel-core/src/main)
 - Community providers and integration paths: [exeris-kernel-community/src/main](exeris-kernel-community/src/main)
-- Contract tests and abstract TCK suites: [exeris-kernel-tck/src/main](exeris-kernel-tck/src/main) and [exeris-kernel-tck/src/test](exeris-kernel-tck/src/test)
+- Contract tests and TCK suites: [exeris-kernel-tck/src/test](exeris-kernel-tck/src/test)
 
 ## Documentation Index
 

--- a/README.md
+++ b/README.md
@@ -1,107 +1,95 @@
 # Exeris Kernel
 
-> **Planned for v0.5:** Drop-in Spring Boot starter that replaces Tomcat/Netty with a native transport layer — same annotations, measurably less memory, higher throughput. Numbers available at v0.5 release.
->
-> The current repository delivers the **standalone Java 26 runtime kernel and transport SPI**. Spring Boot auto-configuration will be published in a future milestone.
+Repository for the Exeris runtime kernel (Java 26 GA with preview stack), organized as a multi-module Maven build.
 
-**Licence in one sentence:** SPI, Core, Community, and TCK are free for any use (including production); only the Enterprise acceleration layer (io_uring, QUIC, native DB drivers) requires a commercial licence — the same Open-Core boundary used by MongoDB and HashiCorp.
+This README is a developer entrypoint for the current repository state.
 
-Exeris Kernel is a **Java 26 native runtime** that sits beneath your application stack. Instead of blocking a thread per request (Tomcat) or allocating event-loop objects (Netty), Exeris uses **Panama FFM** and off-heap memory to move bytes between the kernel and your business logic with zero heap copies and zero context-switch overhead. The Enterprise edition additionally accelerates I/O with **io_uring** and QUIC.
+## Current Repository State
 
-```
-Spring Boot Application
-        │
- ┌──────▼───────────────────────────────────────────┐
- │          Exeris Kernel (this repo)               │
- │  Virtual Threads · Panama FFM · Off-Heap Memory  │  ← Community (free)
- ├──────────────────────────────────────────────────┤
- │    io_uring · QUIC/HTTP3 · Off-Heap TLS accel    │  ← Enterprise (commercial)
- └──────────────────────────────────────────────────┘
-        │
-   Linux Kernel
-```
+- This repository contains source modules for SPI, Core, Community, TCK, BOM, and build config.
+- Enterprise runtime code is not part of this repository.
+- HTTP codec/runtime code is currently embedded in Core in this repository layout.
+- Spring Boot starter/auto-configuration module is not present in this repository.
 
-## Why Exeris instead of Tomcat / Netty?
+## Module Map
 
-| Concern | Tomcat / Netty | Exeris Community | Exeris Enterprise |
-|---|---|---|---|
-| Memory model | JVM heap, GC pressure | Off-heap `MemorySegment`, zero GC | Off-heap `MemorySegment`, zero GC |
-| Concurrency | Thread-per-request / event loops | Virtual Threads + `StructuredTaskScope` | Virtual Threads + `StructuredTaskScope` |
-| I/O | Blocking NIO / `ByteBuffer` copies | Zero-copy `LoanedBuffer`, standard NIO | **io_uring** kernel-bypass, zero-copy |
-| TLS | JSSE (heap allocations) | Off-heap OpenSSL via Panama FFM | **Off-heap TLS acceleration** (QUIC/HTTP3) |
-| Observability | JMX / Micrometer | Built-in JFR events, flamegraph-ready | Built-in JFR events, flamegraph-ready |
-| Context propagation | `ThreadLocal` | `ScopedValue` (JEP 506), VT-safe | `ScopedValue` (JEP 506), VT-safe |
+Root reactor modules from [pom.xml](pom.xml):
 
-## Open-Core Model
+- exeris-kernel-build-config
+- exeris-kernel-bom
+- exeris-kernel-parent
+- exeris-kernel-spi
+- exeris-kernel-tck
+- exeris-kernel-core
+- exeris-kernel-community-testkit
+- exeris-kernel-community
 
-Exeris follows the **Open-Core model** (as used by MongoDB and HashiCorp): the SPI, core orchestration, and community drivers are free and open for use and contribution; enterprise accelerators (io_uring, QUIC/HTTP3, kernel-bypass TLS) require a commercial licence. This protects the project from cloud-vendor repackaging while keeping the community fully productive without paying anything.
+Related directories present in workspace but not part of the root reactor include:
 
-| Module | Licence | What's included |
-|---|---|---|
-| `exeris-kernel-spi` | Free | Immutable contracts, Value Records |
-| `exeris-kernel-core` | Free | Orchestration, bootstrap, context |
-| `exeris-kernel-community` | Free | Java 26 FFM adapters, standard TCP/TLS |
-| `exeris-kernel-tck` | Free | Compliance test kit for third-party drivers |
-| `exeris-kernel-enterprise` | **Commercial** | io_uring, QUIC/HTTP3, off-heap TLS acceleration |
+- exeris-kernel-enterprise (distribution-specific / out-of-repo runtime path)
+- tools (tooling helpers)
 
-## 🏗️ Architecture ("The Wall")
+## Architecture Baseline
 
-Exeris enforces **strict vertical separation** at the Maven module level — not by domain, but by **trust and execution tier**:
+The project keeps strict separation between contracts and implementations ("The Wall"):
 
-```
-exeris-kernel-parent
-├── exeris-kernel-spi        (The Constitution — pure contracts, no impl)
-├── exeris-kernel-core       (The Brain — orchestration, bootstrap, context)
-├── exeris-kernel-community  (The Engine — standard Java 26 FFM adapters)
-├── exeris-kernel-enterprise (The Accelerator — io_uring, QUIC, off-heap TLS)
-└── exeris-kernel-tck        (The Judge — Technology Compatibility Kit)
-```
+- SPI defines contracts and carriers.
+- Core orchestrates via SPI and remains driver-agnostic.
+- Community provides open implementations for current repository runtime paths.
+- TCK verifies observable SPI contract behavior.
 
-The **À la carte** rule: you can mix providers across tiers. Use the free Community Transport while plugging in the Enterprise Persistence driver — or disable higher-level features entirely.
+Authoritative references:
 
-Key principles (see [`docs/architecture.md`](docs/architecture.md)):
-- **spi** has zero Exeris dependencies — it is the immutable foundation.
-- **core** depends only on **spi**.
-- **community** and **enterprise** never depend on each other.
-- **tck** depends only on **spi** — it tests contracts, never implementations.
+- [docs/modules/01-spi.md](docs/modules/01-spi.md)
+- [docs/modules/02-core.md](docs/modules/02-core.md)
+- [docs/modules/03-community.md](docs/modules/03-community.md)
+- [docs/modules/04-enterprise.md](docs/modules/04-enterprise.md)
+- [docs/modules/05-tck.md](docs/modules/05-tck.md)
 
-## 🧩 Key Components
+## Requirements
 
-- **`exeris-kernel-spi`** — Identity-free data carriers (**Value Records**) and lifecycle contracts.
-- **`exeris-kernel-core`** — Core runtime: `SubsystemOrchestrator`, `WatermarkManager`, `ResourceArbiter`, off-heap TLS (`OffHeapTlsEngine`), PAQS transport scheduler. `CoreOrchestrator` and `KernelBootstrap` are planned v0.5+ entrypoints for full `ServiceLoader`-backed multi-provider boot.
-- **`exeris-kernel-community`** — Standard Java 26 FFM TCP/TLS adapters, accessible to all.
-- **`exeris-kernel-enterprise`** — Native C drivers: `io_uring` ring management, `QuicBioMultiplexer`, off-heap OpenSSL.
-- **`exeris-kernel-tck`** — Inquisition suite; any third-party driver must pass all TCK tests before integration.
+- Linux, macOS, or Windows
+- JDK 26 with preview features enabled
+- Maven 3.9+
 
-## 🚀 Quick Start (Spring Boot) — Planned
+The build is configured for Java 26 preview and native access flags in [pom.xml](pom.xml).
 
-> Spring Boot auto-configuration is **planned for v0.5.0**. The coordinates below reflect the target
-> module structure; the Spring Boot starter artifact will be published alongside the v0.5 release notes.
-> The current repository exposes the Exeris Kernel as a standalone Java 26 runtime and low-level
-> transport SPI.
+## Build and Test
 
-```xml
-<!-- pom.xml — planned Spring Boot integration (not yet available) -->
-<!-- A dedicated Spring Boot starter / auto-configuration module will be added in a future release. -->
-<dependency>
-    <groupId>io.exeris</groupId>
-    <artifactId>exeris-kernel-core</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
-</dependency>
-<dependency>
-    <groupId>io.exeris</groupId>
-    <artifactId>exeris-kernel-community</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
-    <scope>runtime</scope>
-</dependency>
+Build all reactor modules:
+
+```bash
+mvn clean install
 ```
 
-Full integration guide → [`docs/architecture.md`](docs/architecture.md)  
-Performance guarantees → [`docs/performance-contract.md`](docs/performance-contract.md)
+Build selected module with dependencies:
 
-## 📄 Licence
+```bash
+mvn -pl exeris-kernel-core -am clean install
+```
 
-The **SPI, Core, Community, and TCK** modules are distributed under **Apache License 2.0 + Commons Clause** ([LICENSE-COMMUNITY](LICENSE-COMMUNITY)) (free for development and production use — see individual module READMEs).  
-The **Enterprise** module is distributed under the **Exeris Commercial Licence** (contact [legal@exeris.eu](mailto:legal@exeris.eu)).
+## Where to Start Reading Code
 
-Copyright © 2025–2026 Exeris. All rights reserved.
+- SPI contracts: [exeris-kernel-spi/src/main](exeris-kernel-spi/src/main)
+- Core bootstrap and orchestration: [exeris-kernel-core/src/main](exeris-kernel-core/src/main)
+- Community providers and integration paths: [exeris-kernel-community/src/main](exeris-kernel-community/src/main)
+- Contract tests and abstract TCK suites: [exeris-kernel-tck/src/main](exeris-kernel-tck/src/main) and [exeris-kernel-tck/src/test](exeris-kernel-tck/src/test)
+
+## Documentation Index
+
+- Architecture overview: [docs/architecture.md](docs/architecture.md)
+- Performance contract: [docs/performance-contract.md](docs/performance-contract.md)
+- Whitepaper: [docs/whitepaper.md](docs/whitepaper.md)
+- ADRs: [docs/adr](docs/adr)
+- Subsystems: [docs/subsystems](docs/subsystems)
+- Module contracts: [docs/modules](docs/modules)
+- Help asset: [docs/assets/help-who-exeris-is-for.md](docs/assets/help-who-exeris-is-for.md)
+- Hub/Hero asset: [docs/assets/hub-hero-adoption-path.md](docs/assets/hub-hero-adoption-path.md)
+
+## Licensing
+
+- Community-side modules (SPI, Core, Community, TCK): [LICENSE-COMMUNITY](LICENSE-COMMUNITY)
+- Enterprise license text: [LICENSE-ENTERPRISE](LICENSE-ENTERPRISE)
+- Additional module-level notes: module-local LICENSE/README files
+
+For legal questions: legal@exeris.eu

--- a/docs/assets/help-who-exeris-is-for.md
+++ b/docs/assets/help-who-exeris-is-for.md
@@ -1,0 +1,117 @@
+# Help Asset: Who Exeris Is For - And Who It Is Not For
+
+## Positioning in One Line
+Exeris is for teams that treat compute and memory as a business budget, not as an invisible tax.
+
+## Who Exeris Is For
+
+### 1) Teams with FinOps pressure on throughput per core
+You are a strong fit if you care about:
+- Higher requests per vCPU and lower memory waste.
+- Predictable behavior under load (admission control and shedding).
+- Cost-per-request as an engineering KPI.
+
+Why this maps to Exeris:
+- `memory` + `transport` + `http` + `crypto` are built around off-heap, bounded-allocation paths.
+- `telemetry` is JFR-first with explicit error contracts (`EX-*`) and low-overhead event paths.
+- `config` and `bootstrap` support fail-fast operation and deterministic startup behavior.
+
+### 2) Teams running high-density multi-tenant workloads
+You are a strong fit if you need:
+- Isolation by contract, not by convention.
+- Stable latency under contention.
+- Hard control over noisy-neighbor effects.
+
+Why this maps to Exeris:
+- `security` uses `ScopedValue` propagation and fail-closed admission at the edge.
+- `persistence` has admission signaling (`canServiceRequest()`) and context-driven isolation.
+- `transport` PAQS shedding protects critical traffic before heap pressure cascades.
+
+### 3) Teams that want incremental adoption, not a big-bang rewrite
+You are a strong fit if you need to adopt in phases:
+- Start with existing JDBC and standard Java app structure.
+- Move selected paths to lower allocation and zero-copy behavior over time.
+- Keep a contract-tested surface while evolving internals.
+
+Why this maps to Exeris:
+- SPI/Core/Community split keeps boundaries explicit.
+- TCK layer verifies observable contracts as implementations evolve.
+- Community runtime is available in-repo; Enterprise remains separate distribution.
+
+### 4) Teams that value operational truth over framework abstraction
+You are a strong fit if you prefer:
+- Typed subsystem contracts.
+- Explicit lifecycle and ownership rules.
+- Diagnostics grounded in stable error code schemas.
+
+Why this maps to Exeris:
+- `exceptions` + `telemetry` define deterministic rawArgs schemas per error code.
+- `bootstrap` lifecycle and subsystem phases are explicit and documented.
+
+### 5) Teams that want Spring apps with Exeris runtime ownership (Future Track)
+You are a potential fit if you need:
+- Spring application ergonomics with Exeris execution ownership.
+- A migration path that keeps kernel boundaries intact (no Spring in SPI/Core).
+- Explicit trade-offs between pure performance mode and compatibility mode.
+
+Why this maps to Exeris:
+- `exeris-spring-runtime` is being built as a separate integration layer.
+- Its stated direction is Exeris-owned ingress/runtime while preserving The Wall.
+- It is suitable as a planned adoption track, not as current in-repo kernel baseline.
+
+## Who Exeris Is Not For
+
+### 1) Teams optimizing for framework convenience first
+Not a fit if your top priority is:
+- Maximum framework magic and auto-configuration.
+- Heavy reflection-driven stacks as the default runtime model.
+
+Reason:
+- Exeris favors explicit contracts, explicit bootstrap behavior, and low-level ownership control.
+
+### 2) Teams with no resource-efficiency problem to solve
+Not a fit if:
+- Your workload is low-volume and low-cost.
+- Latency/cost density is not a business concern.
+
+Reason:
+- Exeris architecture pays off most when efficiency and predictability are first-order constraints.
+
+### 3) Teams unwilling to enforce subsystem boundaries
+Not a fit if:
+- You regularly blur contract boundaries across runtime layers.
+- You prefer ad-hoc integration over SPI/TCK discipline.
+
+Reason:
+- Exeris depends on boundary integrity (The Wall) to preserve long-term performance and portability.
+
+### 4) Teams needing closed-source Enterprise internals in this repository
+Not a fit if you require:
+- Enterprise source code in this public/community repository.
+
+Reason:
+- Enterprise runtime is distributed separately.
+
+### 5) Teams expecting production-complete Spring-hosted Exeris in this repository today
+Not a fit right now if you require:
+- Officially in-repo, production-complete Spring runtime integration as a current baseline.
+
+Reason:
+- The Spring runtime track exists in a separate repository and is currently in early architecture/bootstrap stage.
+
+## Decision Check (Fast Self-Assessment)
+
+You are likely a fit if you answer yes to at least 3:
+- We track cost per request and density metrics.
+- We need predictable behavior under pressure, not best-effort degradation.
+- We can adopt by subsystem and measurable milestones.
+- We accept explicit contracts over hidden framework behavior.
+- We need a path from standard Java stack toward lower-copy, lower-allocation runtime.
+
+If you answer yes to 0-1, Exeris is probably not the right first move today.
+
+## Reality Guardrails
+- Current repository state includes SPI, Core, Community, and TCK runtime code.
+- HTTP codec/runtime implementation is currently in Core.
+- Enterprise module is not present in this repository and should be treated as separate distribution scope.
+- `exeris-spring-runtime` exists as a separate repository and should be treated as a future adoption track until officially folded into kernel release posture.

--- a/docs/assets/hub-hero-adoption-path.md
+++ b/docs/assets/hub-hero-adoption-path.md
@@ -1,0 +1,139 @@
+# Hub/Hero Asset: Exeris Adoption Path - From Standard Java Stack to Zero-Copy Runtime
+
+## Executive Summary
+Exeris adoption is designed as a staged path: start where your team is today, harden contracts, then move high-cost paths toward bounded allocation and zero-copy behavior where it matters most.
+
+This path is optimized for two outcomes:
+- FinOps resource efficiency (cost per request, cost per transaction).
+- High density (more stable throughput per vCPU under load).
+
+## Stage 0 - Baseline and Cost Map (No Runtime Rewrite)
+
+Primary subsystem focus:
+- `telemetry`, `exceptions`, `config`
+
+What to do:
+- Establish baseline KPIs: p95/p99 latency, CPU per request, memory per request, error budget.
+- Normalize error signals around stable `EX-*` codes and JFR events.
+- Freeze operating defaults via explicit config keys and fail-fast expectations.
+
+Exit criteria:
+- You can explain current spend and latency using repeatable telemetry.
+- Hot-path incidents are visible through code-based error taxonomy, not only logs.
+
+## Stage 1 - Contract First (Boundary Hardening)
+
+Primary subsystem focus:
+- `spi`, `core`, `tck`
+
+What to do:
+- Move integration seams behind SPI contracts where missing.
+- Add or align TCK coverage for observable behaviors you depend on.
+- Remove implementation leakage across module boundaries.
+
+Exit criteria:
+- Critical paths are expressed through contracts, not concrete runtime classes.
+- Regression risk is reduced by executable contract tests.
+
+## Stage 2 - Admission and Runtime Stability (Density Before Speed)
+
+Primary subsystem focus:
+- `transport`, `security`, `persistence`, `memory`
+
+What to do:
+- Enable and tune admission logic (PAQS and persistence admission checks) to avoid overload collapse.
+- Enforce fail-closed security at ingress with clear 401/403 semantics.
+- Use bounded pool sizing and shedding thresholds to prioritize critical workloads.
+
+Exit criteria:
+- Under synthetic pressure, the system sheds predictably instead of cascading.
+- Critical traffic remains serviceable while low-priority traffic is throttled/shed.
+
+## Parallel Future Track - Spring Application Model on Exeris Runtime
+
+Primary focus:
+- Separate `exeris-spring-runtime` integration layer (outside this repository)
+
+What to do:
+- Evaluate this path when Spring programming model continuity is a hard requirement.
+- Keep boundary integrity: no Spring dependency leakage into kernel SPI/Core.
+- Choose explicitly between pure Exeris runtime ownership and compatibility-oriented mode.
+
+Exit criteria:
+- Team can preserve Spring delivery ergonomics without surrendering runtime ownership assumptions.
+- Architecture decision is documented as future-track until officially part of kernel release posture.
+
+## Stage 3 - Low-Allocation Data Plane (Community Path)
+
+Primary subsystem focus:
+- `http`, `transport`, `crypto`, `memory`
+
+What to do:
+- Keep wire handling on off-heap buffers where supported by current implementation.
+- Remove avoidable heap copies in request/response processing.
+- Validate zero/low-allocation expectations with JFR and targeted TCK/integration tests.
+
+Exit criteria:
+- Request path allocation profile is materially lower than baseline.
+- Throughput per vCPU improves without instability regressions.
+
+## Stage 4 - Persistence and Workflow Efficiency
+
+Primary subsystem focus:
+- `persistence`, `events`, `flow`, `graph`
+
+What to do:
+- Reduce unnecessary object churn in persistence and event paths.
+- Keep transactional guarantees and idempotency intact while optimizing throughput.
+- Apply workflow and graph capabilities where they remove duplicate application-layer work.
+
+Exit criteria:
+- Lower CPU and allocation overhead for DB/event-heavy workloads.
+- Clear operational boundaries for retries, DLQ, and long-running flow behavior.
+
+## Stage 5 - Advanced Zero-Copy Trajectory (Enterprise Scope)
+
+Primary subsystem focus:
+- Enterprise runtime capabilities (outside this repository)
+
+What to do:
+- Evaluate enterprise-only path for kernel-bypass and full end-to-end zero-heap goals.
+- Prioritize only if Stage 0-4 metrics show a clear economic case.
+
+Exit criteria:
+- Decision is justified by measured savings and density gains, not by architecture fashion.
+
+## Adoption Patterns by Team Maturity
+
+Pattern A - Conservative
+- Goal: risk reduction and cost visibility first.
+- Typical path: Stage 0 -> 1 -> 2.
+
+Pattern B - Throughput Focused
+- Goal: stabilize under load quickly.
+- Typical path: Stage 0 -> 2 -> 3.
+
+Pattern C - Platform Team
+- Goal: long-term contract governance and multi-service standardization.
+- Typical path: Stage 0 -> 1 -> 2 -> 3 -> 4.
+
+Pattern E - Spring Migration Program (Future Track)
+- Goal: retain Spring application model while moving runtime ownership toward Exeris.
+- Typical path: Stage 0 -> 1 -> 2 + Parallel Future Track -> 3 -> 4.
+
+Pattern D - Extreme Density Program
+- Goal: maximum resource efficiency for high-scale workloads.
+- Typical path: Stage 0 -> 1 -> 2 -> 3 -> 4 -> 5.
+
+## KPI Ladder (What to Measure at Each Stage)
+- Cost per request.
+- Requests per vCPU at target latency SLO.
+- Allocation rate on request hot path.
+- Shed ratio by priority under stress.
+- Error-code distribution (`EX-*`) per subsystem.
+
+## Current Repository Reality Notes
+- Community runtime path is present in this repository.
+- HTTP codec/runtime implementation is currently embedded in Core.
+- Enterprise runtime capabilities are out-of-repo and should be treated as separate distribution scope.
+- `exeris-spring-runtime` exists as a separate repository, in early architecture/bootstrap stage; treat it as future adoption scope until officially included in kernel release posture.

--- a/docs/research/RESEARCH-TEMPLATE.md
+++ b/docs/research/RESEARCH-TEMPLATE.md
@@ -1,0 +1,100 @@
+# Research: [Short Title]
+
+> **Branch:** `research/[slug]`
+> **Author:** [GitHub handle]
+> **Started:** [YYYY-MM-DD]
+> **Milestone:** [v0.x — or "unbounded"]
+> **Status:** `active` | `concluded` | `abandoned`
+
+---
+
+## Hypothesis
+
+> One paragraph. What do you believe is true, and why does it matter for Exeris Kernel?
+> Be specific — "I think X will reduce Y by Z% because W" is a good hypothesis.
+> "Let's explore X" is not.
+
+---
+
+## Motivation
+
+Why now? What existing evidence (benchmark, profiling data, JEP, paper, external benchmark)
+suggests this is worth investigating? Link to:
+
+- Relevant ADR (if any)
+- JEP number (if JVM feature)
+- External benchmark / paper (DOI or URL)
+- JFR recording or JMH result that shows the bottleneck
+
+---
+
+## Methodology
+
+### What will be measured
+
+| Metric | Tool | Baseline | Target |
+|:-------|:-----|:---------|:-------|
+| e.g. P99 latency | JMH + JFR | X µs | < Y µs |
+| e.g. heap alloc/op | JFR TLAB | X bytes | 0 bytes |
+
+### How it will be measured
+
+Describe the benchmark / test harness setup:
+
+- Hardware (bare metal / VM / CI runner)
+- JDK version + flags
+- JMH parameters (forks, warmup, iterations)
+- Any kernel tunables (cpu governor, io_uring flags, etc.)
+
+### What will NOT be measured (scope boundary)
+
+Explicitly list what is out of scope to prevent scope creep.
+
+---
+
+## Implementation Notes
+
+*Free-form. Updated as work progresses.*
+
+Running notes, dead ends, surprising findings. This is a lab notebook, not a design doc.
+Broken code, TODOs, and half-finished ideas are acceptable here.
+
+---
+
+## Results
+
+*Fill in when experiments are complete.*
+
+### Summary
+
+One paragraph conclusion. Did the hypothesis hold?
+
+### Data
+
+| Config | Metric | Value | vs Baseline |
+|:-------|:-------|:------|:------------|
+| | | | |
+
+Attach JMH JSON (`results/jmh-*.json`) and JFR recordings (`results/*.jfr`) to this branch.
+
+---
+
+## Decision
+
+Choose one:
+
+- [ ] **Promote to ADR** — findings are conclusive, open ADR PR to `main`
+- [ ] **Promote to Feature** — no ADR needed, open feature PR with research branch as base
+- [ ] **Park** — promising but not urgent, convert to GitHub Discussion
+- [ ] **Abandon** — hypothesis falsified or effort not justified
+
+**Rationale:** [why this decision]
+
+**Follow-up issue:** [link to GitHub issue if promoting]
+
+---
+
+## References
+
+- [Link 1]
+- [Link 2]

--- a/docs/research/RESEARCH.md
+++ b/docs/research/RESEARCH.md
@@ -1,0 +1,441 @@
+# Research Framework
+
+Exeris Kernel uses **branch-scoped research** to investigate architectural, performance,
+runtime, and native-integration questions before promoting changes into the mainline.
+
+This document defines:
+
+- what counts as research,
+- how research is structured,
+- how research relates to ADRs and feature work,
+- which research tracks are currently active or planned,
+- and how findings are promoted back into the main repository.
+
+Research in Exeris is not informal note-taking. It is a controlled mechanism for
+evaluating high-risk, high-impact changes without polluting `main` with unstable
+assumptions, speculative abstractions, or premature APIs.
+
+---
+
+## Purpose
+
+Research exists to answer questions that are too important to guess at and too
+uncertain to merge directly.
+
+Typical examples:
+
+- JVM/runtime evolution that may affect architecture or hot-path behavior,
+- scheduler and concurrency model changes,
+- native boundary redesign,
+- performance-contract validation,
+- kernel / transport / crypto capability shifts,
+- migration readiness for foundational dependencies.
+
+A research branch should produce evidence strong enough to support one of four outcomes:
+
+1. **Promote to ADR**
+2. **Promote directly to feature work**
+3. **Park for later**
+4. **Abandon**
+
+If a question does not require measurement, architectural validation, or prototype
+evidence, it probably does not need a research branch.
+
+---
+
+## Research Model
+
+Every concrete research effort lives in its **own branch**:
+
+- `research/loom-continuation-locality`
+- `research/openssl-4-migration-envelope`
+- `research/jdk27-preparation`
+- etc.
+
+The canonical research document for that effort is stored in the branch itself,
+typically as:
+
+- `research.md`
+- or a more specific path inside `docs/research/`
+
+Use one canonical path per research effort.
+Do not maintain duplicated full copies of the same living research document in multiple locations.
+
+The `main` branch does **not** carry all active lab notes and branch-specific details.
+Instead:
+
+- `docs/RESEARCH.md` defines the framework and portfolio,
+- each research branch contains the living research document,
+- conclusions are promoted back into `main` via ADRs, feature PRs, or summary updates.
+
+This keeps speculative work isolated while preserving a clear, auditable research trail.
+
+---
+
+## When to Open a Research Branch
+
+Open a research branch when **at least one** of the following is true:
+
+- the work may change an architectural boundary,
+- the work depends on benchmark or profiling evidence,
+- the work involves experimental JVM, kernel, or native-library behavior,
+- the work may require prototype-only code not suitable for `main`,
+- the work explores multiple competing designs,
+- the work needs a formal decision trail before implementation.
+
+Do **not** open a research branch for:
+
+- straightforward bug fixes,
+- small refactors with obvious outcomes,
+- feature work that already has a settled design,
+- generic notes that do not lead to a decision.
+
+---
+
+## Required Shape of a Research Document
+
+Every concrete research document should follow the structure defined in
+`docs/RESEARCH-TEMPLATE.md`.
+
+At minimum, a research document must contain:
+
+- a specific hypothesis,
+- a reason the question matters now,
+- a methodology,
+- a scope boundary,
+- implementation notes,
+- results,
+- and a final decision.
+
+A research document is not a vague exploration memo.
+It must be decision-oriented.
+
+---
+
+## Relationship to ADRs
+
+Research is upstream of ADRs, not a replacement for them.
+
+Use **research** when:
+- the question is still open,
+- evidence is still being gathered,
+- prototype code may be unstable or disposable,
+- multiple designs are still in play.
+
+Use an **ADR** when:
+- the decision is ready to be made,
+- the evidence is sufficiently conclusive,
+- the chosen direction is intended to shape `main`.
+
+A strong research branch often ends with:
+- “Promote to ADR”
+- plus a follow-up ADR PR summarizing the outcome.
+
+Not every research effort needs an ADR.
+If the result is implementation-local and does not affect architecture, it may go
+straight to feature work.
+
+---
+
+## Relationship to Feature Work
+
+Feature branches implement decisions.
+Research branches validate whether those decisions should exist at all.
+
+The correct order is usually:
+
+1. research branch
+2. findings
+3. ADR or direct decision
+4. feature branch / PR
+
+This order is especially important for:
+
+- scheduler changes,
+- native-boundary changes,
+- crypto upgrades,
+- new transport geometry,
+- JVM preview or incubator features,
+- major dependency migration preparation.
+
+---
+
+## Research Quality Bar
+
+A research branch is considered healthy only if it has:
+
+- a falsifiable or confirmable hypothesis,
+- explicit baseline and target metrics where measurement applies,
+- clear scope boundaries,
+- reproducible methodology,
+- raw artifacts where possible (`.jfr`, JMH JSON, perf outputs, benchmark logs),
+- and a decision path at the end.
+
+Weak research usually looks like one of these:
+
+- “let’s explore X”
+- no benchmark harness
+- no baseline
+- no out-of-scope boundary
+- no recorded findings
+- no final decision
+
+That is not enough.
+
+---
+
+## Evidence Expectations
+
+The required evidence depends on the research type.
+
+### Performance / scheduler / runtime research
+
+Expected evidence:
+- JMH or dedicated benchmark harness
+- JFR
+- perf / async-profiler / OS counters where applicable
+- fixed-rate and/or saturation comparisons
+- baseline and candidate comparisons
+
+### Native dependency / migration research
+
+Expected evidence:
+- compatibility inventory
+- API impact analysis
+- prototype wrappers or spike notes
+- lifecycle and ownership analysis
+- migration risk matrix
+
+### JVM / JDK preparation research
+
+Expected evidence:
+- JEP review
+- compatibility audit
+- prototype or spike notes if needed
+- impact on build, runtime, and architecture
+- migration envelope proposal
+
+Not every research effort needs all tool types.
+But every effort must produce evidence appropriate to its claims.
+
+---
+
+## Active Research Portfolio
+
+The following research tracks are currently recognized as load-bearing for Exeris Kernel.
+
+### 1. OpenSSL 4.0 Migration Envelope for Native Crypto
+
+**Branch:** `research/openssl-4-migration-envelope`
+
+Focus:
+- OpenSSL 4.0 readiness,
+- opaque types,
+- const-correct API drift,
+- lifecycle/init/cleanup behavior,
+- provider-era assumptions,
+- shared crypto boundary across Core/Community and Enterprise.
+
+Why it matters:
+- OpenSSL is foundational across the stack,
+- migration debt grows if 3.x assumptions continue to leak upward,
+- native crypto boundary must be hardened before 4.0 becomes unavoidable.
+
+Expected outcome:
+- migration envelope,
+- native crypto boundary hardening guidance,
+- possible ADR if the shared crypto boundary must change materially.
+
+### 2. JDK 27 Preparation
+
+**Branch:** `research/jdk27-preparation`
+
+Focus:
+- preparation for JDK 27 language/runtime/toolchain changes,
+- preview/incubator maturity tracking,
+- Loom / FFM / GC / runtime behavior shifts,
+- compatibility and migration planning across build and runtime surfaces.
+
+Why it matters:
+- Exeris is intentionally close to modern JVM capabilities,
+- delayed preparation creates architectural and operational debt,
+- runtime assumptions must be revalidated before adoption.
+
+Expected outcome:
+- migration-readiness matrix,
+- compatibility inventory,
+- adoption / defer / watch recommendations per JEP or feature area.
+
+---
+
+## Concluded Research
+
+### 1. Loom Continuation Locality
+
+**Branch:** `research/loom-continuation-locality`
+
+**Status:** `concluded`
+
+Focus:
+- continuation locality,
+- default Loom/ForkJoin resume behavior,
+- transport-affine execution,
+- Core/Community and Enterprise benchmark tracks,
+- scheduler seam extraction,
+- possible bounded-drain event-loop follow-up.
+
+Outcome:
+- scheduler seam was successfully extracted and kept as useful infrastructure,
+- Community measurements did not show a material E2E payoff for `locality-aware`,
+- latest Community `shop-order-saga` run stayed at throughput parity while increasing CPU cost,
+- Enterprise escalation was not justified in the current cycle.
+
+Final decision:
+- primary disposition: **Park**
+- cycle decision: **NO_GO**
+- follow-up: keep the seam and findings as evidence in research branch,
+  with no H2 and no Enterprise escalation in the current cycle; any future Enterprise-side
+  locality work requires a materially different hypothesis.
+
+Note:
+Any future Enterprise-side locality experiment is not a continuation of the closed
+Community payoff track. It is a separate, native-transport-specific follow-up motivated
+by materially different execution geometry (`io_uring` / `IOCP`, poller interaction,
+wakeup costs, and scheduler/carrier coupling).
+
+---
+
+## How Results Flow Back to Main
+
+When a research branch concludes, one or more of the following should happen:
+
+### Option 1 — Promote to ADR
+Use when findings imply a durable architectural decision.
+
+### Option 2 — Promote to Feature
+Use when findings are conclusive but architecture does not need an ADR.
+
+### Option 3 — Update `docs/RESEARCH.md`
+Add status update, final disposition, or successor work.
+
+### Option 4 — Open follow-up issue/discussion
+Use when work is promising but deferred.
+
+The branch itself remains the primary historical record of the investigation.
+
+---
+
+## Research Status Conventions
+
+Use one of the following statuses in each research document:
+
+- `active`
+- `concluded`
+- `abandoned`
+
+Recommended interpretation:
+
+### `active`
+Work is ongoing; notes, prototypes, and measurements are still evolving.
+
+### `concluded`
+Evidence is sufficient and a final decision has been made.
+
+### `abandoned`
+The hypothesis was falsified, superseded, or no longer worth pursuing.
+
+If a research effort is merely paused, keep it as `active` and explain that in the
+Decision section.
+
+---
+
+## Recommended Branch Lifecycle
+
+1. Create `research/[slug]`
+2. Add `research.md` from `docs/RESEARCH-TEMPLATE.md`
+3. Define hypothesis and methodology before large prototype work
+4. Collect evidence and update implementation notes continuously
+5. Record results
+6. Make a final decision
+7. Promote findings through ADR / feature PR / issue / summary update
+
+This sequence is preferred because it keeps branch work decision-oriented rather
+than drifting into undocumented experimentation.
+
+---
+
+## Naming Conventions
+
+### Branch name
+Use:
+
+`research/[slug]`
+
+Examples:
+- `research/loom-continuation-locality`
+- `research/openssl-4-migration-envelope`
+- `research/jdk27-preparation`
+
+### Document title
+Use:
+
+`# Research: [Short Title]`
+
+### Main branch documentation
+- `docs/RESEARCH.md` — framework and portfolio
+- `docs/RESEARCH-TEMPLATE.md` — canonical template
+
+### Branch-local document
+Prefer:
+- `research.md`
+
+unless the branch has a compelling reason to use a more specific path.
+
+---
+
+## What Research Must Not Become
+
+Research branches must not become:
+
+- undocumented long-lived forks,
+- feature branches pretending to be research,
+- ADR substitutes,
+- dumping grounds for random notes,
+- unbounded prototype branches with no decision pressure.
+
+If the branch has no hypothesis, no methodology, and no decision path, it should
+either be fixed or closed.
+
+---
+
+## Decision Framework
+
+Every research branch should end in exactly one primary disposition:
+
+- **Promote to ADR**
+- **Promote to Feature**
+- **Park**
+- **Abandon**
+
+These are intentionally strict.
+A research effort that never reaches a disposition is incomplete.
+
+---
+
+## Template
+
+Use the canonical template in:
+
+- `docs/RESEARCH-TEMPLATE.md`
+
+for all new research branches.
+
+---
+
+## References
+
+- `docs/RESEARCH-TEMPLATE.md`
+- `docs/architecture.md`
+- `docs/performance-contract.md`
+- `docs/adr/ADR-007*`
+- `docs/adr/ADR-008*`

--- a/docs/research/RESEARCH.md
+++ b/docs/research/RESEARCH.md
@@ -64,7 +64,7 @@ Do not maintain duplicated full copies of the same living research document in m
 The `main` branch does **not** carry all active lab notes and branch-specific details.
 Instead:
 
-- `docs/RESEARCH.md` defines the framework and portfolio,
+- `docs/research/RESEARCH.md` defines the framework and portfolio,
 - each research branch contains the living research document,
 - conclusions are promoted back into `main` via ADRs, feature PRs, or summary updates.
 
@@ -95,7 +95,7 @@ Do **not** open a research branch for:
 ## Required Shape of a Research Document
 
 Every concrete research document should follow the structure defined in
-`docs/RESEARCH-TEMPLATE.md`.
+`docs/research/RESEARCH-TEMPLATE.md`.
 
 At minimum, a research document must contain:
 
@@ -315,7 +315,7 @@ Use when findings imply a durable architectural decision.
 ### Option 2 — Promote to Feature
 Use when findings are conclusive but architecture does not need an ADR.
 
-### Option 3 — Update `docs/RESEARCH.md`
+### Option 3 — Update `docs/research/RESEARCH.md`
 Add status update, final disposition, or successor work.
 
 ### Option 4 — Open follow-up issue/discussion
@@ -352,7 +352,7 @@ Decision section.
 ## Recommended Branch Lifecycle
 
 1. Create `research/[slug]`
-2. Add `research.md` from `docs/RESEARCH-TEMPLATE.md`
+2. Add `research.md` from `docs/research/RESEARCH-TEMPLATE.md`
 3. Define hypothesis and methodology before large prototype work
 4. Collect evidence and update implementation notes continuously
 5. Record results
@@ -382,8 +382,8 @@ Use:
 `# Research: [Short Title]`
 
 ### Main branch documentation
-- `docs/RESEARCH.md` — framework and portfolio
-- `docs/RESEARCH-TEMPLATE.md` — canonical template
+- `docs/research/RESEARCH.md` — framework and portfolio
+- `docs/research/RESEARCH-TEMPLATE.md` — canonical template
 
 ### Branch-local document
 Prefer:
@@ -426,7 +426,7 @@ A research effort that never reaches a disposition is incomplete.
 
 Use the canonical template in:
 
-- `docs/RESEARCH-TEMPLATE.md`
+- `docs/research/RESEARCH-TEMPLATE.md`
 
 for all new research branches.
 
@@ -434,7 +434,7 @@ for all new research branches.
 
 ## References
 
-- `docs/RESEARCH-TEMPLATE.md`
+- `docs/research/RESEARCH-TEMPLATE.md`
 - `docs/architecture.md`
 - `docs/performance-contract.md`
 - `docs/adr/ADR-007*`


### PR DESCRIPTION
This pull request significantly updates the project documentation to clarify repository structure, target audience, adoption paths, and introduces a research template. The main README is rewritten for clarity and accuracy, two new help and adoption assets are added, and a structured template for research work is introduced.

**Documentation Restructure and Clarification**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R95): Completely rewritten to reflect the current multi-module Maven structure, clarify what is and isn't in the repository, provide a clear module map, update build/test instructions, and link to authoritative docs. Licensing and architecture sections are clarified, and legacy or planned Spring Boot integration content is removed.

**Audience and Adoption Guidance**

* [`docs/assets/help-who-exeris-is-for.md`](diffhunk://#diff-c2ae3bd1ca16631bfc8d5ebe19bde0341906a201e687a93b3756b3f853cb660dR1-R117): New help asset added, outlining which teams and use cases Exeris is (and is not) a good fit for, with clear rationale for each. Includes a self-assessment checklist and repository reality notes.
* [`docs/assets/hub-hero-adoption-path.md`](diffhunk://#diff-54aa06048eb4d3ef94b1aadceb40360a942211231eda652399bef97fec6a413cR1-R139): New "hub/hero" asset describing the staged adoption path from a standard Java stack toward a zero-copy runtime, including KPIs, adoption patterns, and repository scope notes.

**Research Process Improvements**

* [`docs/research/RESEARCH-TEMPLATE.md`](diffhunk://#diff-6ec45d02edd330d3c5f74f2dfa26615aba5e98b1fdbcf56c6cfa1b0c8f9c43a4R1-R100): Adds a detailed research template to standardize experiment tracking, including sections for hypothesis, methodology, results, and decision, to support disciplined, reproducible research in the codebase.