### PR TITLE
Refactor NativeTcpCarrier and NativeTcpStream for improved request handling

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,11 +104,11 @@ See also: [Flow Subsystem](./subsystems/flow.md) — JFR Events.
 
 ---
 
-### Security: `CitadelGuard` Lacks Abstract TCK Suite
+### Security: `CitadelGuard` Abstract TCK Suite Added
 
-`CitadelGuard` (Core: `eu.exeris.kernel.core.security.CitadelGuard`) implements sentinel-pool RBAC enforcement (`preAllocate(String role)` / `seal()` / `requireRole(String role)`). There is no abstract `AbstractCitadelGuardTck` in `exeris-kernel-tck`.
+`CitadelGuard` (Core: `eu.exeris.kernel.core.security.CitadelGuard`) now has a shared `AbstractCitadelGuardTck` in `exeris-kernel-tck` plus Community and Core bindings.
 
-**Gap:** Alternative RBAC gate implementations cannot prove contract compliance through a shared TCK harness. Coverage relies on Core unit tests.
+**Status:** Contract closure is in place for v0.6; alternative RBAC gate implementations can now prove compliance through the shared harness.
 
 **Owner:** Core / Security subsystem.
 
@@ -120,11 +120,11 @@ See also: [Security Subsystem](./subsystems/security.md) — Responsibilities.
 
 ---
 
-### Security: `StorageContextBridge` Lacks Abstract TCK Suite
+### Security: `StorageContextBridge` Abstract TCK Suite Added
 
-`StorageContextBridge.derive(PrincipalContext)` (Core: `eu.exeris.kernel.core.security.StorageContextBridge`) derives a SHARED-isolation `StorageContext` from a verified `PrincipalContext`. The derivation contract is tested only transitively via `AbstractSecurityInterceptorTck`.
+`StorageContextBridge.derive(PrincipalContext)` (Core: `eu.exeris.kernel.core.security.StorageContextBridge`) now has a standalone `AbstractStorageContextBridgeTck` in `exeris-kernel-tck`, with Community and Core bindings.
 
-**Gap:** No standalone `AbstractStorageContextBridgeTck` to verify SHARED derivation produces correct `tenantId`; SEPARATED_SCHEMA/DEDICATED strategies are rejected (delegated to `SecurityProvider`); null principal throws `EX-SEC-2001`.
+**Status:** SHARED derivation and fail-closed null-principal handling are now covered directly for v0.6.
 
 **Owner:** Core / Security subsystem.
 
@@ -254,6 +254,18 @@ See also: [Security Subsystem](./subsystems/security.md) — `@RequiresRole` Pro
 **Merge Gate:** Validate async path with both `AbstractTelemetryRingBufferTck` (dispatch/ring contract) and `TelemetryZeroAllocTck` (caller-path allocation discipline). Keep synchronous path as supported baseline until async gate passes.
 
 See also: [Telemetry Subsystem](./subsystems/telemetry.md) — Design Principles.
+
+---
+
+### Runtime: Hot-Path Collections Review
+
+**Gap:** Some Community runtime hot paths may justify a targeted collections review, but replacement structures must preserve current contracts and lookup semantics.
+
+**Owner:** Core / Flow / Transport subsystem.
+
+**Resolution:** Evaluate specialized runtime collections only where profiling shows real contention. Identity-based maps such as JCTools `NonBlockingIdentityHashMap` are not a fit for Flow registries/catalogs because those paths use value-semantic keys for restart, wake, and idempotency lookups; queue-oriented JCTools structures may still be assessed for bounded internal handoff paths as an implementation detail only.
+
+**Merge Gate:** Any adoption must remain Community-internal, keep SPI/Core contracts unchanged, and show measurable benefit under representative profiling.
 
 ---
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+        </dependency>
         <!-- TCK abstract test classes -->
         <dependency>
             <groupId>eu.exeris</groupId>

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -716,12 +716,21 @@ public final class NativeTcpCarrier implements TransportEngine {
         }
     }
 
