### PR TITLE
v0.7 Sprint 1: SPI schemaVersion, bootstrap availability filter, doc sync

### DIFF
--- a/docs/adr/ADR-013 Distributed Saga State Distribution Model.md
+++ b/docs/adr/ADR-013 Distributed Saga State Distribution Model.md
@@ -2,9 +2,9 @@
 
 | Attribute      | Value                                                                                  |
 |:---------------|:---------------------------------------------------------------------------------------|
-| **Status**     | **PROPOSED**                                                                           |
+| **Status**     | **ACCEPTED**                                                                           |
 | **Deciders**   | Arkadiusz Przychocki                                                                   |
-| **Date**       | 2026-05-01                                                                             |
+| **Date**       | 2026-05-02                                                                             |
 | **Driven By**  | ADR-007 (next-gen runtime), ADR-008 (open-core), `docs/subsystems/flow.md`, `docs/subsystems/events.md`, ROADMAP DIST-301 |
 | **Compliance** | [Strategic Pillar: Distributed Saga Recovery](../whitepaper.md)                        |
 

--- a/docs/adr/ADR-013 Distributed Saga State Distribution Model.md
+++ b/docs/adr/ADR-013 Distributed Saga State Distribution Model.md
@@ -1,0 +1,81 @@
+# ADR-013: Distributed Saga State Distribution Model
+
+| Attribute      | Value                                                                                  |
+|:---------------|:---------------------------------------------------------------------------------------|
+| **Status**     | **PROPOSED**                                                                           |
+| **Deciders**   | Arkadiusz Przychocki                                                                   |
+| **Date**       | 2026-05-01                                                                             |
+| **Driven By**  | ADR-007 (next-gen runtime), ADR-008 (open-core), `docs/subsystems/flow.md`, `docs/subsystems/events.md`, ROADMAP DIST-301 |
+| **Compliance** | [Strategic Pillar: Distributed Saga Recovery](../whitepaper.md)                        |
+
+## 1) Context and Problem Statement
+- Single-node `FlowEngine` already supports PARK/WAKE recovery via `FlowSnapshotStore` (in-memory) and choreography wake via the in-memory parked-instance index.
+- Distributed deployments must coordinate saga state across multiple kernel instances that share business workflows: a saga parked on node A may receive a wake-trigger event on node B after a restart of either side.
+- Two coordination problems must be solved together: (a) durable, cross-restart saga state that survives a single kernel process; (b) cross-service event delivery that drives wake on the node currently owning capacity.
+- The decision must keep SPI implementation-blind, must not move broker/database concerns into Core, and must preserve the No-Waste-Compute hot-path discipline on the in-memory fast path.
+
+## 2) Decision Scope
+- In scope: durable saga snapshot model, cross-restart recovery, optimistic concurrency on shared snapshot rows, event-driven cross-service wake, error/telemetry contract for distributed coordination.
+- In scope: SPI surface area (`FlowSnapshot.schemaVersion` for OCC; a future parked-enumeration entry point on `FlowSnapshotStore` to be designed in Sprint 3 when `JdbcFlowSnapshotStore` lands), Core orchestration responsibilities, Community/Enterprise provider obligations.
+- Out of scope: identity/auth concerns for cross-service calls (covered by ADR-012), specific JDBC vendor optimizations beyond Postgres baseline, central saga-coordinator services, multi-region replication.
+
+## 3) Decision — Option A: Shared Durable Store + Event-Driven Choreography Wake
+- **Source of truth:** durable `FlowSnapshotStore` shared by all participating kernel instances. The reference Community implementation in 0.7 is `JdbcFlowSnapshotStore` over Postgres.
+- **Coordination primitive:** choreography events delivered through the Community Kafka `EventEngine`. There is no central saga coordinator and no distributed lock service.
+- **Conflict discriminator:** `FlowSnapshot.schemaVersion` (introduced in 0.7 SPI groundwork) acts as an optimistic-locking version on durable rows. Concurrent advance attempts on the same instance from two kernels resolve to one winner; the loser receives `EX-FLOW-7002 / phase=OPTIMISTIC_LOCK_CONFLICT` and falls back to the engine's existing idempotency guard for retry semantics.
+- **Cross-restart recovery:** on kernel start, the engine enumerates previously parked instances from the durable store via the parked-enumeration entry point introduced alongside `JdbcFlowSnapshotStore` in Sprint 3, and re-arms in-memory wake routing. Steady-state choreography continues to use the in-memory parked-instance index as the O(1) fast path; a snapshot-store probe on miss is the bounded fallback (already documented in `flow.md`).
+
+### Rejected alternatives
+- **Option B — distributed lock service (ZooKeeper/etcd) for saga coordination.** Adds a new operational dependency, raises bootstrap fragility, and shifts blocking calls onto the saga advance path. Rejected as inconsistent with the No-Waste-Compute contract.
+- **Option C — CRDT-based saga-state replication.** Saga compensation stack and step ordering are not commutative; merging concurrent advances at the data-structure level violates correctness. Rejected as semantically unsound for the saga model.
+- **Option D — single-leader saga coordinator with consensus (Raft/Paxos).** Acceptable correctness, but reintroduces a stateful central component the open-core kernel deliberately avoids; also inconsistent with ADR-008's preference for keeping Community drivers commodity-grade.
+
+## 4) Architecture Boundaries (The Wall)
+- SPI remains implementation-blind: only `FlowSnapshotStore` and event SPI types appear; no JDBC types (`Connection`, `DataSource`), no Kafka types (`Producer`, `Consumer`, `ProducerRecord`), no broker product names.
+- Core remains driver-agnostic: distributed wake is orchestrated through `FlowSnapshotStore`, `EventBus`/`EventLoop`, and `OutboxBrokerPort`. Core may host session-orchestration code (e.g., `eu.exeris.kernel.core.events.kafka.KafkaSessionOrchestrator`) but MUST NOT depend on `org.apache.kafka.*` — all Kafka client interaction stays inside the Community module.
+- Community owns the JDBC and Kafka client adapters. The Kafka adapter ships in a dedicated `exeris-kernel-community-kafka` submodule so single-node operators do not transitively pull `kafka-clients` and its dependency chain.
+- Enterprise binding remains out-of-repo. The contract obligations defined here apply to Enterprise on parity with Community.
+
+## 5) Optimistic Concurrency Contract
+- Every persisted saga row carries a `schema_version` column matching `FlowSnapshot.schemaVersion`. New snapshots use `FlowSnapshot.SCHEMA_VERSION_INITIAL` (`1L`).
+- `JdbcFlowSnapshotStore.save()` uses `INSERT ... ON CONFLICT (instance_id_most, instance_id_least) DO UPDATE` guarded by `WHERE schema_version = :incomingVersion`. On a CAS miss the store MUST raise `EX-FLOW-7002` with `phase=OPTIMISTIC_LOCK_CONFLICT` and rawArgs carrying `(engineName, "OPTIMISTIC_LOCK_CONFLICT", "STALE_VERSION", incomingVersion)`.
+- On a successful write the store MUST advance the on-disk version by exactly one. The runtime engine receives the new version via `load()` on the next replay and propagates it through `RuntimeFlowInstance.toSnapshot()` so subsequent saves carry the up-to-date version.
+- Layered idempotency: the in-memory `IdempotencyGuard` (heap CAS) and the durable `schemaVersion` (DB CAS) MUST agree on terminal states. TCK MUST cover the case where the heap guard reports "already done" but the durable row claims otherwise; the durable answer wins, and the heap state is reconciled on next load.
+
+## 6) Recovery Model
+- Engine startup enumerates parked instances through the durable store's parked-enumeration entry point (introduced alongside `JdbcFlowSnapshotStore` in Sprint 3) and rehydrates wake routing for every returned snapshot. Implementations MAY return a fully materialized list; pagination is not required for v0.7 but MAY be added in v0.8 if operator profiles show large parked populations.
+- Per-instance snapshot fallback on choreography wake remains unchanged: in-memory miss → `snapshotStore.load(...)` → filter `FlowState.PARKED` → reconstruct `FlowContext`. Repeated unknown-instance misses MUST be negatively suppressed in Core to bound persistence cost.
+- Saga TTL is governed by `FlowEngineConfig.defaultSagaTimeoutShort` and `defaultSagaTimeoutLong`. Timeout enforcement on wake compares `snapshot.timeout()` against `Instant.now()` and triggers compensation rather than wake when expired. Operators that override TTL defaults MUST document the operational implication.
+
+## 7) Hot Path Constraints (Performance Contract)
+- The in-memory parked-instance index remains O(1) on the steady-state choreography path. The durable store is consulted only on a miss or at startup.
+- `JdbcFlowSnapshotStore` MUST NOT use `ThreadLocal` for context propagation. `DataSource` is constructor-injected through `BootstrapContext`; ownership of the pool lifecycle stays with the bootstrapper.
+- The Kafka choreography path MUST NOT pin a Virtual Thread carrier across consumer-group rebalance. `FlowCarrierPinningTck` patterns apply.
+- `FlowSnapshot.schemaVersion` is a primitive `long`; the addition does not regress Valhalla readiness.
+
+## 8) Error and Telemetry Contract
+- New error condition: `EX-FLOW-7002 / phase=OPTIMISTIC_LOCK_CONFLICT` (see §5). No new error code is introduced; the existing `EX-FLOW-7002` taxonomy is reused with a new `phase` value.
+- JFR contract: distributed saga events MUST emit JFR-first telemetry on wake-on-load fallback, optimistic-lock conflicts, and parked-enumeration latency. Existing flow lifecycle JFR events (`FlowEngineShutdownEvent`, `FlowTimeoutEvent`) cover steady-state observability.
+- Payloads are secret-safe: no payload bytes from `opaqueState`, no JDBC connection strings, no Kafka credentials in emitted diagnostics. `EX-FLOW-7002` rawArgs carries only structural context (engineName, phase, reasonCode, contextVal).
+
+## 9) TCK Obligations
+- `AbstractDistributedFlowSnapshotStoreTck` (introduced in Sprint 3 alongside `JdbcFlowSnapshotStore`) codifies: save/load round-trip, delete semantics, parked-enumeration returning only `PARKED` rows, cross-restart simulation, concurrent-save CAS resolution, and `EX-FLOW-7002` on stale-version writes.
+- `AbstractSagaRecoveryTck` extension covers cross-restart choreography wake under persistence-enabled engines.
+- `AbstractKafkaEventEngineTck` (Sprint 5) covers consumer-rebalance behavior under in-flight choreography.
+- Community bindings: `CommunityJdbcFlowSnapshotStoreTckTest` (Postgres via Testcontainers, optional H2 fallback for developer-loop speed) and `CommunityKafkaEventEngineTckTest` (Kafka 3.x via Testcontainers).
+- Enterprise bindings: parity obligation declared; out-of-repo verification.
+- Contract changes are incomplete until abstract suites and both binding layers validate observable behavior.
+
+## 10) Implemented vs Planned (mandatory anti-drift block)
+- Implemented now (repository state, 0.7 SPI groundwork): `FlowSnapshot.schemaVersion` field with `SCHEMA_VERSION_INITIAL = 1L`; convenience constructor preserves the v0.6 call shape so existing in-memory stores compile unchanged. The parked-enumeration entry point on `FlowSnapshotStore` is intentionally deferred to Sprint 3 so its return type and pagination contract can be co-designed with `JdbcFlowSnapshotStore`.
+- Implemented now (repository state, pre-0.7): in-memory parked-instance index O(1) fast path; per-instance snapshot fallback on miss with negative suppression; `EX-FLOW-7002` taxonomy with phase discriminator; `AbstractSagaRecoveryTck` covers single-node mid-saga kill / idempotency / compensation.
+- Planned (0.7, Sprint 3 — FLOW-103/104/105/106): `exeris_saga_state` DDL with composite PK and partial PARKED index; `JdbcFlowSnapshotStore` with UPSERT + CAS; `lookupParked` snapshot fallback wired to durable store; `AbstractDistributedFlowSnapshotStoreTck` and Community Postgres binding.
+- Planned (0.7, Sprint 4 — FLOW-107/108, DIST-303): bounded terminal-state catalog with snapshot-store fallback verification; saga TTL enforcement; `FlowEngineShutdownEvent` and `FlowTimeoutEvent` JFR events.
+- Planned (0.7, Sprint 5/6 — EVENT-204, DIST-302): Community Kafka `EventEngine` in `exeris-kernel-community-kafka`; Core `KafkaSessionOrchestrator` (no `org.apache.kafka.*` leak); Flow→Events choreography handoff with `IdempotencyGuard` fence on at-least-once delivery; cross-service E2E recovery covered by integration tests.
+- Planned (0.7+, post-merge): the `RuntimeFlowInstance` wire-through of `schemaVersion` from load to save (so non-trivial OCC begins to advance through the lifecycle) lands as part of Sprint 3 alongside `JdbcFlowSnapshotStore`. Pre-Sprint-3 `toSnapshot()` continues to emit `SCHEMA_VERSION_INITIAL`, which is harmless for in-memory bindings.
+
+## 11) Consequences
+- Operators of single-node Community deployments are unaffected: the in-memory `CommunityFlowSnapshotStore` ignores `schemaVersion` and is not required to implement parked-enumeration (the entry point is introduced in Sprint 3 alongside the durable JDBC store). No new dependency is pulled.
+- Operators of distributed deployments adopt `JdbcFlowSnapshotStore` and the `exeris-kernel-community-kafka` module explicitly; absence of either keeps the system in single-node semantics.
+- Enterprise binding inherits the same SPI contract and the same TCK obligations; off-heap zero-copy snapshot writes and broker integrations remain Enterprise-internal but MUST honor the OCC discriminator and the parked-enumeration contract introduced in Sprint 3.
+- Future evolution toward streaming `EventStreamReader` / `EventStreamAppender` SPI types (Sprint 5 EVENT-203) is unblocked; this ADR does not foreclose adding those.

