### PR TITLE
Enhance TLS setup, CoreFlowRuntime, and add TCK tests

### DIFF
--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -59,9 +59,9 @@ zero-leak, hyper-density concurrency with immutable identity at every layer. It 
 4. `CitadelGuard` — sentinel-pool RBAC enforcement gate with `preAllocate(String role)` / `seal()` / `requireRole(String role)`. Sealed at bootstrap READY transition.
 5. `StorageContextBridge` — derives a SHARED `StorageContext` from a `PrincipalContext` (SHARED-only derivation contract per ADR-010 §4a; full SEPARATED_SCHEMA/DEDICATED derivation comes from `SecurityProvider.authenticate()`).
 
-> **TCK gap:** `CitadelGuard` (RBAC sentinel-pool enforcement, `preAllocate` / `seal` / `requireRole`) has no abstract TCK suite in `exeris-kernel-tck`. Its correctness is covered only by unit and integration tests in `exeris-kernel-community`. A dedicated `AbstractCitadelGuardTck` is needed before any external provider implements a competing RBAC gate. Tracking: see `docs/ROADMAP.md`.
+> **TCK status:** `CitadelGuard` is now covered by the shared `AbstractCitadelGuardTck` contract plus Community/Core bindings.
 
-> **TCK gap:** `StorageContextBridge.derive()` (SHARED-derivation path) has no abstract TCK suite. The derivation contract is tested only via `AbstractSecurityInterceptorTck` integration path. A standalone `AbstractStorageContextBridgeTck` should be added. Tracking: see `docs/ROADMAP.md`.
+> **TCK status:** `StorageContextBridge.derive()` is now covered by a standalone `AbstractStorageContextBridgeTck`, including SHARED derivation and fail-closed handling for missing principal context.
 
 ---
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityHttpSubsystemLifecycleTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityHttpSubsystemLifecycleTckTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.spi.bootstrap.Subsystem;
+import eu.exeris.kernel.spi.config.ConfigProvider;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.tck.contract.bootstrap.AbstractSubsystemLifecycleTck;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Community binding: verifies {@link CommunityHttpSubsystem} satisfies
+ * {@link AbstractSubsystemLifecycleTck} contract in DISABLED mode.
+ *
+ * <p>{@code KernelProviders.CURRENT_CONFIG} is bound via {@link #withLifecycleContext(Runnable)}
+ * using a minimal stub that returns {@link Optional#empty()} for all keys.
+ * {@code http.mode} therefore falls back to {@code "DISABLED"} in
+ * {@code CommunityHttpSubsystem.resolveMode()}, avoiding any network or provider binding.
+ */
+@DisplayName("Community: CommunityHttpSubsystem lifecycle TCK")
+class CommunityHttpSubsystemLifecycleTckTest extends AbstractSubsystemLifecycleTck {
+
+    @Override
+    protected Subsystem createSubsystem() {
+        return new CommunityHttpSubsystem();
+    }
+
+    @Override
+    protected void withLifecycleContext(Runnable action) {
+        ScopedValue.where(KernelProviders.CURRENT_CONFIG, new DisabledConfigProvider())
+                .run(action);
+    }
+
+    private static final class DisabledConfigProvider implements ConfigProvider {
+
+        @Override
+        public Supplier<KernelSettings> kernelSettings() {
+            return KernelSettings::defaults;
+        }
+
+        @Override
+        public Optional<String> getString(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Integer> getInt(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Long> getLong(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Boolean> getBoolean(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> Optional<T> get(String key, Class<T> type) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void watch(String file, String key, Consumer<Object> callback) {
+            // no-op
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityHttpSubsystemLifecycleTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityHttpSubsystemLifecycleTckTest.java
@@ -44,8 +44,8 @@ class CommunityHttpSubsystemLifecycleTckTest extends AbstractSubsystemLifecycleT
     private static final class DisabledConfigProvider implements ConfigProvider {
 
         @Override
-        public Supplier<KernelSettings> kernelSettings() {
-            return KernelSettings::defaults;
+        public Supplier<ConfigProvider.KernelSettings> kernelSettings() {
+            return ConfigProvider.KernelSettings::defaults;
         }
 
         @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystemLifecycleTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystemLifecycleTckTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.spi.bootstrap.Subsystem;
+import eu.exeris.kernel.spi.config.ConfigProvider;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.tck.contract.bootstrap.AbstractSubsystemLifecycleTck;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Community binding: verifies {@link CommunityTransportSubsystem} satisfies
+ * {@link AbstractSubsystemLifecycleTck} contract in DISABLED mode.
+ *
+ * <p>{@code KernelProviders.CURRENT_CONFIG} is bound via {@link #withLifecycleContext(Runnable)}
+ * using a minimal stub that returns {@link Optional#empty()} for all keys.
+ * {@code transport.mode} and {@code network.transportMode} therefore both resolve to
+ * {@code null} in {@code CommunityTransportSubsystem.resolveMode()}, yielding
+ * {@code TransportMode.DISABLED} and avoiding any engine creation or network binding.
+ */
+@DisplayName("Community: CommunityTransportSubsystem lifecycle TCK")
+class CommunityTransportSubsystemLifecycleTckTest extends AbstractSubsystemLifecycleTck {
+
+    @Override
+    protected Subsystem createSubsystem() {
+        return new CommunityTransportSubsystem();
+    }
+
+    @Override
+    protected void withLifecycleContext(Runnable action) {
+        ScopedValue.where(KernelProviders.CURRENT_CONFIG, new DisabledConfigProvider())
+                .run(action);
+    }
+
+    private static final class DisabledConfigProvider implements ConfigProvider {
+
+        @Override
+        public Supplier<KernelSettings> kernelSettings() {
+            return KernelSettings::defaults;
+        }
+
+        @Override
+        public Optional<String> getString(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Integer> getInt(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Long> getLong(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Boolean> getBoolean(String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> Optional<T> get(String key, Class<T> type) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void watch(String file, String key, Consumer<Object> callback) {
+            // no-op
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystemLifecycleTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystemLifecycleTckTest.java
@@ -45,8 +45,8 @@ class CommunityTransportSubsystemLifecycleTckTest extends AbstractSubsystemLifec
     private static final class DisabledConfigProvider implements ConfigProvider {
 
         @Override
-        public Supplier<KernelSettings> kernelSettings() {
-            return KernelSettings::defaults;
+        public Supplier<ConfigProvider.KernelSettings> kernelSettings() {
+            return ConfigProvider.KernelSettings::defaults;
         }
 
         @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityCitadelGuardTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityCitadelGuardTckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.CitadelGuard;
+import eu.exeris.kernel.tck.contract.security.AbstractCitadelGuardTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Community: CitadelGuard TCK")
+class CommunityCitadelGuardTckTest extends AbstractCitadelGuardTck<CitadelGuard> {
+
+    @Override
+    protected CitadelGuard createGuard() {
+        return new CitadelGuard();
+    }
+
+    @Override
+    protected void preAllocate(CitadelGuard guard, String requiredRole) {
+        guard.preAllocate(requiredRole);
+    }
+
+    @Override
+    protected void seal(CitadelGuard guard) {
+        guard.seal();
+    }
+
+    @Override
+    protected boolean isSealed(CitadelGuard guard) {
+        return guard.isSealed();
+    }
+
+    @Override
+    protected void requireRole(CitadelGuard guard, String requiredRole) {
+        guard.requireRole(requiredRole);
+    }
+
+    @Override
+    protected boolean hasRole(CitadelGuard guard, String role) {
+        return guard.hasRole(role);
+    }
+
+    @Override
+    protected int preAllocatedCount(CitadelGuard guard) {
+        return guard.preAllocatedCount();
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityStorageContextBridgeTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityStorageContextBridgeTckTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.StorageContextBridge;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.StorageContext;
+import eu.exeris.kernel.tck.contract.security.AbstractStorageContextBridgeTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Community: StorageContextBridge TCK")
+class CommunityStorageContextBridgeTckTest extends AbstractStorageContextBridgeTck {
+
+    @Override
+    protected StorageContext derive(PrincipalContext principal) {
+        return StorageContextBridge.derive(principal);
+    }
+
+    @Override
+    protected StorageContext deriveFromActivePrincipal() {
+        return StorageContextBridge.deriveFromActivePrincipal();
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/StorageContextBridge.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/StorageContextBridge.java
@@ -10,6 +10,7 @@ package eu.exeris.kernel.core.security;
 
 import eu.exeris.kernel.core.security.jfr.SecurityJfrEvents;
 import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.exceptions.security.PrincipalContextMissingException;
 import eu.exeris.kernel.spi.security.ImmutableStorageContext;
 import eu.exeris.kernel.spi.security.PrincipalContext;
 import eu.exeris.kernel.spi.security.StorageContext;
@@ -96,6 +97,10 @@ public final class StorageContextBridge {
      * @return derived {@link StorageContext}; never {@code null}
      */
     public static StorageContext derive(PrincipalContext principal) {
+        if (principal == null) {
+            throw new PrincipalContextMissingException();
+        }
+
         StorageContext result = principal.tenantId()
                 .map(tenantId -> (StorageContext) ImmutableStorageContext.shared(
                         tenantId.getMostSignificantBits(),

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/jfr/PaqsHandlerFailureEvent.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/jfr/PaqsHandlerFailureEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.transport.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * JFR event emitted when a PAQS stream handler fails inside the VT boundary.
+ *
+ * @since 0.5.0
+ */
+@Name("eu.exeris.kernel.core.transport.PaqsHandlerFailure")
+@Label("PAQS Handler Failure")
+@Category({"Exeris Kernel", "Transport", "PAQS"})
+@Description("Emitted when a PAQS stream handler fails during stream lifecycle processing.")
+@StackTrace(false)
+public final class PaqsHandlerFailureEvent extends Event {
+
+    @Label("Stream ID")
+    public long streamId;
+
+    @Label("Engine Name")
+    public String engineName;
+
+    @Label("Exception Class")
+    public String exceptionClass;
+
+    @Label("Lifecycle Phase")
+    public String lifecyclePhase;
+
+    public static void emit(long streamId,
+                            String engineName,
+                            String exceptionClass,
+                            String lifecyclePhase) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        PaqsHandlerFailureEvent evt = new PaqsHandlerFailureEvent();
+        if (evt.isEnabled()) {
+            evt.streamId = streamId;
+            evt.engineName = engineName;
+            evt.exceptionClass = exceptionClass;
+            evt.lifecyclePhase = lifecyclePhase;
+            evt.commit();
+        }
+    }
+}

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/StorageContextBridgeTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/StorageContextBridgeTest.java
@@ -77,6 +77,13 @@ class StorageContextBridgeTest {
             StorageContext ctx = StorageContextBridge.derive(SYSTEM_PRINCIPAL);
             assertThat(ctx.isolationKey()).isEmpty();
         }
+
+        @Test
+        @DisplayName("null principal is rejected with PrincipalContextMissingException")
+        void nullPrincipalRejectedFailClosed() {
+            assertThatThrownBy(() -> StorageContextBridge.derive(null))
+                    .isInstanceOf(PrincipalContextMissingException.class);
+        }
     }
 
     // =========================================================================

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreCitadelGuardTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreCitadelGuardTckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security.tck;
+
+import eu.exeris.kernel.core.security.CitadelGuard;
+import eu.exeris.kernel.tck.contract.security.AbstractCitadelGuardTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Core: CitadelGuard TCK")
+class CoreCitadelGuardTckTest extends AbstractCitadelGuardTck<CitadelGuard> {
+
+    @Override
+    protected CitadelGuard createGuard() {
+        return new CitadelGuard();
+    }
+
+    @Override
+    protected void preAllocate(CitadelGuard guard, String requiredRole) {
+        guard.preAllocate(requiredRole);
+    }
+
+    @Override
+    protected void seal(CitadelGuard guard) {
+        guard.seal();
+    }
+
+    @Override
+    protected boolean isSealed(CitadelGuard guard) {
+        return guard.isSealed();
+    }
+
+    @Override
+    protected void requireRole(CitadelGuard guard, String requiredRole) {
+        guard.requireRole(requiredRole);
+    }
+
+    @Override
+    protected boolean hasRole(CitadelGuard guard, String role) {
+        return guard.hasRole(role);
+    }
+
+    @Override
+    protected int preAllocatedCount(CitadelGuard guard) {
+        return guard.preAllocatedCount();
+    }
+}

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreStorageContextBridgeTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreStorageContextBridgeTckTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security.tck;
+
+import eu.exeris.kernel.core.security.StorageContextBridge;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.StorageContext;
+import eu.exeris.kernel.tck.contract.security.AbstractStorageContextBridgeTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Core: StorageContextBridge TCK")
+class CoreStorageContextBridgeTckTest extends AbstractStorageContextBridgeTck {
+
+    @Override
+    protected StorageContext derive(PrincipalContext principal) {
+        return StorageContextBridge.derive(principal);
+    }
+
+    @Override
+    protected StorageContext deriveFromActivePrincipal() {
+        return StorageContextBridge.deriveFromActivePrincipal();
+    }
+}

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/tck/CorePaqsSchedulerTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/tck/CorePaqsSchedulerTckTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.transport.tck;
+
+import eu.exeris.kernel.spi.memory.AllocationHint;
+import eu.exeris.kernel.spi.memory.LeakDetectionMode;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryStats;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@DisplayName("Core: PAQS Scheduler TCK")
+class CorePaqsSchedulerTckTest extends AbstractPaqsSchedulerTck {
+
+    @Override
+    protected MemoryAllocator createDynamicAllocator(AtomicLong allocated, long totalBytes) {
+        return new MemoryAllocator() {
+            @Override
+            public MemoryStats stats() {
+                long current = allocated.get();
+                return new MemoryStats(totalBytes, current, totalBytes - current,
+                        0, 0, current, 0, 0, LeakDetectionMode.DISABLED);
+            }
+
+            @Override
+            public LoanedBuffer allocate(AllocationHint hint) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LoanedBuffer allocateNetwork(int bytes) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LoanedBuffer allocateCarrierSlab(int sizeClass) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LoanedBuffer allocateInfrastructure(long size) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void close() {
+                // test stub
+            }
+        };
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/bootstrap/AbstractSubsystemLifecycleTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/bootstrap/AbstractSubsystemLifecycleTck.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.bootstrap;
+
+import eu.exeris.kernel.spi.bootstrap.Subsystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * TCK: Abstract base for {@link Subsystem} per-instance lifecycle state machine verification.
+ *
+ * <h2>Gap Closed</h2>
+ * <p>{@link AbstractSubsystemProviderTck} verifies provider-level concerns.
+ * This class closes the spec-drift gap by verifying each subsystem's own
+ * {@code initialize → start → stop} state machine contract.
+ *
+ * <h2>Verified Constraints</h2>
+ * <ol>
+ *   <li>{@code name()} returns non-null, non-blank identifier.</li>
+ *   <li>{@code phase()} returns non-null {@link eu.exeris.kernel.spi.bootstrap.BootstrapPhase}.</li>
+ *   <li>{@code dependsOn()} returns non-null list with no null or blank entries.</li>
+ *   <li>{@code initialize()} does not throw for a valid, isolated instance.</li>
+ *   <li>{@code start()} after {@code initialize()} does not throw.</li>
+ *   <li>{@code stop()} after {@code start()} does not throw.</li>
+ *   <li>{@code stop()} after {@code stop()} is idempotent — does not throw.</li>
+ *   <li>{@code isRunning()} returns {@code false} after {@code stop()}.</li>
+ * </ol>
+ *
+ * <h2>Context Hook</h2>
+ * <p>Subsystems whose lifecycle methods require a bound execution context
+ * (e.g., a {@code ScopedValue} slot such as {@code KernelProviders.CURRENT_CONFIG}) must
+ * override {@link #withLifecycleContext(Runnable)} to wrap the action in that scope.
+ * The default implementation runs the action directly with no additional context.
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * class MySubsystemLifecycleTckTest extends AbstractSubsystemLifecycleTck {
+ *     \@Override protected Subsystem createSubsystem() {
+ *         return new MySubsystem();
+ *     }
+ * }
+ * }</pre>
+ *
+ * @since 0.5.0
+ */
+public abstract class AbstractSubsystemLifecycleTck {
+
+    // =========================================================================
+    // Template methods
+    // =========================================================================
+
+    /** Creates a {@link Subsystem} instance ready for {@code initialize()} — not yet initialized. */
+    protected abstract Subsystem createSubsystem();
+
+    /**
+     * Wraps a lifecycle action in any required execution context.
+     *
+     * <p>Override in binding tests to bind {@code ScopedValue} slots or other required
+     * context before calling lifecycle methods on the subsystem under test.
+     * The default implementation runs the action directly with no additional scope.
+     *
+     * <p>Implementations must propagate all unchecked exceptions thrown by {@code action}.
+     */
+    protected void withLifecycleContext(Runnable action) {
+        action.run();
+    }
+
+    private Subsystem subsystem;
+
+    @BeforeEach
+    final void setUpSubsystem() {
+        subsystem = createSubsystem();
+    }
+
+    // =========================================================================
+    // Identity contract — name, phase, dependsOn
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Identity contract — name, phase, dependsOn")
+    class IdentityContract {
+
+        @Test
+        @DisplayName("name() returns non-null non-blank string")
+        void nameIsNonBlank() {
+            assertThat(subsystem.name())
+                    .as("Subsystem.name() MUST be non-null and non-blank")
+                    .isNotBlank();
+        }
+
+        @Test
+        @DisplayName("phase() returns non-null BootstrapPhase")
+        void phaseIsNonNull() {
+            assertThat(subsystem.phase())
+                    .as("Subsystem.phase() MUST return a non-null BootstrapPhase")
+                    .isNotNull();
+        }
+
+        @Test
+        @DisplayName("dependsOn() returns non-null list")
+        void dependsOnIsNonNull() {
+            assertThat(subsystem.dependsOn())
+                    .as("Subsystem.dependsOn() MUST return a non-null list")
+                    .isNotNull();
+        }
+
+        @Test
+        @DisplayName("dependsOn() list contains no null entries")
+        void dependsOnContainsNoNulls() {
+            assertThat(subsystem.dependsOn())
+                    .as("Subsystem.dependsOn() MUST NOT contain null entries")
+                    .doesNotContainNull();
+        }
+
+        @Test
+        @DisplayName("dependsOn() list contains no blank string entries")
+        void dependsOnContainsNoBlanks() {
+            subsystem.dependsOn().forEach(dep ->
+                    assertThat(dep)
+                            .as("Subsystem.dependsOn() MUST NOT contain blank dependency names")
+                            .isNotBlank());
+        }
+    }
+
+    // =========================================================================
+    // Lifecycle state machine
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Lifecycle state transitions")
+    class LifecycleStateTransitions {
+
+        @Test
+        @DisplayName("initialize() does not throw")
+        void initializeDoesNotThrow() {
+            assertThatCode(() -> withLifecycleContext(subsystem::initialize))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("start() after initialize() does not throw")
+        void startAfterInitializeDoesNotThrow() {
+            withLifecycleContext(subsystem::initialize);
+            assertThatCode(() -> withLifecycleContext(subsystem::start))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("stop() after start() does not throw")
+        void stopAfterStartDoesNotThrow() {
+            withLifecycleContext(subsystem::initialize);
+            withLifecycleContext(subsystem::start);
+            assertThatCode(() -> withLifecycleContext(subsystem::stop))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("stop() after stop() is idempotent — does not throw")
+        void doubleStopIsIdempotent() {
+            withLifecycleContext(subsystem::initialize);
+            withLifecycleContext(subsystem::start);
+            withLifecycleContext(subsystem::stop);
+            assertThatCode(() -> withLifecycleContext(subsystem::stop))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("isRunning() returns false after stop()")
+        void isRunningFalseAfterStop() {
+            withLifecycleContext(subsystem::initialize);
+            withLifecycleContext(subsystem::start);
+            withLifecycleContext(subsystem::stop);
+            assertThat(subsystem.isRunning())
+                    .as("Subsystem.isRunning() MUST return false after stop()")
+                    .isFalse();
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractCitadelGuardTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractCitadelGuardTck.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * TCK: Abstract base for Citadel-style RBAC gate verification.
@@ -187,7 +188,7 @@ public abstract class AbstractCitadelGuardTck<G> {
     private InsufficientPrivilegesException catchRejection(ScopedValue.Carrier carrier, String requiredRole) {
         try {
             carrier.run(() -> requireRole(guard, requiredRole));
-            return null;
+            return fail("Expected requireRole() to reject missing role: " + requiredRole);
         } catch (InsufficientPrivilegesException ex) {
             return ex;
         }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractCitadelGuardTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractCitadelGuardTck.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.security;
+
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.exceptions.KernelErrorCodes;
+import eu.exeris.kernel.spi.exceptions.security.InsufficientPrivilegesException;
+import eu.exeris.kernel.spi.exceptions.security.PrincipalContextMissingException;
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.tck.contract.JfrAllocationMonitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: Abstract base for Citadel-style RBAC gate verification.
+ *
+ * @param <G> concrete guard type under test
+ */
+public abstract class AbstractCitadelGuardTck<G> {
+
+    protected abstract G createGuard();
+
+    protected abstract void preAllocate(G guard, String requiredRole);
+
+    protected abstract void seal(G guard);
+
+    protected abstract boolean isSealed(G guard);
+
+    protected abstract void requireRole(G guard, String requiredRole);
+
+    protected abstract boolean hasRole(G guard, String role);
+
+    protected abstract int preAllocatedCount(G guard);
+
+    protected PrincipalContext createAdminPrincipal() {
+        return ImmutablePrincipal.ofTenant(
+                UUID.randomUUID(), UUID.randomUUID(), Set.of("ROLE_ADMIN", "ROLE_USER"));
+    }
+
+    protected PrincipalContext createUserPrincipal() {
+        return ImmutablePrincipal.ofTenant(
+                UUID.randomUUID(), UUID.randomUUID(), Set.of("ROLE_USER"));
+    }
+
+    private G guard;
+
+    @BeforeEach
+    final void setUpGuard() {
+        guard = createGuard();
+    }
+
+    @Nested
+    @DisplayName("preAllocate() and seal() contract")
+    class BootstrapContract {
+
+        @Test
+        @DisplayName("first preAllocate() call increments the sentinel pool size")
+        void preAllocateIncrementsCount() {
+            preAllocate(guard, "ROLE_ADMIN");
+            assertThat(preAllocatedCount(guard)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("preAllocate() is idempotent for the same role")
+        void preAllocateIsIdempotent() {
+            preAllocate(guard, "ROLE_ADMIN");
+            preAllocate(guard, "ROLE_ADMIN");
+            assertThat(preAllocatedCount(guard)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("seal() prevents further sentinel registrations")
+        void sealPreventsFurtherRegistration() {
+            preAllocate(guard, "ROLE_ADMIN");
+            seal(guard);
+
+            assertThat(isSealed(guard)).isTrue();
+            assertThatThrownBy(() -> preAllocate(guard, "ROLE_AUDITOR"))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("requireRole() contract")
+    class RequireRoleContract {
+
+        @Test
+        @DisplayName("principal with the required role is allowed through")
+        void allowsPrincipalWithRequiredRole() {
+            ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, createAdminPrincipal())
+                    .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL)
+                    .run(() -> assertThatCode(() -> requireRole(guard, "ROLE_ADMIN"))
+                            .doesNotThrowAnyException());
+        }
+
+        @Test
+        @DisplayName("hasRole() mirrors the bound principal roles")
+        void hasRoleReflectsPrincipal() {
+            boolean[] result = new boolean[2];
+            ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, createAdminPrincipal())
+                    .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL)
+                    .run(() -> {
+                        result[0] = hasRole(guard, "ROLE_ADMIN");
+                        result[1] = hasRole(guard, "ROLE_BILLING");
+                    });
+
+            assertThat(result[0]).isTrue();
+            assertThat(result[1]).isFalse();
+        }
+
+        @Test
+        @DisplayName("missing role is rejected with EX-SEC-2003")
+        void rejectsMissingRoleWithCanonicalErrorCode() {
+            ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, createUserPrincipal())
+                    .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL)
+                    .run(() -> assertThatThrownBy(() -> requireRole(guard, "ROLE_ADMIN"))
+                            .isInstanceOf(InsufficientPrivilegesException.class)
+                            .satisfies(ex -> assertThat(((InsufficientPrivilegesException) ex).errorCode())
+                                    .isEqualTo(KernelErrorCodes.EX_SEC_2003)));
+        }
+
+        @Test
+        @DisplayName("pre-allocated role rejection reuses the same sentinel instance")
+        void reusesSentinelForPreAllocatedRole() {
+            preAllocate(guard, "ROLE_ADMIN");
+            seal(guard);
+
+            ScopedValue.Carrier carrier = ScopedValue
+                    .where(KernelProviders.PRINCIPAL_CONTEXT, createUserPrincipal())
+                    .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL);
+
+            InsufficientPrivilegesException first = catchRejection(carrier, "ROLE_ADMIN");
+            InsufficientPrivilegesException second = catchRejection(carrier, "ROLE_ADMIN");
+
+            assertThat(first).isSameAs(second);
+        }
+
+        @Test
+        @DisplayName("calling requireRole() outside a security scope is fail-closed")
+        void requiresBoundPrincipalContext() {
+            assertThatThrownBy(() -> requireRole(guard, "ROLE_ADMIN"))
+                    .isInstanceOf(PrincipalContextMissingException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("JFR allocation contract")
+    class AllocationContract {
+
+        @Test
+        @DisplayName("steady-state allow path performs zero eu.exeris allocations")
+        void allowPathIsAllocationFree() throws IOException {
+            PrincipalContext principal = createAdminPrincipal();
+            JfrAllocationMonitor.Result result = JfrAllocationMonitor.measure(
+                    JfrAllocationMonitor.Config.ofDefaults("Security", getClass().getSimpleName()),
+                    iterations -> ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, principal)
+                            .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL)
+                            .run(() -> {
+                                for (int i = 0; i < iterations; i++) {
+                                    requireRole(guard, "ROLE_ADMIN");
+                                }
+                            }));
+
+            JfrAllocationMonitor.assertZeroExerisAllocations(result,
+                    "CitadelGuard allow path must not allocate eu.exeris.* objects");
+        }
+    }
+
+    private InsufficientPrivilegesException catchRejection(ScopedValue.Carrier carrier, String requiredRole) {
+        try {
+            carrier.run(() -> requireRole(guard, requiredRole));
+            return null;
+        } catch (InsufficientPrivilegesException ex) {
+            return ex;
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractStorageContextBridgeTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractStorageContextBridgeTck.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.security;
+
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.exceptions.KernelErrorCodes;
+import eu.exeris.kernel.spi.exceptions.security.PrincipalContextMissingException;
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.StorageContext;
+import eu.exeris.kernel.spi.security.StorageContext.IsolationStrategy;
+import eu.exeris.kernel.tck.contract.JfrAllocationMonitor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: Abstract base for StorageContext bridge derivation verification.
+ */
+public abstract class AbstractStorageContextBridgeTck {
+
+    protected abstract StorageContext derive(PrincipalContext principal);
+
+    protected abstract StorageContext deriveFromActivePrincipal();
+
+    protected UUID tenantId() {
+        return UUID.fromString("00000000-0000-0000-0000-000000000042");
+    }
+
+    protected PrincipalContext createTenantPrincipal() {
+        return ImmutablePrincipal.ofTenant(
+                UUID.fromString("00000000-0000-0000-0000-000000000041"),
+                tenantId(),
+                Set.of("ROLE_USER"));
+    }
+
+    protected PrincipalContext createSystemPrincipal() {
+        return ImmutablePrincipal.system(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                Set.of("ROLE_SYSTEM"));
+    }
+
+    @Nested
+    @DisplayName("derive(PrincipalContext) contract")
+    class DirectDerivation {
+
+        @Test
+        @DisplayName("tenant principal derives SHARED context with tenant isolation key")
+        void tenantPrincipalDerivesSharedContext() {
+            StorageContext ctx = derive(createTenantPrincipal());
+
+            assertThat(ctx.strategy()).isEqualTo(IsolationStrategy.SHARED);
+            assertThat(ctx.isolationKey()).isPresent().contains(tenantId().toString());
+            assertThat(ctx.schemaName()).isEmpty();
+            assertThat(ctx.dataSourceKey()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("system principal maps to the GLOBAL singleton")
+        void systemPrincipalMapsToGlobalSingleton() {
+            StorageContext first = derive(createSystemPrincipal());
+            StorageContext second = derive(createSystemPrincipal());
+
+            assertThat(first).isSameAs(ImmutableStorageContext.GLOBAL);
+            assertThat(second).isSameAs(first);
+            assertThat(first.isolationKey()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null principal is rejected with EX-SEC-2001")
+        void nullPrincipalIsRejectedFailClosed() {
+            assertThatThrownBy(() -> derive(null))
+                    .isInstanceOf(PrincipalContextMissingException.class)
+                    .satisfies(ex -> assertThat(((PrincipalContextMissingException) ex).errorCode())
+                            .isEqualTo(KernelErrorCodes.EX_SEC_2001));
+        }
+    }
+
+    @Nested
+    @DisplayName("deriveFromActivePrincipal() scope contract")
+    class ScopedDerivation {
+
+        @Test
+        @DisplayName("bound tenant principal is derived from ScopedValue context")
+        void derivesFromBoundScope() {
+            AtomicReference<StorageContext> result = new AtomicReference<>();
+
+            ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, createTenantPrincipal())
+                    .where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.GLOBAL)
+                    .run(() -> result.set(deriveFromActivePrincipal()));
+
+            assertThat(result.get().strategy()).isEqualTo(IsolationStrategy.SHARED);
+            assertThat(result.get().isolationKey()).contains(tenantId().toString());
+        }
+
+        @Test
+        @DisplayName("missing ScopedValue binding throws EX-SEC-2001")
+        void missingScopeThrowsCanonicalException() {
+            assertThatThrownBy(AbstractStorageContextBridgeTck.this::deriveFromActivePrincipal)
+                    .isInstanceOf(PrincipalContextMissingException.class)
+                    .satisfies(ex -> assertThat(((PrincipalContextMissingException) ex).errorCode())
+                            .isEqualTo(KernelErrorCodes.EX_SEC_2001));
+        }
+    }
+
+    @Nested
+    @DisplayName("JFR allocation contract")
+    class AllocationContract {
+
+        @Test
+        @DisplayName("GLOBAL derivation path remains bounded under JFR-assisted telemetry")
+        void globalDerivationIsAllocationDisciplined() throws IOException {
+            PrincipalContext principal = createSystemPrincipal();
+            JfrAllocationMonitor.Config config =
+                    JfrAllocationMonitor.Config.ofDefaults("Security", getClass().getSimpleName());
+            JfrAllocationMonitor.Result result = JfrAllocationMonitor.measure(config,
+                    iterations -> {
+                        for (int i = 0; i < iterations; i++) {
+                            StorageContext ctx = derive(principal);
+                            if (ctx.strategy() == null) {
+                                throw new AssertionError("unreachable");
+                            }
+                        }
+                    });
+
+            JfrAllocationMonitor.assertBoundedExerisAllocations(
+                    result,
+                    config.hotPathIterations(),
+                    1,
+                    "StorageContextBridge GLOBAL path must stay allocation-disciplined under telemetry");
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to subsystem test coverage and updates to documentation, particularly around transport, flow, and security subsystems. The main highlights are the addition of new TCK (Technology Compatibility Kit) tests for Community implementations, updates to subsystem documentation to reflect current and planned migration paths, and clarifications to flow and security operational contracts.

**Test Coverage Additions**

* Added TCK tests for Community subsystem lifecycle in DISABLED mode, ensuring `CommunityHttpSubsystem` and `CommunityTransportSubsystem` correctly implement the expected lifecycle contract without network or engine binding. (`exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityHttpSubsystemLifecycleTckTest.java`, `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystemLifecycleTckTest.java`) [[1]](diffhunk://#diff-e43704d5744f392610eadc1306c9653fd4e77c660cd9c8f1e06d5bb381063da7R1-R81) [[2]](diffhunk://#diff-92359065a857ff6ceb5f1c4255ce36d3b6d1444e65ea2a5593dcec292968ea59R1-R82)
* Introduced TCKs for flow and security subsystems in Community:
  - `CommunityFlowChoreographyTckTest` now runs with the implemented `CommunityEventProvider` (removes previous `@Disabled`). [[1]](diffhunk://#diff-3e14bd2cf549267ee99f6dfc65cf07d5934ce10c698a5639326a0c0633e4aae6R11-L18) [[2]](diffhunk://#diff-3e14bd2cf549267ee99f6dfc65cf07d5934ce10c698a5639326a0c0633e4aae6L30-R30)
  - Added tests for flow idempotency guard and zero-allocation contracts (`CommunityFlowIdempotencyGuardTckTest`, `CommunityFlowZeroAllocTckTest`). [[1]](diffhunk://#diff-07430485220c37385f51440e19a464b9a2f7bcc5c1c126838904e4f7bef8dcbeR1-R45) [[2]](diffhunk://#diff-1096cc3c843e2d459b254179fed32e053f3251edd3ea0fe094c63424de6b8fedR1-R36)
  - Added TCKs for `CitadelGuard` and `StorageContextBridge` in security (`CommunityCitadelGuardTckTest`, `CommunityStorageContextBridgeTckTest`). [[1]](diffhunk://#diff-a8f17d97ac7edb007764e769768c636d1efeaaaec219a9d4e1d4ded38d3ed587R1-R52) [[2]](diffhunk://#diff-36e5640e73927738c52890485297440c176b8d9ea9bb5cac78f959110d954725R1-R29)

**Documentation Updates**

* Transport subsystem documentation and roadmap updated to clarify the planned migration of the Community carrier from Java NIO to Core FFM (Foreign Function & Memory API) syscalls, with NIO retained as a fallback. Merge gates and validation requirements for this migration are specified. (`docs/ROADMAP.md`, `docs/subsystems/transport.md`) [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2R153-R166) [[2]](diffhunk://#diff-daa82c59bde91fc54615717da52c30e2e81b64410ef111e66b2173d51a77f9adL81-R81)
* Flow subsystem documentation improved:
  - Clarifies the emission and semantics of `FlowEngineShutdownEvent` and its JFR payload. [[1]](diffhunk://#diff-f2ea836aa75ce8d07d3bfdcb8648d8187d537e2de7d08b1155dafea21a05c800L24-R24) [[2]](diffhunk://#diff-f2ea836aa75ce8d07d3bfdcb8648d8187d537e2de7d08b1155dafea21a05c800R86)
  - Expands on idempotency fence and operational stance for terminal state catalog retention, and details choreography wake behavior with/without persistence.
* Security documentation updated to reflect that `CitadelGuard` and `StorageContextBridge.derive()` are now covered by abstract TCK contracts, closing previous testing gaps. (`docs/subsystems/security.md`)

These changes collectively strengthen subsystem reliability and clarify both current and future directions for transport, flow, and security within the Community and Core modules.