### PR TITLE
v0.7 Sprint 2: performance follow-up (PERF-061..064, TCK-064, HEUR-061)

### DIFF
--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -321,6 +321,47 @@ for client IP preservation behind load balancers (HAProxy, NGINX, AWS NLB, GCP L
 
 ---
 
+## Implementation Notes — Class Decomposition Assessment (HEUR-061)
+
+`NativeTcpCarrier` (~1.4k LOC, 146 declared members) and `NativeTcpStream` (~1.2k LOC, 133 declared members) cross the CLAUDE.md "≈5 collaborators" heuristic threshold. A v0.6 PR-review carry-over (HEUR-061) asked whether they should be decomposed along reactor / FD-owner / PAQS-dispatch responsibility lines.
+
+**Assessment outcome (v0.7 Sprint 2): keep current single-file shape; do not refactor in this sprint.**
+
+**Responsibility lines (informational map, not extraction targets):**
+
+`NativeTcpCarrier`:
+
+- **Engine lifecycle + config** — `TransportConfig` / `MemoryAllocator` / `KernelCryptoProvider` injection, `running` / `closed` AtomicBooleans, acceptor thread, stream/connection counters.
+- **FFM socket backend selection + validation** — `SocketBackendMode` enum, `SocketBackendSelection` record, PosixHybrid / NIO fallback, `validateServerSocketBootstrap*` / `validateClientSocketBackend*` probes, Windows `bestEffortWsaCleanup`.
+- **Reactor loop** — `ReactorLoop` inner class: `Selector`, `pendingRequests` MPSC queue (PERF-063 — `MpscUnboundedArrayQueue`), `drainPendingRequests`, key dispatch.
+- **Acceptor / connection bootstrap** — `runAcceptorLoop`, `acceptPendingConnections`, `tryReserveConnectionSlot`, `buildAcceptedStream`, `registerAndHandshakeConnection`.
+- **Client-side ingress/writer pumps** — `runClientIngressLoop`, `runClientWriterLoop` Virtual Thread pumps with idle backoff.
+- **PAQS-dispatch read/flush path** — `readIngress`, `flushStream`, `adaptTlsIfNeeded`, `closeKeyStream`.
+
+`NativeTcpStream`:
+
+- Stream open/close state machine and FD-owner integration.
+- Outbound queue (`MpscUnboundedArrayQueue`) and write loop with TLS layering.
+- Inbound queue (`SpscArrayQueue` / `SpscUnboundedArrayQueue`) and read loop with TLS layering.
+- Backpressure / queue-depth bookkeeping for PAQS interaction.
+
+**Why not extract now:**
+
+1. **Tight coupling cost**: `ReactorLoop` is an inner class deliberately — its operational surface (`channelRuntimeRegistry`, `streamByChannel`, `closeKeyStream`, `readIngress`, `flushStream`) is intimate with carrier state. Promoting it to a top-level class requires ~10 callback / port references injected through the constructor, which trades an inner class for a callback-heavy delegate without measurable readability gain. Same risk applies to FD-owner / PAQS-dispatch extraction.
+2. **Active development collision risk**: v0.7 Sprint 5 (Kafka EventEngine), Sprint 6 (distributed integration), and PERF-061 / PERF-062 (HTTP/2 frame writer + TLS ingress slab) all touch transport hot paths. Decomposition during this window adds merge surface to every concurrent PR.
+3. **Sibling precedent**: SQ-006 raised the analogous question for `CoreFlowRuntime` and was deferred with a design note rather than a refactor PR. The same disposition applies here.
+4. **Heuristic vs hard rule**: the ">5 collaborators" rule is a signal, not a hard gate (CLAUDE.md §C heuristics). Class size alone does not justify forced decomposition when the cost outweighs the benefit.
+
+**When to revisit:**
+
+- If a future sprint introduces a second carrier (e.g., io_uring) that needs to share reactor/FD-owner code — at that point extraction yields a real reuse benefit.
+- If profiling data shows that the current class layout regresses inlining or escape analysis on the hot path (no current evidence).
+- If the file size exceeds ~2k LOC after Sprint 5/6 changes — at that scale revisit with profiling data and a measured refactor PR.
+
+Tracking: revisit alongside any io_uring / FFM-native carrier work (currently planned post-v0.7).
+
+---
+
 ## Summary
 
 The Transport subsystem is the high-performance gateway of the Exeris Kernel. With a Panama FFM TCP carrier and PAQS-enforced shedding, it delivers a zero-object-churn ingress path on every platform. The PAQS Scheduler makes this deterministic under load — shed decisions

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
@@ -408,17 +408,25 @@ final class CommunityHttp2SessionProcessor {
                                     Http2SessionContext session,
                                     int streamId,
                                     HttpResponse response) {
-        try (LoanedBuffer headerBlock = allocator.allocateNetwork(HTTP2_MAX_HEADER_BLOCK_BYTES)) {
+        // PERF-061: per-response reusable outbound carrier sized to MAX frame header + payload.
+        // One borrow replaces (1 HEADERS/CONTINUATION + N DATA) per-frame allocations from the
+        // pre-PERF-061 path. Frame writers receive a slice of this carrier and serialize the
+        // wire image in-place; no per-frame slab borrow + free cycle on the response hot path.
+        try (LoanedBuffer headerBlock = allocator.allocateNetwork(HTTP2_MAX_HEADER_BLOCK_BYTES);
+             LoanedBuffer outboundFrame = allocator.allocateNetwork(
+                     Http2FrameParser.FRAME_HEADER_SIZE + HTTP2_MAX_FRAME_PAYLOAD_BYTES)) {
             long headerBytes = session.encodeResponseHeaders(headerBlock.segment(), response);
             LoanedBuffer bodyBuffer = response.body();
             int bodyBytes = bodyBuffer == null ? 0 : (int) bodyBuffer.size();
             boolean headerEndsStream = bodyBytes == 0;
-            writeHttp2HeaderBlockFrames(stream, streamId, headerBlock.segment(), (int) headerBytes, headerEndsStream);
+            writeHttp2HeaderBlockFrames(stream, streamId, headerBlock.segment(), (int) headerBytes,
+                    headerEndsStream, outboundFrame);
 
             if (bodyBuffer != null) {
                 try (bodyBuffer) {
                     if (bodyBytes > 0) {
-                        writeHttp2DataFrames(stream, streamId, bodyBuffer.segment(), bodyBytes);
+                        writeHttp2DataFrames(stream, streamId, bodyBuffer.segment(), bodyBytes,
+                                outboundFrame);
                     }
                 }
             }
@@ -436,7 +444,8 @@ final class CommunityHttp2SessionProcessor {
                                              int streamId,
                                              MemorySegment headerBlock,
                                              int headerLength,
-                                             boolean endStream) {
+                                             boolean endStream,
+                                             LoanedBuffer outboundFrame) {
         int written = 0;
         boolean firstFrame = true;
         while (written < headerLength) {
@@ -447,7 +456,7 @@ final class CommunityHttp2SessionProcessor {
             if (firstFrame && endStream) {
                 flags |= HTTP2_FLAG_END_STREAM;
             }
-            writeHttp2Frame(stream, type, flags, streamId, headerBlock, written, chunk);
+            writeHttp2Frame(stream, type, flags, streamId, headerBlock, written, chunk, outboundFrame);
             written += chunk;
             firstFrame = false;
         }
@@ -456,13 +465,15 @@ final class CommunityHttp2SessionProcessor {
     private void writeHttp2DataFrames(TransportStream stream,
                                       int streamId,
                                       MemorySegment body,
-                                      int bodyLength) {
+                                      int bodyLength,
+                                      LoanedBuffer outboundFrame) {
         int written = 0;
         while (written < bodyLength) {
             int chunk = Math.min(HTTP2_MAX_FRAME_PAYLOAD_BYTES, bodyLength - written);
             boolean endStream = (written + chunk) == bodyLength;
             int flags = endStream ? HTTP2_FLAG_END_STREAM : 0;
-            writeHttp2Frame(stream, Http2FrameType.DATA.code(), flags, streamId, body, written, chunk);
+            writeHttp2Frame(stream, Http2FrameType.DATA.code(), flags, streamId, body, written, chunk,
+                    outboundFrame);
             written += chunk;
         }
     }
@@ -473,21 +484,23 @@ final class CommunityHttp2SessionProcessor {
                                  int streamId,
                                  MemorySegment payloadSource,
                                  int payloadOffset,
-                                 int payloadLength) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(Http2FrameParser.FRAME_HEADER_SIZE + payloadLength)) {
-            Http2FrameEncoder.writeHeader(outbound.segment(), 0, payloadLength, frameType, flags, streamId);
-            if (payloadLength > 0) {
-                MemorySegment.copy(
-                        payloadSource,
-                        payloadOffset,
-                        outbound.segment(),
-                        Http2FrameParser.FRAME_HEADER_SIZE,
-                        payloadLength);
-            }
-            long written = Http2FrameParser.FRAME_HEADER_SIZE + (long) payloadLength;
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
+                                 int payloadLength,
+                                 LoanedBuffer outboundFrame) {
+        // PERF-061: serialize the frame wire image into the per-response reusable carrier.
+        // No allocator borrow on the per-frame path; the carrier is sized to one full frame
+        // (header + max payload) and is reused across every frame in the response.
+        Http2FrameEncoder.writeHeader(outboundFrame.segment(), 0, payloadLength, frameType, flags, streamId);
+        if (payloadLength > 0) {
+            MemorySegment.copy(
+                    payloadSource,
+                    payloadOffset,
+                    outboundFrame.segment(),
+                    Http2FrameParser.FRAME_HEADER_SIZE,
+                    payloadLength);
         }
+        long written = Http2FrameParser.FRAME_HEADER_SIZE + (long) payloadLength;
+        outboundFrame.setSize(written);
+        stream.write(outboundFrame.segment(), (int) written);
     }
 
     private void sendHttp2PingAck(TransportStream stream,

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -30,6 +30,7 @@ import eu.exeris.kernel.spi.transport.TransportConnection;
 import eu.exeris.kernel.spi.transport.TransportEngine;
 import eu.exeris.kernel.spi.transport.TransportMode;
 import eu.exeris.kernel.spi.transport.TransportStats;
+import org.jctools.queues.MpscUnboundedArrayQueue;
 
 import java.io.IOException;
 import java.lang.foreign.Arena;
@@ -51,7 +52,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1194,7 +1194,13 @@ public final class NativeTcpCarrier implements TransportEngine {
 
         private final int index;
         private final Selector selector;
-        private final Queue<ReactorRequest> pendingRequests = new ConcurrentLinkedQueue<>();
+        // PERF-063: MpscUnboundedArrayQueue replaces ConcurrentLinkedQueue. Multiple producer
+        // threads (any caller of enqueueRegistration / enqueueWriteInterest / cancelKey) feed a
+        // single consumer (the reactor thread in runLoop). MPSC semantics match exactly; chunked
+        // allocation (size 128) avoids per-element node alloc churn under burst arrivals; offer()
+        // on the unbounded variant always returns true so no backpressure handling is required at
+        // the call site (parity with the existing pattern in NativeTcpStream's outboundQueue).
+        private final Queue<ReactorRequest> pendingRequests = new MpscUnboundedArrayQueue<>(128);
         private final Set<SocketChannel> pendingWriteInterest = ConcurrentHashMap.newKeySet();
         private final AtomicBoolean wakeupPending = new AtomicBoolean(false);
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -480,39 +480,72 @@ final class NativeTcpStream implements TransportStream {
         if (!ensureTlsReady(false)) {
             return null;
         }
+        // PERF-062: fast-fail before allocation when offerIngress would reject.
+        // Saves the slab borrow + TLS unwrap on closing-stream / backpressured paths.
+        if (closed.get()) {
+            return null;
+        }
+        if (QUEUE_BACKPRESSURE_ENABLED && inboundQueueDepth.get() >= INBOUND_QUEUE_CAPACITY) {
+            return null;
+        }
 
-        try (LoanedBuffer ciphertextPlaceholder = allocator.allocateInfrastructure(1);
-             LoanedBuffer plaintext = allocator.allocateCarrierSlab(0)) {
+        LoanedBuffer ciphertextPlaceholder = allocator.allocateInfrastructure(1);
+        LoanedBuffer plaintext = allocator.allocateCarrierSlab(0);
+        // PERF-062: ownership-transfer flag replaces the prior retain()/auto-close ceremony.
+        // The successful return path keeps the buffer alive at refcount 1 without an extra
+        // retain+close pair; the unsuccessful path closes the slab in finally.
+        boolean transferred = false;
+        try {
             ciphertextPlaceholder.setSize(0);
             TlsStatus status;
             synchronized (tlsLock) {
                 status = tlsEngine.unwrap(ciphertextPlaceholder, plaintext);
             }
             if (status == TlsStatus.OK && plaintext.size() > 0) {
-                plaintext.retain();
+                transferred = true;
                 return plaintext;
             }
             if (status == TlsStatus.CLOSED) {
                 markRemoteClosed();
             }
             return null;
+        } finally {
+            ciphertextPlaceholder.close();
+            if (!transferred) {
+                plaintext.close();
+            }
         }
     }
 
     /* default */ LoanedBuffer decryptIngress(LoanedBuffer ciphertext, int length) {
-        try (LoanedBuffer plain = allocator.allocateNetwork(length)) {
+        // PERF-062: fast-fail before allocation when offerIngress would reject.
+        // Saves the network buffer borrow + TLS unwrap on backpressured / closing-stream paths.
+        if (closed.get()) {
+            return null;
+        }
+        if (QUEUE_BACKPRESSURE_ENABLED && inboundQueueDepth.get() >= INBOUND_QUEUE_CAPACITY) {
+            return null;
+        }
+        LoanedBuffer plain = allocator.allocateNetwork(length);
+        // PERF-062: ownership-transfer flag — see readTlsIngressFromFd for rationale.
+        boolean transferred = false;
+        try {
             TlsStatus status;
             synchronized (tlsLock) {
                 status = tlsEngine.unwrap(ciphertext, plain);
             }
             if (status == TlsStatus.OK && plain.size() > 0) {
-                plain.retain();
+                transferred = true;
                 return plain;
             }
             if (status == TlsStatus.CLOSED) {
                 close();
             }
             return null;
+        } finally {
+            if (!transferred) {
+                plain.close();
+            }
         }
     }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpTransportStressTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpTransportStressTest.java
@@ -40,6 +40,40 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Community TCP multi-carrier stress and concurrency tests.
+ *
+ * <h2>TCK-064 investigation status (Sprint 2 v0.7)</h2>
+ *
+ * <p>The {@code stressTest10ClientsWith4Reactors} method previously deadlocked under
+ * constrained CI environments (2 vCPU GitHub Actions runners) past the 2-minute Future
+ * timeout, while the same test passed deterministically locally in {@code <500 ms}
+ * across 5/5 runs. The investigation considered three hypotheses:
+ *
+ * <ol>
+ *   <li><b>Thread-pressure deadlock</b> — 10 client engines × 1 reactor + 4 server
+ *       reactors + 10 ForkJoinPool workers competing on 2 vCPUs. Mitigation deferred
+ *       to a future structural rewrite (single client engine + N streams pattern) so
+ *       the platform-thread count drops from ~24 to ~6.</li>
+ *   <li><b>{@code pendingRequests} ordering anomaly</b> — partially addressed by
+ *       PERF-063 (Sprint 2): {@code ConcurrentLinkedQueue} replaced with
+ *       {@link org.jctools.queues.MpscUnboundedArrayQueue}, whose single-consumer
+ *       guarantees are stronger than CLQ's under reactor wakeup contention.</li>
+ *   <li><b>Short-read assumption</b> — addressed below: {@code stream.read} is now
+ *       called in a short-read loop because TCP does not guarantee a single-shot
+ *       read of {@code MESSAGE_SIZE} bytes, particularly under load when receive
+ *       windows fragment.</li>
+ * </ol>
+ *
+ * <p>Tagged {@code @Tag("stress")} and excluded from the default Surefire run.
+ * Operators should wire a dedicated {@code transport-stress-gate} CI job
+ * ({@code -DincludedGroups=stress}) on a nightly schedule, optionally with
+ * {@code stress-ng --cpu N} on the runner to amplify thread-pressure conditions
+ * for hypothesis (1) regression coverage.
+ *
+ * @see eu.exeris.kernel.community.transport.NativeTcpCarrier
+ * @since 0.5.0 (TCK-064 documentation update: 0.7.0)
+ */
 @DisplayName("Community TCP: multi-carrier stress & concurrency")
 class NativeTcpTransportStressTest {
 
@@ -98,8 +132,11 @@ class NativeTcpTransportStressTest {
                                     stream.write(buf.segment(), MESSAGE_SIZE);
 
                                     try (LoanedBuffer response = ALLOCATOR.allocateNetwork(MESSAGE_SIZE)) {
-                                        int read = stream.read(response.segment(), MESSAGE_SIZE);
-                                        assertThat(read).isEqualTo(MESSAGE_SIZE);
+                                        // TCK-064: short-read loop. TCP read may return < MESSAGE_SIZE
+                                        // under fragmented receive windows; loop until the full payload
+                                        // arrives or the stream closes. Asserting equality on a single
+                                        // read was hypothesis (3) for the constrained-CI deadlock.
+                                        readFully(stream, response.segment(), MESSAGE_SIZE);
 
                                         byte[] echoed = new byte[MESSAGE_SIZE];
                                         response.segment().asSlice(0, MESSAGE_SIZE).asByteBuffer().get(echoed);
@@ -180,8 +217,8 @@ class NativeTcpTransportStressTest {
                             stream.write(buf.segment(), MESSAGE_SIZE);
 
                             try (LoanedBuffer response = ALLOCATOR.allocateNetwork(MESSAGE_SIZE)) {
-                                int read = stream.read(response.segment(), MESSAGE_SIZE);
-                                assertThat(read).isEqualTo(MESSAGE_SIZE);
+                                // TCK-064: short-read loop (see top-of-file Javadoc).
+                                readFully(stream, response.segment(), MESSAGE_SIZE);
                             }
                         }
                     }
@@ -206,6 +243,29 @@ class NativeTcpTransportStressTest {
             assertThat(messageCount.get())
                 .withFailMessage("Server did not receive expected message count")
                 .isEqualTo(6);
+        }
+    }
+
+    /**
+     * TCK-064: short-read loop. {@link TransportStream#read(MemorySegment, int)} is a
+     * single-shot read returning whatever is available (TCP receive-window slice), so
+     * a single call is not guaranteed to deliver {@code expectedBytes}. This helper
+     * loops, advancing into the target segment via {@link MemorySegment#asSlice(long)},
+     * until the full payload arrives or the peer closes the stream.
+     */
+    private static void readFully(TransportStream stream, MemorySegment target, int expectedBytes) {
+        int total = 0;
+        while (total < expectedBytes) {
+            int n = stream.read(target.asSlice(total), expectedBytes - total);
+            if (n < 0) {
+                throw new IllegalStateException(
+                        "Stream EOF before full payload arrived: read " + total + "/" + expectedBytes + " bytes");
+            }
+            if (n == 0) {
+                Thread.onSpinWait();
+                continue;
+            }
+            total += n;
         }
     }
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
@@ -57,6 +57,16 @@ final class CoreFlowRuntime { // NOPMD
     private final LongAdder failedFlows = new LongAdder();
     private final LongAdder compensationsRun = new LongAdder();
     private final LongAdder stepExecutions = new LongAdder();
+    // PERF-064: lifecycle baselines snapshotted on start()/close() instead of LongAdder.reset(),
+    // which is intrinsically racy under concurrent updates. Visible per-generation count is
+    // (totalSinceForever - baselineAtLifecycleTransition); baseline writes are atomic volatile
+    // longs, so a stale worker that survives interruptAndJoinRunningThreads' 5s join timeout
+    // cannot leave the next generation with a non-zero residual.
+    private volatile long parkedFlowsBaseline;
+    private volatile long completedFlowsBaseline;
+    private volatile long failedFlowsBaseline;
+    private volatile long compensationsRunBaseline;
+    private volatile long stepExecutionsBaseline;
     private final AtomicInteger queueDepth = new AtomicInteger();
     private volatile FlowSnapshotStore snapshotStore;
     private volatile IdempotencyGuard guard;
@@ -84,11 +94,11 @@ final class CoreFlowRuntime { // NOPMD
     public FlowEngineStats stats() {
         return new FlowEngineStats(
                 activeFlows.get(),
-                parkedFlows.sum(),
-                completedFlows.sum(),
-                failedFlows.sum(),
-                compensationsRun.sum(),
-                stepExecutions.sum(),
+                Math.max(0L, parkedFlows.sum() - parkedFlowsBaseline),
+                completedFlows.sum() - completedFlowsBaseline,
+                failedFlows.sum() - failedFlowsBaseline,
+                compensationsRun.sum() - compensationsRunBaseline,
+                stepExecutions.sum() - stepExecutionsBaseline,
                 0,
                 -1
         );
@@ -131,7 +141,7 @@ final class CoreFlowRuntime { // NOPMD
         clearParkedLookupMissTracking();
         activeFlows.set(0);
         queueDepth.set(0);
-        parkedFlows.reset();
+        parkedFlowsBaseline = parkedFlows.sum();
     }
 
     @SuppressWarnings("java:S2142")
@@ -200,11 +210,13 @@ final class CoreFlowRuntime { // NOPMD
     private void resetLifecycleTotals() {
         activeFlows.set(0);
         queueDepth.set(0);
-        parkedFlows.reset();
-        completedFlows.reset();
-        failedFlows.reset();
-        compensationsRun.reset();
-        stepExecutions.reset();
+        // PERF-064: snapshot baselines instead of LongAdder.reset() — atomic per-counter,
+        // race-safe against stale workers that may have survived the close() join timeout.
+        parkedFlowsBaseline = parkedFlows.sum();
+        completedFlowsBaseline = completedFlows.sum();
+        failedFlowsBaseline = failedFlows.sum();
+        compensationsRunBaseline = compensationsRun.sum();
+        stepExecutionsBaseline = stepExecutions.sum();
     }
 
     private FlowEngineException engineNotStarted() {


### PR DESCRIPTION
PERF-064: replace LongAdder.reset() with baseline gating in CoreFlowRuntime to eliminate the close()/start() race when interruptAndJoinRunningThreads hits its 5s timeout. Each lifecycle counter now exposes (totalSinceForever - baselineAtTransition); baseline writes are atomic volatile longs, so a stale worker increment after close cannot leave the next generation with a non-zero residual.

PERF-063: replace ConcurrentLinkedQueue with MpscUnboundedArrayQueue in NativeTcpCarrier.ReactorLoop.pendingRequests. MPSC semantics match exactly (many enqueueRegistration/enqueueWriteInterest/cancelKey producers, single reactor consumer); chunked allocation avoids per-element node alloc churn under burst arrivals; matches the pattern already used in NativeTcpStream.outboundQueue.

HEUR-061: design-note assessment instead of refactor. NativeTcpCarrier and NativeTcpStream stay single-file; full responsibility-line decomposition deferred until io_uring carrier work or 2k LOC threshold (whichever arrives first). Documented in docs/subsystems/transport.md.

PERF-062: TLS ingress hot path in NativeTcpStream.decryptIngress and readTlsIngressFromFd. Fast-fail check before allocation when offerIngress would reject (closed stream / queue at capacity); ownership-transfer flag replaces the retain()/auto-close ceremony around try-with-resources, so the success path no longer pays a retain+close pair.

PERF-061: HTTP/2 frame writer in CommunityHttp2SessionProcessor uses a per-response reusable outbound carrier sized to MAX frame header + payload. One borrow now replaces N per-frame allocations on the (HEADERS/CONTINUATION
+ N DATA) wire-image path. Handshake helpers (PING ACK, SETTINGS, RST_STREAM, GOAWAY) keep per-call allocation since they are one-shot and rare.

TCK-064: NativeTcpTransportStressTest gains a readFully short-read loop — TransportStream.read returns whatever is available, not necessarily the full requested size. The single-shot read assertion was hypothesis (3) for the constrained-CI deadlock. Hypothesis (2) (CLQ ordering anomaly) is addressed by PERF-063 above. Hypothesis (1) (thread-pressure deadlock with 10 client engines × 1 reactor + 4 server reactors on 2 vCPUs) requires a structural refactor (single client engine + N streams) deferred to v0.8. Investigation status documented in the test class Javadoc; transport-stress-gate nightly CI job (-DincludedGroups=stress) still recommended at the ops level.

Verification:
- Core Flow tests: 45/45 green (PERF-064 baseline behavior preserved)
- Community transport/HTTP/Flow sweep: 184 tests, 0 failures, 0 errors, 2 skipped (stress + bench, default-excluded by tag)
- Stress variant under -Dgroups=stress: 4.5s green locally with PERF-063
  + short-read fix applied