--- a/docs/adr/ADR-014 RequiresRole Compile-Time RBAC Generation.md
+++ b/docs/adr/ADR-014 RequiresRole Compile-Time RBAC Generation.md
@@ -2,9 +2,9 @@
 
 | Attribute      | Value                                                                                  |
 |:---------------|:---------------------------------------------------------------------------------------|
-| **Status**     | **PROPOSED**                                                                           |
+| **Status**     | **ACCEPTED**                                                                           |
 | **Deciders**   | Arkadiusz Przychocki                                                                   |
-| **Date**       | 2026-05-01                                                                             |
+| **Date**       | 2026-05-02                                                                             |
 | **Driven By**  | ADR-007 (next-gen runtime), ADR-012 (security trust model), `docs/subsystems/security.md` (`@RequiresRole` design note), performance contract |
 | **Compliance** | [Strategic Pillar: Zero-Reflection Security Hot Path](../whitepaper.md)               |
 

--- a/docs/adr/ADR-014 RequiresRole Compile-Time RBAC Generation.md
+++ b/docs/adr/ADR-014 RequiresRole Compile-Time RBAC Generation.md
@@ -1,0 +1,72 @@
+# ADR-014: `@RequiresRole` Compile-Time RBAC Generation
+
+| Attribute      | Value                                                                                  |
+|:---------------|:---------------------------------------------------------------------------------------|
+| **Status**     | **PROPOSED**                                                                           |
+| **Deciders**   | Arkadiusz Przychocki                                                                   |
+| **Date**       | 2026-05-01                                                                             |
+| **Driven By**  | ADR-007 (next-gen runtime), ADR-012 (security trust model), `docs/subsystems/security.md` (`@RequiresRole` design note), performance contract |
+| **Compliance** | [Strategic Pillar: Zero-Reflection Security Hot Path](../whitepaper.md)               |
+
+## 1) Context and Problem Statement
+- The kernel's admission path already enforces fail-closed authorization via `CitadelGuard.requireRole()` for dynamic, runtime-decided checks.
+- Static, declarative role requirements on method-level entry points (HTTP handlers, command receivers, scheduled tasks) are widely useful and currently have no kernel-blessed mechanism. Reflection-based annotation scanning would violate the No-Waste-Compute contract by allocating on the request hot path and by deferring failure to runtime that should be visible at compile time.
+- `docs/subsystems/security.md` already describes a target design that uses an APT-generated `RoleCheckRegistry` and a single bitmask AND on the hot path, but no decision document records the boundary commitments, the open-core placement, the TCK obligations, or the build-system contract.
+- This ADR is a pre-implementation gate. Code does not enter the kernel until this decision is signed off.
+
+## 2) Decision Scope
+- In scope: the `@RequiresRole` annotation type on the SPI surface, the APT processor placement and ownership, the generated artifact's binary contract, runtime integration with the existing security pipeline, error/telemetry contract, and TCK obligations.
+- In scope: interaction with `CitadelGuard` (runtime fallback for dynamic checks) and with the resource-server validation pipeline established in ADR-012.
+- Out of scope: dynamic policy decisioning (ABAC/PBAC), per-principal rate limiting (already addressed in `security.md` as a distinct mechanism), role hierarchy semantics beyond bitmask membership.
+
+## 3) Decision — Compile-Time Bitmask Registry
+- **Annotation surface (SPI):** `@RequiresRole(String[] value, RoleMatch match = RoleMatch.ANY)` lives in `exeris-kernel-spi` under the security package. The annotation is `@Retention(SOURCE)` because it is consumed at compile time only; no runtime reflection ever inspects it. `RoleMatch` is an enum value carrier (`ANY`, `ALL`).
+- **APT processor (build-config):** A `javax.annotation.processing.Processor` ships in `exeris-kernel-build-config` and is wired through `META-INF/services/javax.annotation.processing.Processor`. The processor consumes `@RequiresRole`-bearing elements across consumer modules and emits `eu.exeris.kernel.security.generated.RoleCheckRegistry` — a final class with primitive-only static fields and one O(1) lookup method per method-id.
+- **Generated artifact contract:** for each annotated method, the processor reserves a stable `int methodId` (assigned in source-order to keep the build deterministic) and stores two `long` masks: `requiredAny[methodId]` and `requiredAll[methodId]`. The runtime lookup is `(principal.roleMask() & required) != 0` for `ANY` or `(principal.roleMask() & required) == required` for `ALL`. No allocation, no reflection, no `Class.getAnnotation()` on the hot path.
+- **Role-name to bit mapping:** a single, kernel-owned canonical mapping ships in SPI (`KernelRoles`) for the small set of system roles. Application-defined roles use a stable hash to bit assignment generated at build time and recorded in the same `RoleCheckRegistry`. The mapping is frozen at build time; mismatch between build and runtime mappings is detected on bootstrap and fails closed.
+- **Runtime fallback:** `CitadelGuard.requireRole(String)` remains as the runtime-decided fallback for dynamic checks (e.g., role required is computed from request data). Static `@RequiresRole` checks short-circuit before `CitadelGuard` is consulted.
+
+### Rejected alternatives
+- **Reflection-based runtime scanning.** Allocates on the hot path, defers errors past compile time, and is structurally incompatible with the No-Waste-Compute contract.
+- **AOP/proxy-based interception.** Drags in a runtime weaving framework, conflicts with ScopedValue propagation discipline, and adds dispatch indirection that the dispatcher already avoided in 0.6.
+- **Configuration-file-driven role policy.** Decouples policy from code, increasing drift surface; loses the compile-time error of "annotated method on a class outside the security pipeline".
+
+## 4) Architecture Boundaries (The Wall)
+- SPI exposes only the annotation type, the `RoleMatch` enum, and the canonical `KernelRoles` mapping. No registry implementation lives in SPI.
+- The APT processor lives in `exeris-kernel-build-config` because it is build-time tooling; it MUST NOT depend on Core or Community runtime packages.
+- The generated `RoleCheckRegistry` is loaded by Core at bootstrap as an SPI provider via `ServiceLoader` (or via `LazyConstant.of(...)` at first access, matching the `security.md` description). Core consumes it through an SPI-shaped provider interface so the decision module is replaceable in tests.
+- Runtime integration touches admission (transport edge) and `CitadelGuard`; no Community/Enterprise driver touches the registry directly.
+
+## 5) Hot Path Constraints (Performance Contract)
+- Authorization decision: O(1) bitmask AND/EQ per request. No allocations, no reflection, no `String` interning at decision time.
+- Registry load: one-shot at bootstrap via `LazyConstant`. The fully-loaded registry is then accessed through final-field reads only.
+- Principal carrier: `principal.roleMask()` returns a primitive `long` (or `long[]` if more than 64 roles are required, indexed by registry-recorded shard id). The principal record is immutable and Valhalla-ready.
+- The decision MUST NOT allocate exceptions for accept paths; rejection raises `EX-SEC-2003` once on the deny path with secret-safe rawArgs.
+
+## 6) Error and Telemetry Contract
+- Reuses existing `EX-SEC-2003` (insufficient privileges) for static-check denies. RawArgs include the method id, required mask, and a redacted principal handle (no role names or token bytes).
+- JFR-first telemetry: a `RoleCheckDeniedEvent` records method id, denial reason discriminator (`MISSING_PRINCIPAL`, `INSUFFICIENT_ROLES`, `MAPPING_MISMATCH`), and decision latency. No principal identifiers, no role names.
+- Build-time errors (e.g., `@RequiresRole` referencing an undeclared role) MUST fail the compile with a clear diagnostic. Build failures are preferred over runtime warnings for this contract.
+
+## 7) TCK Obligations
+- `AbstractRequiresRoleTck` (introduced in Sprint 8 alongside the APT) codifies: registry presence after bootstrap, `ANY`/`ALL` matching semantics, fail-closed on missing principal, fail-closed on mapping mismatch, and absence of allocation on the accept path (paired with `RequiresRoleZeroAllocTck`).
+- The APT processor itself is covered by unit tests in `exeris-kernel-build-config` that compile representative source fixtures and assert the generated registry contents — both happy path and diagnostic emission for malformed annotations.
+- Community binding: `CommunityRequiresRoleTckTest`. Enterprise binding obligation declared; out-of-repo verification on parity.
+- Contract changes are incomplete until abstract suites and both binding layers validate observable behavior.
+
+## 8) Build System Contract
+- The APT processor is enabled by default for any consumer of `exeris-kernel-spi` that pulls `exeris-kernel-build-config` as a `provided`/annotation-processor-path dependency. Consumers SHOULD wire the `maven-compiler-plugin` `annotationProcessorPaths` block accordingly; the kernel BOM SHOULD provide a default.
+- Generated source MUST land in `target/generated-sources/annotations` (or the Gradle equivalent) and MUST NOT be checked into source control.
+- Incremental compile MUST regenerate the affected slice of the registry without rebuilding unaffected method ids, preserving the deterministic method-id assignment within a stable canonical ordering of input elements.
+
+## 9) Implemented vs Planned (mandatory anti-drift block)
+- Implemented now (repository state): `CitadelGuard.requireRole(String)` runtime check for dynamic role decisions; `AbstractCitadelGuardTck` and Community binding (`CommunityCitadelGuardTckTest`); secret-safe `EX-SEC-*` taxonomy with rawArgs discipline established by ADR-012; `KernelIsolationClaims` for storage-isolation routing.
+- Implemented now (repository state, design only): `docs/subsystems/security.md` describes the target `@RequiresRole` mechanism (APT-generated `RoleCheckRegistry`, hot-path bitmask check) but explicitly marks it as "Planned — not yet implemented in this repo". This ADR formalizes that design as the chosen direction.
+- Planned (0.7, Sprint 8): `@RequiresRole` annotation type added to `exeris-kernel-spi`; APT processor implemented in `exeris-kernel-build-config`; `RoleCheckRegistry` generation, `LazyConstant` loader, runtime admission integration; `AbstractRequiresRoleTck` and `RequiresRoleZeroAllocTck`; Community binding.
+- Planned (post-0.7): role-mapping versioning across rolling deploys; bitmask shard expansion if real-world consumers need more than 64 roles; build-time emit of operational documentation for the resolved role-name → bit assignment.
+
+## 10) Consequences
+- A new build-time dependency surface (the APT processor) must be wired into consumer build pipelines. The kernel BOM and reference build will provide opinionated defaults; teams that opt out of `@RequiresRole` lose only the static-check ergonomics, not any existing runtime check.
+- Static and dynamic role checks coexist: `@RequiresRole` for declarative method-level enforcement, `CitadelGuard.requireRole()` for code-driven decisions. Both produce the same `EX-SEC-2003` semantics so operators see uniform telemetry.
+- The role-name-to-bit mapping becomes a compile-time artifact. Operational changes to roles require a build, which is the intended trade-off for a zero-reflection hot path. Dynamic role policy (if ever required) remains expressible through the `CitadelGuard` runtime path.
+- This ADR does not foreclose future ABAC/PBAC layers; it scopes the kernel's contribution to the static, well-bounded RBAC slice that is performance-critical.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # Exeris Kernel: Architecture Overview
-**Version:** 0.6.0  
+**Version:** 0.7.0-SNAPSHOT  
 **Last Updated:** May 2026  
 **Status:** Validated Architectural Prototype (TRL‑3)
 