+    private enum ReactorRequestType {
+        REGISTER,
+        ENABLE_WRITE,
+        CANCEL
+    }
+
+    private record ReactorRequest(ReactorRequestType type, SocketChannel channel) {
+    }
+
     private final class ReactorLoop {
 
         private final int index;
         private final Selector selector;
-        private final Queue<SocketChannel> pendingRegistrations = new ConcurrentLinkedQueue<>();
-        private final Queue<SocketChannel> pendingWriteInterests = new ConcurrentLinkedQueue<>();
+        private final Queue<ReactorRequest> pendingRequests = new ConcurrentLinkedQueue<>();
+        private final AtomicBoolean wakeupPending = new AtomicBoolean(false);
 
         private volatile Thread thread;
 
@@ -737,31 +746,34 @@ public final class NativeTcpCarrier implements TransportEngine {
         }
 
         private void enqueueRegistration(SocketChannel channel) {
-            boolean offered = pendingRegistrations.offer(channel);
-            if (!offered) {
-                throw new IllegalStateException("Failed to enqueue registration for channel: " + channel);
-            }
-            selector.wakeup();
+            enqueueRequest(new ReactorRequest(ReactorRequestType.REGISTER, channel));
         }
 
         private void enqueueWriteInterest(SocketChannel channel) {
-            boolean offered = pendingWriteInterests.offer(channel);
-            if (!offered) {
-                throw new IllegalStateException("Failed to enqueue write interest for channel: " + channel);
-            }
-            selector.wakeup();
+            enqueueRequest(new ReactorRequest(ReactorRequestType.ENABLE_WRITE, channel));
         }
 
         private void cancelKey(SocketChannel channel) {
-            SelectionKey key = channel.keyFor(selector);
-            if (key != null) {
-                key.cancel();
-            }
-            selector.wakeup();
+            enqueueRequest(new ReactorRequest(ReactorRequestType.CANCEL, channel));
         }
 
         private void wakeup() {
-            selector.wakeup();
+            signalSelector();
+        }
+
+        private void enqueueRequest(ReactorRequest request) {
+            boolean offered = pendingRequests.offer(request);
+            if (!offered) {
+                throw new IllegalStateException("Failed to enqueue reactor request " + request.type()
+                        + " for channel: " + request.channel());
+            }
+            signalSelector();
+        }
+
+        private void signalSelector() {
+            if (wakeupPending.compareAndSet(false, true)) {
+                selector.wakeup();
+            }
         }
 
         private void join(long timeoutMs) {
@@ -783,10 +795,18 @@ public final class NativeTcpCarrier implements TransportEngine {
         private void runLoop() {
             while (running.get()) {
                 try {
-                    drainRegistrations();
-                    drainWriteInterests();
+                    boolean drainedRequests = drainPendingRequests();
+                    if (!running.get()) {
+                        return;
+                    }
 
-                    selector.select(100L);
+                    if (drainedRequests) {
+                        selector.selectNow();
+                    } else {
+                        selector.select(100L);
+                    }
+
+                    drainPendingRequests();
                     Iterator<SelectionKey> iterator = selector.selectedKeys().iterator();
                     while (iterator.hasNext()) {
                         SelectionKey key = iterator.next();
@@ -802,7 +822,7 @@ public final class NativeTcpCarrier implements TransportEngine {
                             if (key.isWritable()) {
                                 flushStream((SocketChannel) key.channel(), key);
                             }
-                        } catch (CancelledKeyException ignored) {
+                        } catch (CancelledKeyException _) {
                             // channel closed concurrently by VT handler path
                         } catch (RuntimeException _) {
                             closeKeyStream(key);
@@ -817,35 +837,60 @@ public final class NativeTcpCarrier implements TransportEngine {
             }
         }
 
-        private void drainRegistrations() {
-            SocketChannel channel = pendingRegistrations.poll();
-            while (channel != null) {
-                try {
-                    if (channel.isOpen()) {
-                        channel.register(selector, SelectionKey.OP_READ);
-                    }
-                } catch (IOException e) {
-                    NativeTcpStream stream = streamByChannel.get(channel);
-                    if (stream != null) {
-                        stream.close();
-                    }
-                }
-                channel = pendingRegistrations.poll();
+        private boolean drainPendingRequests() {
+            boolean drainedAny = false;
+            ReactorRequest request = pendingRequests.poll();
+            while (request != null) {
+                drainedAny = true;
+                processPendingRequest(request);
+                request = pendingRequests.poll();
+            }
+
+            wakeupPending.set(false);
+            if (!pendingRequests.isEmpty()) {
+                signalSelector();
+                return true;
+            }
+            return drainedAny;
+        }
+
+        private void processPendingRequest(ReactorRequest request) {
+            SocketChannel channel = request.channel();
+            switch (request.type()) {
+                case REGISTER -> registerChannel(channel);
+                case ENABLE_WRITE -> enableWriteInterest(channel);
+                case CANCEL -> cancelSelection(channel);
             }
         }
 
-        private void drainWriteInterests() {
-            SocketChannel channel = pendingWriteInterests.poll();
-            while (channel != null) {
-                SelectionKey key = channel.keyFor(selector);
-                if (key != null && key.isValid()) {
-                    try {
-                        key.interestOps(key.interestOps() | SelectionKey.OP_WRITE | SelectionKey.OP_READ);
-                    } catch (RuntimeException ignored) {
-                        // key may be cancelled concurrently
-                    }
+        private void registerChannel(SocketChannel channel) {
+            try {
+                if (channel.isOpen()) {
+                    channel.register(selector, SelectionKey.OP_READ);
                 }
-                channel = pendingWriteInterests.poll();
+            } catch (IOException e) {
+                NativeTcpStream stream = streamByChannel.get(channel);
+                if (stream != null) {
+                    stream.close();
+                }
+            }
+        }
+
+        private void enableWriteInterest(SocketChannel channel) {
+            SelectionKey key = channel.keyFor(selector);
+            if (key != null && key.isValid()) {
+                try {
+                    key.interestOps(key.interestOps() | SelectionKey.OP_WRITE | SelectionKey.OP_READ);
+                } catch (RuntimeException _) {
+                    // key may be cancelled concurrently during shutdown
+                }
+            }
+        }
+
+        private void cancelSelection(SocketChannel channel) {
+            SelectionKey key = channel.keyFor(selector);
+            if (key != null) {
+                key.cancel();
             }
         }
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -19,6 +19,9 @@ import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.transport.TransportConnection;
 import eu.exeris.kernel.spi.transport.TransportStream;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.SpscArrayQueue;
+import org.jctools.queues.SpscUnboundedArrayQueue;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -26,10 +29,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
@@ -65,6 +67,7 @@ final class NativeTcpStream implements TransportStream {
     private static final int QUEUE_DEPTH_THRESHOLD_LOW = 100;
     private static final int QUEUE_DEPTH_THRESHOLD_MID = 500;
     private static final int QUEUE_DEPTH_THRESHOLD_HIGH = 1000;
+    private static final int JCTOOLS_QUEUE_CHUNK_SIZE = 128;
     private static final int INBOUND_QUEUE_CAPACITY =
             QUEUE_BACKPRESSURE_ENABLED ? QUEUE_DEPTH_THRESHOLD_HIGH : Integer.MAX_VALUE;
 
@@ -79,8 +82,12 @@ final class NativeTcpStream implements TransportStream {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean remoteClosed = new AtomicBoolean(false);
-    private final Queue<PendingWrite> outboundQueue = new LinkedBlockingQueue<>();
-    private final BlockingQueue<LoanedBuffer> inboundQueue = new LinkedBlockingQueue<>(INBOUND_QUEUE_CAPACITY);
+    private final Queue<PendingWrite> outboundQueue = new MpscUnboundedArrayQueue<>(JCTOOLS_QUEUE_CHUNK_SIZE);
+    private final Queue<LoanedBuffer> inboundQueue = QUEUE_BACKPRESSURE_ENABLED
+            ? new SpscArrayQueue<>(INBOUND_QUEUE_CAPACITY)
+            : new SpscUnboundedArrayQueue<>(JCTOOLS_QUEUE_CHUNK_SIZE);
+    private final AtomicInteger outboundQueueDepth = new AtomicInteger(0);
+    private final AtomicInteger inboundQueueDepth = new AtomicInteger(0);
     private final AtomicBoolean tlsBound = new AtomicBoolean(false);
     private final AtomicBoolean tlsReady = new AtomicBoolean(false);
     private final Object tlsLock = new Object();
@@ -138,7 +145,7 @@ final class NativeTcpStream implements TransportStream {
             throw new IllegalStateException(STREAM_CLOSED_MESSAGE);
         }
         // Short-circuit: if peer already closed and no buffered data remain, skip TLS readiness
-        if (remoteClosed.get() && currentInbound == null && inboundQueue.isEmpty()) {
+        if (remoteClosed.get() && currentInbound == null && inboundQueueDepth.get() == 0) {
             return -1;
         }
         ensureTlsReady(true);
@@ -162,6 +169,7 @@ final class NativeTcpStream implements TransportStream {
                     awaitReadableIngress();
                     continue;
                 }
+                decrementDepth(inboundQueueDepth);
                 currentInbound = next;
                 currentInboundOffset = 0;
             }
@@ -249,6 +257,7 @@ final class NativeTcpStream implements TransportStream {
             buffer.close();
             throw new IllegalStateException("Failed to enqueue outbound write for stream " + streamId);
         }
+        outboundQueueDepth.incrementAndGet();
         writeInterestCallback.run();
     }
 
@@ -274,7 +283,7 @@ final class NativeTcpStream implements TransportStream {
 
     @Override
     public boolean hasPendingData() {
-        return !outboundQueue.isEmpty();
+        return outboundQueueDepth.get() > 0;
     }
 
     @Override
@@ -345,11 +354,8 @@ final class NativeTcpStream implements TransportStream {
             ingressBuffer.close();
             return;
         }
-        
-        // Phase 1B: Queue depth monitoring and optional backpressure
-        int currentQueueDepth = inboundQueue.size();
-        
-        // Emit JFR events at thresholds for monitoring
+
+        int currentQueueDepth = inboundQueueDepth.get();
         String trend = currentQueueDepth >= lastQueueDepth ? "up" : "down";
         if (currentQueueDepth >= QUEUE_DEPTH_THRESHOLD_HIGH) {
             TransportIngressQueueDepthEvent.emit(streamId, currentQueueDepth, QUEUE_DEPTH_THRESHOLD_HIGH, trend);
@@ -358,17 +364,22 @@ final class NativeTcpStream implements TransportStream {
         } else if (currentQueueDepth >= QUEUE_DEPTH_THRESHOLD_LOW) {
             TransportIngressQueueDepthEvent.emit(streamId, currentQueueDepth, QUEUE_DEPTH_THRESHOLD_LOW, trend);
         }
-        lastQueueDepth = currentQueueDepth;
-        
+
+        if (QUEUE_BACKPRESSURE_ENABLED && currentQueueDepth >= INBOUND_QUEUE_CAPACITY) {
+            ingressBuffer.close();
+            TransportQueueBackpressureAlertEvent.emit(1, currentQueueDepth, trend);
+            throw new IllegalStateException("Rejected inbound buffer due to backpressure for stream " + streamId);
+        }
+
         boolean offered = inboundQueue.offer(ingressBuffer);
         if (!offered) {
             ingressBuffer.close();
-            // Phase 1B: Backpressure circuit breaker (off-by-default via QUEUE_BACKPRESSURE_ENABLED)
             if (QUEUE_BACKPRESSURE_ENABLED) {
                 TransportQueueBackpressureAlertEvent.emit(1, currentQueueDepth, trend);
             }
             throw new IllegalStateException("Rejected inbound buffer due to backpressure for stream " + streamId);
         }
+        lastQueueDepth = inboundQueueDepth.incrementAndGet();
         signalReadableIngress();
     }
 
@@ -472,6 +483,7 @@ final class NativeTcpStream implements TransportStream {
             if (!Objects.equals(completed, pending)) {
                 throw new IllegalStateException("Outbound queue head changed during flush for stream " + streamId);
             }
+            decrementDepth(outboundQueueDepth);
             completed.close();
             pending = outboundQueue.peek();
         }
@@ -517,7 +529,7 @@ final class NativeTcpStream implements TransportStream {
     private void awaitReadableIngress() {
         readParked.set(true);
         try {
-            if (closed.get() || remoteClosed.get() || currentInbound != null || !inboundQueue.isEmpty()) {
+            if (closed.get() || remoteClosed.get() || currentInbound != null || inboundQueueDepth.get() > 0) {
                 return;
             }
             LockSupport.park();
@@ -666,6 +678,7 @@ final class NativeTcpStream implements TransportStream {
     private void drainInboundQueue() {
         LoanedBuffer inbound = inboundQueue.poll();
         while (inbound != null) {
+            decrementDepth(inboundQueueDepth);
             inbound.close();
             inbound = inboundQueue.poll();
         }
@@ -674,9 +687,14 @@ final class NativeTcpStream implements TransportStream {
     private void drainOutboundQueue() {
         PendingWrite pending = outboundQueue.poll();
         while (pending != null) {
+            decrementDepth(outboundQueueDepth);
             pending.close();
             pending = outboundQueue.poll();
         }
+    }
+
+    private static int decrementDepth(AtomicInteger counter) {
+        return counter.updateAndGet(current -> current > 0 ? current - 1 : 0);
     }
 
     private static void logBestEffortCleanupFailure(String stage, RuntimeException error) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -92,6 +92,8 @@ final class NativeTcpStream implements TransportStream {
     private final AtomicBoolean tlsReady = new AtomicBoolean(false);
     private final Object tlsLock = new Object();
     private final AtomicReference<Thread> streamVt = new AtomicReference<>();
+    private final AtomicReference<Thread> inboundConsumer = new AtomicReference<>();
+    private final AtomicReference<Thread> outboundConsumer = new AtomicReference<>();
     private final AtomicBoolean readParked = new AtomicBoolean(false);
     private final AtomicReference<Thread> writeWaiter = new AtomicReference<>();
     private final AtomicBoolean writeParked = new AtomicBoolean(false);
@@ -138,60 +140,59 @@ final class NativeTcpStream implements TransportStream {
         if (maxBytes == 0) {
             return 0;
         }
-        if (closed.get()) {
-            if (remoteClosed.get()) {
+
+        Thread currentThread = Thread.currentThread();
+        acquireSingleConsumer(inboundConsumer, currentThread, "inbound");
+        try {
+            if (closed.get()) {
+                return closedReadOutcome();
+            }
+            if (remoteClosed.get() && currentInbound == null && inboundQueueDepth.get() == 0) {
                 return -1;
             }
-            throw new IllegalStateException(STREAM_CLOSED_MESSAGE);
-        }
-        // Short-circuit: if peer already closed and no buffered data remain, skip TLS readiness
-        if (remoteClosed.get() && currentInbound == null && inboundQueueDepth.get() == 0) {
-            return -1;
-        }
-        ensureTlsReady(true);
+            ensureTlsReady(true);
 
-        // Register calling VT for close-signal wakeup on first read
-        streamVt.compareAndSet(null, Thread.currentThread());
+            streamVt.compareAndSet(null, currentThread);
 
-        while (true) {
-            if (closed.get()) {
-                if (remoteClosed.get()) {
-                    return -1;
+            while (true) {
+                if (closed.get()) {
+                    return closedReadOutcome();
                 }
-                throw new IllegalStateException(STREAM_CLOSED_MESSAGE);
-            }
-            if (currentInbound == null) {
-                LoanedBuffer next = inboundQueue.poll();
-                if (next == null) {
-                    if (remoteClosed.get()) {
-                        return -1;
+                if (currentInbound == null) {
+                    LoanedBuffer next = inboundQueue.poll();
+                    if (next == null) {
+                        if (remoteClosed.get()) {
+                            return -1;
+                        }
+                        awaitReadableIngress();
+                        continue;
                     }
-                    awaitReadableIngress();
+                    decrementDepth(inboundQueueDepth);
+                    currentInbound = next;
+                    currentInboundOffset = 0;
+                }
+
+                int available = (int) currentInbound.size() - currentInboundOffset;
+                if (available <= 0) {
+                    closeCurrentInbound();
                     continue;
                 }
-                decrementDepth(inboundQueueDepth);
-                currentInbound = next;
-                currentInboundOffset = 0;
-            }
 
-            int available = (int) currentInbound.size() - currentInboundOffset;
-            if (available <= 0) {
-                closeCurrentInbound();
-                continue;
+                int bytes = Math.min(available, maxBytes);
+                MemorySegment.copy(
+                        currentInbound.segment(),
+                        currentInboundOffset,
+                        target,
+                        0,
+                        bytes);
+                currentInboundOffset += bytes;
+                if (currentInboundOffset >= currentInbound.size()) {
+                    closeCurrentInbound();
+                }
+                return bytes;
             }
-
-            int bytes = Math.min(available, maxBytes);
-            MemorySegment.copy(
-                    currentInbound.segment(),
-                    currentInboundOffset,
-                    target,
-                    0,
-                    bytes);
-            currentInboundOffset += bytes;
-            if (currentInboundOffset >= currentInbound.size()) {
-                closeCurrentInbound();
-            }
-            return bytes;
+        } finally {
+            releaseSingleConsumer(inboundConsumer, currentThread);
         }
     }
 
@@ -315,22 +316,15 @@ final class NativeTcpStream implements TransportStream {
         }
 
         try {
-            closeCurrentInbound();
+            cleanupInboundIfOwnedByCurrentThreadOrIdle();
         } catch (RuntimeException error) {
-            // channel.close() must always proceed
-            logBestEffortCleanupFailure("closeCurrentInbound", error);
+            logBestEffortCleanupFailure("cleanupInbound", error);
         }
 
         try {
-            drainInboundQueue();
+            cleanupOutboundIfOwnedByCurrentThreadOrIdle();
         } catch (RuntimeException error) {
-            logBestEffortCleanupFailure("drainInboundQueue", error);
-        }
-
-        try {
-            drainOutboundQueue();
-        } catch (RuntimeException error) {
-            logBestEffortCleanupFailure("drainOutboundQueue", error);
+            logBestEffortCleanupFailure("cleanupOutbound", error);
         }
 
         try {
@@ -452,42 +446,49 @@ final class NativeTcpStream implements TransportStream {
     }
 
     /* default */ boolean flushPendingWrites() {
-        if (closed.get()) {
+        Thread currentThread = Thread.currentThread();
+        acquireSingleConsumer(outboundConsumer, currentThread, "outbound");
+        try {
+            if (closed.get()) {
+                drainOutboundQueue();
+                return true;
+            }
+
+            if (!ensureTlsReady(false)) {
+                return outboundQueue.peek() == null;
+            }
+
+            PendingWrite pending = outboundQueue.peek();
+            while (pending != null) {
+                if (tlsEngine == null) {
+                    if (!tryDrainPlainWrite(pending)) {
+                        return false;
+                    }
+                } else {
+                    TlsStatus status = pending.prepareCipher();
+                    if (status == TlsStatus.CLOSED) {
+                        close();
+                        return true;
+                    }
+                    if (status != TlsStatus.OK) {
+                        throw TransportException.sendFailure(engineName, pending.bytesWritten(), null);
+                    }
+                    if (!tryDrainCipherWrite(pending)) {
+                        return false;
+                    }
+                }
+                PendingWrite completed = outboundQueue.poll();
+                if (!Objects.equals(completed, pending)) {
+                    throw new IllegalStateException("Outbound queue head changed during flush for stream " + streamId);
+                }
+                decrementDepth(outboundQueueDepth);
+                completed.close();
+                pending = outboundQueue.peek();
+            }
             return true;
+        } finally {
+            releaseSingleConsumer(outboundConsumer, currentThread);
         }
-
-        if (!ensureTlsReady(false)) {
-            return outboundQueue.peek() == null;
-        }
-
-        PendingWrite pending = outboundQueue.peek();
-        while (pending != null) {
-            if (tlsEngine == null) {
-                if (!tryDrainPlainWrite(pending)) {
-                    return false;
-                }
-            } else {
-                TlsStatus status = pending.prepareCipher();
-                if (status == TlsStatus.CLOSED) {
-                    close();
-                    return true;
-                }
-                if (status != TlsStatus.OK) {
-                    throw TransportException.sendFailure(engineName, pending.bytesWritten(), null);
-                }
-                if (!tryDrainCipherWrite(pending)) {
-                    return false;
-                }
-            }
-            PendingWrite completed = outboundQueue.poll();
-            if (!Objects.equals(completed, pending)) {
-                throw new IllegalStateException("Outbound queue head changed during flush for stream " + streamId);
-            }
-            decrementDepth(outboundQueueDepth);
-            completed.close();
-            pending = outboundQueue.peek();
-        }
-        return true;
     }
 
     private boolean tryDrainPlainWrite(PendingWrite pending) {
@@ -665,6 +666,63 @@ final class NativeTcpStream implements TransportStream {
             LockSupport.parkNanos(HANDSHAKE_BACKOFF_NANOS);
         }
         return false;
+    }
+
+    private int closedReadOutcome() {
+        closeCurrentInbound();
+        drainInboundQueue();
+        if (remoteClosed.get()) {
+            return -1;
+        }
+        throw new IllegalStateException(STREAM_CLOSED_MESSAGE);
+    }
+
+    private void cleanupInboundIfOwnedByCurrentThreadOrIdle() {
+        Thread currentThread = Thread.currentThread();
+        if (!tryAcquireSingleConsumer(inboundConsumer, currentThread)) {
+            return;
+        }
+        try {
+            closeCurrentInbound();
+            drainInboundQueue();
+        } finally {
+            releaseSingleConsumer(inboundConsumer, currentThread);
+        }
+    }
+
+    private void cleanupOutboundIfOwnedByCurrentThreadOrIdle() {
+        Thread currentThread = Thread.currentThread();
+        if (!tryAcquireSingleConsumer(outboundConsumer, currentThread)) {
+            return;
+        }
+        try {
+            drainOutboundQueue();
+        } finally {
+            releaseSingleConsumer(outboundConsumer, currentThread);
+        }
+    }
+
+    private static void acquireSingleConsumer(AtomicReference<Thread> consumerRef,
+                                              Thread currentThread,
+                                              String queueName) {
+        Thread owner = consumerRef.get();
+        if (owner == currentThread) {
+            return;
+        }
+        if (!consumerRef.compareAndSet(null, currentThread)) {
+            throw new IllegalStateException(
+                    "Concurrent " + queueName + " queue consumer detected for stream thread "
+                            + currentThread.getName());
+        }
+    }
+
+    private static boolean tryAcquireSingleConsumer(AtomicReference<Thread> consumerRef, Thread currentThread) {
+        Thread owner = consumerRef.get();
+        return owner == currentThread || (owner == null && consumerRef.compareAndSet(null, currentThread));
+    }
+
+    private static void releaseSingleConsumer(AtomicReference<Thread> consumerRef, Thread currentThread) {
+        consumerRef.compareAndSet(currentThread, null);
     }
 
     private void closeCurrentInbound() {

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCarrierIngressIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCarrierIngressIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
@@ -27,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -150,6 +152,114 @@ class NativeTcpCarrierIngressIntegrationTest {
         }
     }
 
+    @Test
+    void immediateLargeServerWritesCompleteDuringRegistrationHandoff() throws Exception {
+        int port = nextFreePort();
+        int connectionCount = 8;
+        int payloadSize = 256 * 1024;
+        byte[] payload = new byte[payloadSize];
+        Arrays.fill(payload, (byte) 'x');
+        CountDownLatch handled = new CountDownLatch(connectionCount);
+
+        NativeTcpTransportProvider provider = new NativeTcpTransportProvider();
+        TransportEngine[] holder = new TransportEngine[1];
+
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
+                .run(() -> holder[0] = provider.createEngine(new TransportConfig(
+                        TransportMode.SERVER,
+                        "127.0.0.1",
+                        port,
+                        2,
+                        null,
+                        null,
+                        1024,
+                        30_000
+                )));
+
+        TransportEngine engine = holder[0];
+        engine.setStreamHandler(stream -> {
+            try (stream) {
+                stream.write(MemorySegment.ofArray(payload), payload.length);
+            } finally {
+                handled.countDown();
+            }
+        });
+
+        List<SocketChannel> clients = new ArrayList<>();
+        try {
+            engine.start();
+
+            for (int i = 0; i < connectionCount; i++) {
+                SocketChannel client = SocketChannel.open();
+                client.configureBlocking(true);
+                client.socket().setReceiveBufferSize(4 * 1024);
+                client.connect(new InetSocketAddress("127.0.0.1", port));
+                clients.add(client);
+            }
+
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(75));
+            assertThat(handled.await(10, TimeUnit.SECONDS)).isTrue();
+
+            for (SocketChannel client : clients) {
+                assertThat(readFully(client, payloadSize, Duration.ofSeconds(5))).isEqualTo(payloadSize);
+            }
+        } finally {
+            for (SocketChannel client : clients) {
+                client.close();
+            }
+            engine.close();
+        }
+    }
+
+    @Test
+    void rapidConnectAndCloseDoesNotLeaveDanglingReactorOwnership() throws Exception {
+        int port = nextFreePort();
+        int connectionCount = 12;
+        CountDownLatch handled = new CountDownLatch(connectionCount);
+
+        NativeTcpTransportProvider provider = new NativeTcpTransportProvider();
+        TransportEngine[] holder = new TransportEngine[1];
+
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
+                .run(() -> holder[0] = provider.createEngine(new TransportConfig(
+                        TransportMode.SERVER,
+                        "127.0.0.1",
+                        port,
+                        2,
+                        null,
+                        null,
+                        1024,
+                        30_000
+                )));
+
+        TransportEngine engine = holder[0];
+        engine.setStreamHandler(stream -> {
+            try (stream) {
+                // close immediately to exercise register/write/cancel handoff ordering
+            } finally {
+                handled.countDown();
+            }
+        });
+
+        try {
+            engine.start();
+
+            for (int i = 0; i < connectionCount; i++) {
+                try (SocketChannel client = SocketChannel.open()) {
+                    client.configureBlocking(true);
+                    client.connect(new InetSocketAddress("127.0.0.1", port));
+                }
+            }
+
+            assertThat(handled.await(10, TimeUnit.SECONDS)).isTrue();
+
+            NativeTcpCarrier carrier = (NativeTcpCarrier) engine;
+            waitUntilNoOwnedChannels(carrier, Duration.ofSeconds(5));
+        } finally {
+            engine.close();
+        }
+    }
+
     private static int nextFreePort() {
         try (ServerSocketChannel server = ServerSocketChannel.open()) {
             server.bind(new InetSocketAddress("127.0.0.1", 0));
@@ -161,7 +271,7 @@ class NativeTcpCarrierIngressIntegrationTest {
 
     private static void waitUntilChannelsAssigned(NativeTcpCarrier carrier,
                                                    int expectedConnections,
-                                                   Duration timeout) throws InterruptedException {
+                                                   Duration timeout) {
         Instant deadline = Instant.now().plus(timeout);
         while (Instant.now().isBefore(deadline)) {
             Map<?, ?> ownerMap = readPrivateField(carrier, "channelOwner", Map.class);
@@ -171,6 +281,34 @@ class NativeTcpCarrierIngressIntegrationTest {
             LockSupport.parkNanos(25_000_000L);
         }
         throw new AssertionError("Expected channel ownership assignments were not created before timeout");
+    }
+
+    private static void waitUntilNoOwnedChannels(NativeTcpCarrier carrier, Duration timeout) {
+        Instant deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            Map<?, ?> ownerMap = readPrivateField(carrier, "channelOwner", Map.class);
+            Map<?, ?> streamMap = readPrivateField(carrier, "streamByChannel", Map.class);
+            if (ownerMap.isEmpty() && streamMap.isEmpty()) {
+                return;
+            }
+            LockSupport.parkNanos(25_000_000L);
+        }
+        throw new AssertionError("Expected channel ownership and stream tracking to drain before timeout");
+    }
+
+    private static int readFully(SocketChannel client, int expectedBytes, Duration timeout) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(expectedBytes);
+        Instant deadline = Instant.now().plus(timeout);
+        while (buffer.hasRemaining() && Instant.now().isBefore(deadline)) {
+            int read = client.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            if (read == 0) {
+                LockSupport.parkNanos(1_000_000L);
+            }
+        }
+        return buffer.position();
     }
 
     private static <T> T readPrivateField(Object target, String name, Class<T> type) {


### PR DESCRIPTION
This pull request introduces targeted performance improvements to the Community runtime's transport layer, specifically optimizing hot-path queue implementations in `NativeTcpStream` and `NativeTcpCarrier`. The changes replace standard JDK queue types with JCTools high-performance queues, refactor reactor request handling for better scalability, and add atomic depth tracking for accurate monitoring and backpressure enforcement. Additionally, the roadmap documentation is updated to reflect the new hot-path collections review and recent TCK suite additions.

**Transport Layer Performance Improvements:**

* Switched `NativeTcpStream`'s `outboundQueue` to `MpscUnboundedArrayQueue` and `inboundQueue` to either `SpscArrayQueue` or `SpscUnboundedArrayQueue` (from JCTools), replacing `LinkedBlockingQueue` for lower-latency, lock-free operation; added atomic depth counters for both queues to enable precise monitoring and backpressure. [[1]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760R22-R34) [[2]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L82-R90)
* Updated all queue operations and queue depth checks in `NativeTcpStream` to use atomic counters instead of `Queue.size()`, ensuring thread-safe and efficient queue depth tracking and alerting. [[1]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L141-R148) [[2]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760R172) [[3]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L349-R358) [[4]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L361-R382) [[5]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760R486) [[6]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L520-R532) [[7]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760R681) [[8]](diffhunk://#diff-ed551817012080eddc5a44c1e2ab31a0a66508d4e1e2e9bc3e79ebf865607760L277-R286)

**Reactor Loop Refactoring:**

* Refactored `NativeTcpCarrier.ReactorLoop` to use a unified `ReactorRequest` queue (with a new enum for request types) instead of separate registration and write-interest queues, improving maintainability and reducing selector wakeups via an atomic "wakeupPending" flag. [[1]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01R719-R733) [[2]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L740-R777) [[3]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L786-R809) [[4]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L820-R866) [[5]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L833-R893)
* Improved selector wakeup logic and request draining to minimize contention and spurious wakeups, and streamlined exception handling in the reactor loop. [[1]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L786-R809) [[2]](diffhunk://#diff-7fe93bbad8bfda73c4834678850e3cf58dbb68dcb4b8cc532a02b3f14b902d01L805-R825)

**Dependency and Documentation Updates:**

* Added JCTools as a dependency in `exeris-kernel-community/pom.xml` to enable use of high-performance queue implementations.
* Updated `docs/ROADMAP.md` to document the hot-path collections review and note the addition of abstract TCK suites for `CitadelGuard` and `StorageContextBridge`. [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L107-R111) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L123-R127) [[3]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2R260-R271)