--- a/docs/subsystems/crypto.md
+++ b/docs/subsystems/crypto.md
@@ -258,6 +258,37 @@ public OffHeapTlsEngine(CoreSslHandles handles, long ctxPointer,
 
 ---
 
+## Operator Notes — FD Resolution on Restricted JDKs
+
+The Community TLS pipeline binds an OpenSSL BIO to the underlying socket file descriptor through
+`SocketChannelFdAccess.requireFd(channel)` at `CommunityTlsEngine.bindFileDescriptor(...)` time.
+On open JDK builds, FD resolution uses reflective access to `sun.nio.ch.SocketChannelImpl` and
+`java.io.FileDescriptor`. On JDKs that close those internals (e.g., distributions with strict
+`--illegal-access=deny`, modular runtime images that omit the relevant exports), reflective FD
+extraction fails with a clear diagnostic.
+
+Two operator-side resolutions exist:
+
+1. **Add JVM flags at startup** — pass:
+
+   ```text
+   --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+   --add-opens java.base/java.io=ALL-UNNAMED
+   ```
+
+   This restores reflective FD access without code changes and is the recommended path for hosts
+   the operator controls.
+2. **Use the explicit FD entry point** — call `CommunityTlsEngine.bindFileDescriptor(int)` directly
+   from your transport carrier with an FD obtained outside the closed reflection path (e.g., from
+   a native socket library or from a pre-opened descriptor). The reference Community carrier
+   already exposes this fallback via `NativeTcpCarrier` / `NativeTcpStream`, and embedders that
+   build their own carrier should mirror the contract.
+
+Either path keeps the SPI surface unchanged — `TlsEngine` does not expose JVM internals, and the
+fallback is a Community implementation detail.
+
+---
+
 ## Error Codes
 
 > **Source of truth:** `KernelErrorCodes.java` in `exeris-kernel-spi`.

--- a/docs/subsystems/persistence.md
+++ b/docs/subsystems/persistence.md
@@ -193,7 +193,7 @@ public interface StorageContext {
     IsolationStrategy strategy();
     Optional<String> schemaName();
     Optional<String> dataSourceKey();
-    Map<String, Object> attributes();
+    Map<String, String> attributes();
 }
 ```
 

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -57,7 +57,7 @@ zero-leak, hyper-density concurrency with immutable identity at every layer. It 
 2. Bind `PrincipalContext` and `StorageContext` via `ScopedValue.where(...)` for the duration of the request.
 3. Coordinate with the Persistence subsystem to enforce Row-Level Security (RLS).
 4. `CitadelGuard` — sentinel-pool RBAC enforcement gate with `preAllocate(String role)` / `seal()` / `requireRole(String role)`. Sealed at bootstrap READY transition.
-5. `StorageContextBridge` — derives a SHARED `StorageContext` from a `PrincipalContext` (SHARED-only derivation contract per ADR-010 §4a; full SEPARATED_SCHEMA/DEDICATED derivation comes from `SecurityProvider.authenticate()`).
+5. `StorageContextBridge` — derives a SHARED `StorageContext` from a `PrincipalContext` (SHARED-only derivation contract per ADR-010 §4a; full SEPARATED_SCHEMA/DEDICATED derivation comes from `SecurityProvider.authenticate()`). Fail-closed: when the `PrincipalContext` ScopedValue is unbound at the call site, `StorageContextBridge.derive()` raises `PrincipalContextMissingException` (`EX-SEC-2001`) and the request is rejected at the security boundary before any persistence interaction.
 
 > **TCK status:** `CitadelGuard` is now covered by the shared `AbstractCitadelGuardTck` contract plus Community/Core bindings.
 

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -82,6 +82,29 @@ The Community carrier transfers bytes from the network socket directly into off-
 
 ---
 
+## Provider Selection — Descending Priority + First-Available
+
+`CommunityTransportSubsystem` resolves a `TransportProvider` at bootstrap via the shared
+`BootstrapProviderSelector.loadHighestPriority(...)` helper with the availability filter
+`TransportProvider::isAvailable`. Selection semantics:
+
+1. **Discovery:** all `TransportProvider` implementations on the classpath are loaded via `ServiceLoader`.
+2. **Availability filter:** providers for which `isAvailable()` returns `false` are removed from the
+   candidate set. Platform-conditional providers (e.g., io_uring on Linux only, IOCP on Windows only)
+   gate themselves here. The default `isAvailable()` returns `true`.
+3. **Descending priority + deterministic tie-break:** remaining candidates are ranked by
+   `priority()` (higher wins). On ties, the implementation class name (alphabetical, last wins under
+   `Stream.max`) breaks the tie deterministically across JVMs and ServiceLoader orderings.
+4. **First-available wins:** the highest-priority available provider is selected. If the candidate
+   set is empty, no transport engine is created and the subsystem stays in `DISABLED` mode.
+
+This means an unavailable higher-priority provider (e.g., io_uring on a non-Linux host) does NOT
+shadow an available lower-priority provider (e.g., NIO Community baseline). The selection contract
+is exercised by `BootstrapProviderSelectorTest` and validated end-to-end through the
+`CommunityTransportSubsystemLifecycleTckTest` binding.
+
+---
+
 ## Error Codes
 
 > **Source of truth:** `KernelErrorCodes.java` in `exeris-kernel-spi`.

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityTransportSubsystem.java
@@ -9,6 +9,7 @@
 package eu.exeris.kernel.community.bootstrap;
 
 import eu.exeris.kernel.community.transport.CommunityReactorCountResolver;
+import eu.exeris.kernel.core.bootstrap.BootstrapProviderSelector;
 import eu.exeris.kernel.spi.bootstrap.BootstrapPhase;
 import eu.exeris.kernel.spi.config.ConfigProvider;
 import eu.exeris.kernel.spi.context.KernelProviders;
@@ -20,7 +21,6 @@ import eu.exeris.kernel.spi.transport.TransportProvider;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.ServiceLoader;
 import java.util.function.UnaryOperator;
 
 final class CommunityTransportSubsystem extends AbstractCommunitySubsystem {
@@ -49,14 +49,10 @@ final class CommunityTransportSubsystem extends AbstractCommunitySubsystem {
     @Override
     public void initialize() {
         ConfigProvider configProvider = KernelProviders.CURRENT_CONFIG.get();
-        transportProvider = ServiceLoader.load(TransportProvider.class)
-                .stream()
-                .map(ServiceLoader.Provider::get)
-                .sorted(Comparator.comparingInt(TransportProvider::priority)
-                        .reversed()
-                        .thenComparing(p -> p.getClass().getName()))
-                .filter(TransportProvider::isAvailable)
-                .findFirst()
+        transportProvider = BootstrapProviderSelector.loadHighestPriority(
+                        TransportProvider.class,
+                        Comparator.comparingInt(TransportProvider::priority),
+                        TransportProvider::isAvailable)
                 .orElse(null);
 
         if (transportProvider == null) {

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelector.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelector.java
@@ -12,12 +12,22 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Predicate;
 
 /**
  * Internal core utility for deterministic ServiceLoader-based provider selection.
  *
  * <p>Providers are ranked by the supplied comparator. When two providers compare as equal,
- * selection is deterministically resolved by provider implementation class name.</p>
+ * selection is deterministically resolved by provider implementation class name.
+ *
+ * <h2>Availability Filtering</h2>
+ * <p>SPI types that expose a platform-availability predicate (currently
+ * {@code TransportProvider.isAvailable()}) MUST use the
+ * {@link #loadHighestPriority(Class, Comparator, Predicate)} overload and pass the
+ * predicate explicitly. The selector applies the filter before ranking, so an
+ * unavailable higher-priority provider does not shadow an available lower-priority
+ * one. SPI types that do not declare an availability predicate use the unfiltered
+ * {@link #loadHighestPriority(Class, Comparator)} method.</p>
  */
 public final class BootstrapProviderSelector {
 
@@ -25,10 +35,56 @@ public final class BootstrapProviderSelector {
         // utility -- no instances
     }
 
+    /**
+     * Loads the highest-priority provider via {@link ServiceLoader}, ranked by
+     * {@code comparator}. No availability filtering is applied. Use
+     * {@link #loadHighestPriority(Class, Comparator, Predicate)} for SPI types that
+     * declare a platform-availability predicate.
+     */
     public static <T> Optional<T> loadHighestPriority(Class<T> providerType,
                                                       Comparator<? super T> comparator) {
+        return loadHighestPriority(providerType, comparator, anyProvider -> true);
+    }
+
+    /**
+     * Loads the highest-priority <em>available</em> provider via {@link ServiceLoader}.
+     *
+     * <p>The {@code availabilityFilter} is applied before ranking; only providers for
+     * which the predicate returns {@code true} participate in the selection. When two
+     * available providers compare as equal under {@code comparator}, the tie is broken
+     * deterministically by provider implementation class name.</p>
+     *
+     * @param providerType        SPI type loaded via {@code ServiceLoader}
+     * @param comparator          ranking comparator (higher rank wins)
+     * @param availabilityFilter  predicate that gates which providers can be selected;
+     *                            typically a method reference such as
+     *                            {@code TransportProvider::isAvailable}
+     * @param <T>                 provider type
+     * @return highest-ranked available provider, or empty if none qualify
+     */
+    public static <T> Optional<T> loadHighestPriority(Class<T> providerType,
+                                                      Comparator<? super T> comparator,
+                                                      Predicate<? super T> availabilityFilter) {
         Objects.requireNonNull(providerType, "providerType must not be null");
+        return selectFrom(
+                ServiceLoader.load(providerType)
+                        .stream()
+                        .map(ServiceLoader.Provider::get),
+                comparator,
+                availabilityFilter);
+    }
+
+    /**
+     * Package-private selection core. Splits the {@code ServiceLoader} discovery from the
+     * filter+rank logic so tests can drive selection from any provider stream without
+     * registering {@code META-INF/services} fixtures.
+     */
+    static <T> Optional<T> selectFrom(java.util.stream.Stream<T> providers,
+                                       Comparator<? super T> comparator,
+                                       Predicate<? super T> availabilityFilter) {
+        Objects.requireNonNull(providers, "providers must not be null");
         Objects.requireNonNull(comparator, "comparator must not be null");
+        Objects.requireNonNull(availabilityFilter, "availabilityFilter must not be null");
 
         Comparator<T> deterministicComparator = (left, right) -> {
             int compared = comparator.compare(left, right);
@@ -38,9 +94,8 @@ public final class BootstrapProviderSelector {
             return left.getClass().getName().compareTo(right.getClass().getName());
         };
 
-        return ServiceLoader.load(providerType)
-                .stream()
-                .map(ServiceLoader.Provider::get)
+        return providers
+                .filter(availabilityFilter)
                 .max(deterministicComparator);
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelector.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelector.java
@@ -79,7 +79,7 @@ public final class BootstrapProviderSelector {
      * filter+rank logic so tests can drive selection from any provider stream without
      * registering {@code META-INF/services} fixtures.
      */
-    static <T> Optional<T> selectFrom(java.util.stream.Stream<T> providers,
+    /* default */ static <T> Optional<T> selectFrom(java.util.stream.Stream<T> providers,
                                        Comparator<? super T> comparator,
                                        Predicate<? super T> availabilityFilter) {
         Objects.requireNonNull(providers, "providers must not be null");

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java
@@ -78,7 +78,7 @@ import java.util.function.Supplier;
 public final class KernelBootstrap {
 
     /** Kernel artifact version — emitted in JFR events for traceability. */
-    private static final String KERNEL_VERSION = "0.5.0";
+    private static final String KERNEL_VERSION = "0.7.0-SNAPSHOT";
 
     private final SubsystemOrchestrator.FailurePolicy failurePolicy;
     private final BootstrapSelector                   selector;

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelectorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelectorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.bootstrap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * L1 Contract: {@link BootstrapProviderSelector} ranking + availability filtering +
+ * deterministic tie-break.
+ *
+ * <h2>Scope</h2>
+ * <ul>
+ *   <li>Higher comparator rank wins.</li>
+ *   <li>Availability filter excludes providers BEFORE ranking — an unavailable
+ *       higher-priority provider must NOT shadow an available lower-priority one
+ *       (TCK-061 contract).</li>
+ *   <li>Tie-break is by implementation class name (deterministic across JVMs).</li>
+ *   <li>Empty selection returns {@link Optional#empty()}.</li>
+ * </ul>
+ *
+ * <p>The test exercises the package-private {@code selectFrom(Stream, ...)} core to
+ * decouple the contract from {@code ServiceLoader} discovery.</p>
+ *
+ * @since 0.7.0
+ */
+@DisplayName("L1: BootstrapProviderSelector — rank + availability filter + deterministic tie-break")
+class BootstrapProviderSelectorTest {
+
+    private interface FakeProvider {
+        int priority();
+        boolean isAvailable();
+    }
+
+    private static final class HighPriorityUnavailable implements FakeProvider {
+        @Override public int priority()      { return 100; }
+        @Override public boolean isAvailable() { return false; }
+    }
+
+    private static final class LowPriorityAvailable implements FakeProvider {
+        @Override public int priority()      { return 10; }
+        @Override public boolean isAvailable() { return true; }
+    }
+
+    private static final class HighPriorityAvailableA implements FakeProvider {
+        @Override public int priority()      { return 50; }
+        @Override public boolean isAvailable() { return true; }
+    }
+
+    private static final class HighPriorityAvailableB implements FakeProvider {
+        @Override public int priority()      { return 50; }
+        @Override public boolean isAvailable() { return true; }
+    }
+
+    private static final Comparator<FakeProvider> BY_PRIORITY =
+            Comparator.comparingInt(FakeProvider::priority);
+
+    @Nested
+    @DisplayName("Availability filter (TCK-061): unavailable higher-priority provider must not shadow available lower-priority one")
+    class AvailabilityFilterContract {
+
+        @Test
+        @DisplayName("Filter excludes the high-priority unavailable provider; low-priority available wins")
+        void filterPicksAvailableLowerPriority() {
+            FakeProvider winner = BootstrapProviderSelector.selectFrom(
+                    Stream.of(new HighPriorityUnavailable(), new LowPriorityAvailable()),
+                    BY_PRIORITY,
+                    FakeProvider::isAvailable
+            ).orElseThrow();
+            assertThat(winner).isInstanceOf(LowPriorityAvailable.class);
+        }
+
+        @Test
+        @DisplayName("Without the filter, the high-priority unavailable provider would have won — confirms the filter changes the outcome")
+        void withoutFilterUnavailableProviderWins() {
+            FakeProvider winner = BootstrapProviderSelector.selectFrom(
+                    Stream.of(new HighPriorityUnavailable(), new LowPriorityAvailable()),
+                    BY_PRIORITY,
+                    p -> true
+            ).orElseThrow();
+            assertThat(winner).isInstanceOf(HighPriorityUnavailable.class);
+        }
+
+        @Test
+        @DisplayName("All providers unavailable -> empty Optional")
+        void allUnavailableYieldsEmpty() {
+            Optional<FakeProvider> result = BootstrapProviderSelector.selectFrom(
+                    Stream.of(new HighPriorityUnavailable()),
+                    BY_PRIORITY,
+                    FakeProvider::isAvailable
+            );
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Deterministic tie-break by class name")
+    class TieBreakContract {
+
+        @Test
+        @DisplayName("Two providers with equal priority -> winner is deterministic across runs (alphabetically last by class name wins under max())")
+        void tieBreakByClassName() {
+            FakeProvider a = new HighPriorityAvailableA();
+            FakeProvider b = new HighPriorityAvailableB();
+
+            FakeProvider winner1 = BootstrapProviderSelector.selectFrom(
+                    Stream.of(a, b), BY_PRIORITY, p -> true).orElseThrow();
+            FakeProvider winner2 = BootstrapProviderSelector.selectFrom(
+                    Stream.of(b, a), BY_PRIORITY, p -> true).orElseThrow();
+            // Stream.max with a comparator returns the maximum; alphabetical tiebreak
+            // means HighPriorityAvailableB > HighPriorityAvailableA, so B wins regardless of input order.
+            assertThat(winner1).isInstanceOf(HighPriorityAvailableB.class);
+            assertThat(winner2).isInstanceOf(HighPriorityAvailableB.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Empty input + null guards")
+    class GuardContract {
+
+        @Test
+        @DisplayName("Empty stream -> empty Optional")
+        void emptyStream() {
+            Optional<FakeProvider> result = BootstrapProviderSelector.selectFrom(
+                    Stream.empty(), BY_PRIORITY, p -> true);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Null providers stream rejected")
+        void nullProvidersRejected() {
+            assertThatThrownBy(() ->
+                    BootstrapProviderSelector.selectFrom(null, BY_PRIORITY, p -> true))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("providers");
+        }
+
+        @Test
+        @DisplayName("Null comparator rejected")
+        void nullComparatorRejected() {
+            assertThatThrownBy(() ->
+                    BootstrapProviderSelector.selectFrom(Stream.empty(), null, p -> true))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("comparator");
+        }
+
+        @Test
+        @DisplayName("Null availability filter rejected")
+        void nullFilterRejected() {
+            assertThatThrownBy(() ->
+                    BootstrapProviderSelector.selectFrom(Stream.empty(), BY_PRIORITY, null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("availabilityFilter");
+        }
+    }
+}

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
@@ -20,6 +20,15 @@ import java.util.Objects;
  * PARK/WAKE cycles and kernel restarts. Fields map 1:1 to the off-heap context
  * slab layout in the Enterprise tier (see {@code FLOW_CONTEXT_STRIDE}).
  *
+ * <h2>Optimistic Concurrency (since 0.7.0)</h2>
+ * <p>{@code schemaVersion} carries a monotonic version counter that durable, distributed
+ * stores (e.g., {@code JdbcFlowSnapshotStore}) use as an optimistic-locking discriminator
+ * on UPSERT. New snapshots SHOULD start at {@link #SCHEMA_VERSION_INITIAL}; durable stores
+ * MUST advance the on-disk value on every accepted write and MUST reject a write whose
+ * incoming {@code schemaVersion} does not match the on-disk row, raising
+ * {@code EX-FLOW-7002 / phase=OPTIMISTIC_LOCK_CONFLICT}. In-memory stores (which never
+ * race across processes) MAY ignore the field entirely.
+ *
  * <h2>Array Equality</h2>
  * <p>This record contains {@code int[]} and {@code byte[]} array fields.
  * The default record {@code equals()}/{@code hashCode()}/{@code toString()} use
@@ -43,6 +52,8 @@ import java.util.Objects;
  * @param compensationStack array of step ids whose compensations must execute in reverse order
  * @param stackPointer      number of valid entries in {@code compensationStack}
  * @param opaqueState       raw byte payload for implementation-specific state (max 916 bytes)
+ * @param schemaVersion     monotonic version for optimistic concurrency control on durable
+ *                          stores; {@code >= 1L}; new snapshots use {@link #SCHEMA_VERSION_INITIAL}
  *
  * @since 0.5.0
  */
@@ -56,7 +67,8 @@ public record FlowSnapshot(
         Instant   timeout,
         int[]     compensationStack,
         int       stackPointer,
-        byte[]    opaqueState
+        byte[]    opaqueState,
+        long      schemaVersion
 ) {
 
     /**
@@ -64,6 +76,14 @@ public record FlowSnapshot(
      * off-heap context slab reserved region documented in {@code FLOW_CONTEXT_STRIDE}.
      */
     public static final int MAX_OPAQUE_STATE_BYTES = 916;
+
+    /**
+     * Initial value of {@link #schemaVersion} for newly created snapshots. Durable stores
+     * MUST advance from this value on every accepted write.
+     *
+     * @since 0.7.0
+     */
+    public static final long SCHEMA_VERSION_INITIAL = 1L;
 
     /**
      * Compact constructor — validates all invariants eagerly (fail-fast) and defensively
@@ -108,8 +128,38 @@ public record FlowSnapshot(
                     "opaqueState exceeds max size: " + opaqueState.length
                     + " > " + MAX_OPAQUE_STATE_BYTES);
         }
+        if (schemaVersion < SCHEMA_VERSION_INITIAL) {
+            throw new IllegalArgumentException(
+                    "schemaVersion must be >= " + SCHEMA_VERSION_INITIAL + ", got: " + schemaVersion);
+        }
         compensationStack = Arrays.copyOf(compensationStack, compensationStack.length);
         opaqueState       = Arrays.copyOf(opaqueState, opaqueState.length);
+    }
+
+    /**
+     * Convenience constructor that omits {@link #schemaVersion}, defaulting it to
+     * {@link #SCHEMA_VERSION_INITIAL}. Preserves the pre-0.7 call shape so existing
+     * callers (e.g., the runtime engine's {@code toSnapshot} path and in-memory stores)
+     * compile unchanged. Durable stores that participate in optimistic concurrency
+     * MUST use the canonical constructor and pass the current on-disk version.
+     *
+     * @since 0.7.0
+     */
+    public FlowSnapshot(
+            long      instanceIdMost,
+            long      instanceIdLeast,
+            String    definitionName,
+            int       currentStep,
+            FlowState state,
+            Instant   lastUpdate,
+            Instant   timeout,
+            int[]     compensationStack,
+            int       stackPointer,
+            byte[]    opaqueState
+    ) {
+        this(instanceIdMost, instanceIdLeast, definitionName, currentStep, state,
+             lastUpdate, timeout, compensationStack, stackPointer, opaqueState,
+             SCHEMA_VERSION_INITIAL);
     }
 
     /**
@@ -167,6 +217,7 @@ public record FlowSnapshot(
                && instanceIdLeast  == other.instanceIdLeast
                && currentStep      == other.currentStep
                && stackPointer     == other.stackPointer
+               && schemaVersion    == other.schemaVersion
                && state            == other.state
                && Objects.equals(definitionName, other.definitionName)
                && Objects.equals(lastUpdate,     other.lastUpdate)
@@ -183,7 +234,7 @@ public record FlowSnapshot(
     public int hashCode() {
         int result = Objects.hash(
                 instanceIdMost, instanceIdLeast, definitionName,
-                currentStep, state, lastUpdate, timeout, stackPointer);
+                currentStep, state, lastUpdate, timeout, stackPointer, schemaVersion);
         result = 31 * result + Arrays.hashCode(compensationStack);
         result = 31 * result + Arrays.hashCode(opaqueState);
         return result;
@@ -205,6 +256,7 @@ public record FlowSnapshot(
                + ", compensationStack=" + Arrays.toString(compensationStack)
                + ", stackPointer=" + stackPointer
                + ", opaqueState=" + Arrays.toString(opaqueState)
+               + ", schemaVersion=" + schemaVersion
                + ']';
     }
 }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
@@ -145,6 +145,7 @@ public record FlowSnapshot(
      *
      * @since 0.7.0
      */
+    @SuppressWarnings("PMD.ExcessiveParameterList") // backward-compat bridge — preserves v0.6 call shape
     public FlowSnapshot(
             long      instanceIdMost,
             long      instanceIdLeast,

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/flow/FlowSnapshotTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/flow/FlowSnapshotTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.flow;
+
+import eu.exeris.kernel.spi.flow.model.FlowSnapshot;
+import eu.exeris.kernel.spi.flow.model.FlowState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * L1 Contract: {@link FlowSnapshot} compact-constructor invariants, defensive array copy,
+ * convenience-constructor compatibility, and the 0.7.0 {@code schemaVersion} optimistic-concurrency
+ * field semantics.
+ *
+ * <h2>Scope</h2>
+ * <ul>
+ *   <li>All constructor invariants reject malformed input (null, blank, out-of-bounds).</li>
+ *   <li>{@code compensationStack} and {@code opaqueState} are defensively copied on construction
+ *       AND on accessor read — caller mutations cannot alter snapshot state.</li>
+ *   <li>The 10-arg convenience constructor preserves the v0.6 call shape and defaults
+ *       {@link FlowSnapshot#schemaVersion()} to {@link FlowSnapshot#SCHEMA_VERSION_INITIAL}.</li>
+ *   <li>{@code schemaVersion} participates in {@code equals}/{@code hashCode} and appears in
+ *       {@code toString} — two snapshots that differ ONLY in schemaVersion are not equal
+ *       (optimistic-concurrency contract from ADR-013 §5).</li>
+ * </ul>
+ *
+ * @since 0.7.0
+ */
+@DisplayName("L1: FlowSnapshot — invariants + defensive copy + schemaVersion (FLOW-101)")
+class FlowSnapshotTest {
+
+    private static final long      ID_MOST  = 0x0123456789ABCDEFL;
+    private static final long      ID_LEAST = 0xFEDCBA9876543210L;
+    private static final String    DEF_NAME = "checkout-saga";
+    private static final FlowState STATE    = FlowState.PARKED;
+    private static final Instant   T_NOW    = Instant.parse("2026-05-01T10:00:00Z");
+    private static final Instant   T_END    = Instant.parse("2026-05-01T10:30:00Z");
+    private static final int[]     STACK    = {1, 2, 3};
+    private static final byte[]    OPAQUE   = {0x10, 0x20, 0x30};
+
+    private static FlowSnapshot canonical(long schemaVersion) {
+        return new FlowSnapshot(
+                ID_MOST, ID_LEAST, DEF_NAME, 5, STATE, T_NOW, T_END,
+                STACK.clone(), STACK.length, OPAQUE.clone(), schemaVersion);
+    }
+
+    private static FlowSnapshot canonical() {
+        return canonical(FlowSnapshot.SCHEMA_VERSION_INITIAL);
+    }
+
+    @Nested
+    @DisplayName("Constructor invariants — fail-fast on malformed input")
+    class ConstructorInvariants {
+
+        @Test
+        @DisplayName("Null definitionName -> NPE")
+        void nullDefinitionName() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, null, 0, STATE, T_NOW, T_END,
+                    new int[0], 0, new byte[0], 1L))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("definitionName");
+        }
+
+        @Test
+        @DisplayName("Blank definitionName -> IAE")
+        void blankDefinitionName() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, "  ", 0, STATE, T_NOW, T_END,
+                    new int[0], 0, new byte[0], 1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("definitionName");
+        }
+
+        @Test
+        @DisplayName("Negative currentStep -> IAE")
+        void negativeCurrentStep() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, -1, STATE, T_NOW, T_END,
+                    new int[0], 0, new byte[0], 1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("currentStep");
+        }
+
+        @Test
+        @DisplayName("stackPointer > compensationStack.length -> IAE")
+        void stackPointerOutOfBounds() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    new int[2], 3, new byte[0], 1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("stackPointer");
+        }
+
+        @Test
+        @DisplayName("opaqueState exceeding MAX_OPAQUE_STATE_BYTES -> IAE")
+        void opaqueStateTooLarge() {
+            byte[] tooLarge = new byte[FlowSnapshot.MAX_OPAQUE_STATE_BYTES + 1];
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    new int[0], 0, tooLarge, 1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("opaqueState");
+        }
+
+        @Test
+        @DisplayName("Null compensationStack -> NPE (use new int[0] for empty)")
+        void nullCompensationStack() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    null, 0, new byte[0], 1L))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("compensationStack");
+        }
+
+        @Test
+        @DisplayName("Null opaqueState -> NPE (use new byte[0] for empty)")
+        void nullOpaqueState() {
+            assertThatThrownBy(() -> new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    new int[0], 0, null, 1L))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("opaqueState");
+        }
+    }
+
+    @Nested
+    @DisplayName("Defensive array copy — caller mutations cannot alter snapshot state")
+    class DefensiveCopyContract {
+
+        @Test
+        @DisplayName("Mutating the input compensationStack after construction does not affect the snapshot")
+        void inputStackMutationIsolated() {
+            int[] input = {7, 8, 9};
+            FlowSnapshot s = new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    input, input.length, new byte[0], 1L);
+            input[0] = 999;
+            assertThat(s.compensationStack()).containsExactly(7, 8, 9);
+        }
+
+        @Test
+        @DisplayName("Mutating the input opaqueState after construction does not affect the snapshot")
+        void inputOpaqueMutationIsolated() {
+            byte[] input = {0x01, 0x02, 0x03};
+            FlowSnapshot s = new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    new int[0], 0, input, 1L);
+            input[0] = (byte) 0xFF;
+            assertThat(s.opaqueState()).containsExactly(0x01, 0x02, 0x03);
+        }
+
+        @Test
+        @DisplayName("Mutating the returned compensationStack does not affect the snapshot")
+        void returnedStackMutationIsolated() {
+            FlowSnapshot s = canonical();
+            int[] returned = s.compensationStack();
+            returned[0] = 999;
+            assertThat(s.compensationStack()).containsExactly(STACK);
+        }
+
+        @Test
+        @DisplayName("Mutating the returned opaqueState does not affect the snapshot")
+        void returnedOpaqueMutationIsolated() {
+            FlowSnapshot s = canonical();
+            byte[] returned = s.opaqueState();
+            returned[0] = (byte) 0xFF;
+            assertThat(s.opaqueState()).containsExactly(OPAQUE);
+        }
+    }
+
+    @Nested
+    @DisplayName("schemaVersion (FLOW-101) — optimistic-concurrency field semantics")
+    class SchemaVersionContract {
+
+        @Test
+        @DisplayName("SCHEMA_VERSION_INITIAL == 1L (durable stores advance from this baseline)")
+        void initialConstant() {
+            assertThat(FlowSnapshot.SCHEMA_VERSION_INITIAL).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("10-arg convenience constructor defaults schemaVersion to SCHEMA_VERSION_INITIAL — preserves v0.6 call shape")
+        void convenienceConstructorDefaultsToInitial() {
+            FlowSnapshot s = new FlowSnapshot(
+                    ID_MOST, ID_LEAST, DEF_NAME, 0, STATE, T_NOW, T_END,
+                    new int[0], 0, new byte[0]);
+            assertThat(s.schemaVersion()).isEqualTo(FlowSnapshot.SCHEMA_VERSION_INITIAL);
+        }
+
+        @Test
+        @DisplayName("schemaVersion = 0L rejected (must be >= SCHEMA_VERSION_INITIAL)")
+        void zeroSchemaVersionRejected() {
+            assertThatThrownBy(() -> canonical(0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("schemaVersion");
+        }
+
+        @Test
+        @DisplayName("Negative schemaVersion rejected")
+        void negativeSchemaVersionRejected() {
+            assertThatThrownBy(() -> canonical(-1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("schemaVersion");
+        }
+
+        @Test
+        @DisplayName("schemaVersion = 1L accepted (boundary)")
+        void initialSchemaVersionAccepted() {
+            assertThat(canonical(1L).schemaVersion()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("Large schemaVersion accepted (no upper bound)")
+        void largeSchemaVersionAccepted() {
+            assertThat(canonical(Long.MAX_VALUE).schemaVersion()).isEqualTo(Long.MAX_VALUE);
+        }
+    }
+
+    @Nested
+    @DisplayName("equals / hashCode / toString — schemaVersion participates")
+    class EqualityContract {
+
+        @Test
+        @DisplayName("Two snapshots with identical content (including arrays) are equal — deep array semantics")
+        void deepEquality() {
+            FlowSnapshot a = canonical();
+            FlowSnapshot b = canonical();
+            assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        }
+
+        @Test
+        @DisplayName("Snapshots differing ONLY in schemaVersion are NOT equal — OCC discriminator (ADR-013 §5)")
+        void schemaVersionDeltaBreaksEquality() {
+            FlowSnapshot v1 = canonical(1L);
+            FlowSnapshot v2 = canonical(2L);
+            assertThat(v1).isNotEqualTo(v2);
+        }
+
+        @Test
+        @DisplayName("equals(null) -> false (no NPE)")
+        void equalsNull() {
+            assertThat(canonical().equals(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("equals(differentType) -> false")
+        @SuppressWarnings("unlikely-arg-type")
+        void equalsDifferentType() {
+            assertThat(canonical().equals("not-a-snapshot")).isFalse();
+        }
+
+        @Test
+        @DisplayName("equals is reflexive")
+        void equalsReflexive() {
+            FlowSnapshot s = canonical();
+            assertThat(s).isEqualTo(s);
+        }
+
+        @Test
+        @DisplayName("toString includes schemaVersion field")
+        void toStringContainsSchemaVersion() {
+            assertThat(canonical(42L).toString()).contains("schemaVersion=42");
+        }
+    }
+}

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0-SNAPSHOT</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
## Summary

v0.7 Sprint 1 closure. Three concrete code/doc changes plus two ADR drafts that gate later sprints.

### SPI groundwork (FLOW-101)
- `FlowSnapshot.schemaVersion: long` field + `SCHEMA_VERSION_INITIAL = 1L` constant for optimistic-concurrency control on durable stores
- v0.6-shape convenience constructor preserves the pre-0.7 call shape — existing in-memory bindings (`RuntimeFlowInstance.toSnapshot`, `CommunityFlowSnapshotStore`, test in-memory stores) compile unchanged
- Validation rejects `schemaVersion < 1L`
- The parked-enumeration entry point on `FlowSnapshotStore` is intentionally **deferred to Sprint 3** so its return type and pagination contract can be co-designed with `JdbcFlowSnapshotStore`. ADR-013 reflects this scope.

### Bootstrap availability filter (TCK-061)
- `BootstrapProviderSelector` gains a `Predicate` overload + package-private `selectFrom(Stream, ...)` core for testability
- `CommunityTransportSubsystem` migrates from its local `ServiceLoader` pipeline to the central selector with `TransportProvider::isAvailable`, ending the asymmetry where four bootstraps (`PersistenceBootstrap`, `FlowBootstrap`, `EventBootstrap`, `GraphBootstrap`) used the unfiltered selector while only `CommunityTransportSubsystem` filtered
- The unfiltered overload (`loadHighestPriority(Class, Comparator)`) delegates to the filtered one with `p -> true`, so existing callers compile unchanged
- New unit test `BootstrapProviderSelectorTest` (8 tests): filter excludes unavailable providers before ranking, deterministic tie-break by class name, null-guard contract

> Subsystems whose provider SPIs do not declare `isAvailable()` (Persistence/Flow/Event/Graph) keep using the unfiltered overload. No additional binding tests are needed there until those SPIs grow an availability predicate.

### v0.6 PR-review carry-overs (DOC-061..064)
- `persistence.md` — `StorageContext.attributes()` typed as `Map<String, String>` to match the SPI
- `transport.md` — new "Provider Selection — Descending Priority + First-Available" paragraph
- `security.md` — `StorageContextBridge` failure path linked to `PrincipalContextMissingException` / `EX-SEC-2001`
- `crypto.md` — new "Operator Notes — FD Resolution on Restricted JDKs" with `--add-opens` flags and `bindFileDescriptor(int)` fallback

### Architecture decision drafts (PROPOSED)
- **ADR-013 Distributed Saga State Distribution Model** — Option A: shared durable `FlowSnapshotStore` + Kafka choreography wake + `schemaVersion` as OCC discriminator. Pre-implementation gate for EPIC-1/3 (Sprints 3-6).
- **ADR-014 @RequiresRole Compile-Time RBAC Generation** — APT processor in `exeris-kernel-build-config` emits a bitmask `RoleCheckRegistry`; hot-path single-AND check; `CitadelGuard.requireRole` remains the runtime fallback. Pre-implementation gate for Sprint 8.

## Test plan

- [x] SPI module: `mvn -pl exeris-kernel-spi test` — all green (no regression from `schemaVersion` addition)
- [x] Core Flow: `CoreFlowEngineTest`, `CoreFlowRuntimeTest`, `CoreSagaRecoveryTckTest` — 45/45 green
- [x] Core Bootstrap: new `BootstrapProviderSelectorTest` — 8/8 green
- [x] Community: `CommunityTransportSubsystemLifecycleTckTest`, `CommunitySagaRecoveryTckTest`, `CommunityFlow*TckTest` — 40/40 green (selector refactor non-observable)
- [x] Reviewer: ADR-013 sign-off (PROPOSED → ACCEPTED) before Sprint 3 implementation start
- [x] Reviewer: ADR-014 sign-off (PROPOSED → ACCEPTED) before Sprint 8 implementation start

## Out of scope (kept for follow-up)

- `JdbcFlowSnapshotStore`, `exeris_saga_state` DDL, `lookupParked` snapshot fallback — Sprint 3 (FLOW-103/104/105/106)
- `@RequiresRole` SPI annotation + APT processor + `RoleCheckRegistry` — Sprint 8
- Performance carry-overs (PERF-061..064, TCK-064 stress investigation) — Sprint 2