### PR TITLE
v0.7 Sprint 3: durable JDBC FlowSnapshotStore (EPIC-1 part 1)

### DIFF
--- a/docs/subsystems/flow.md
+++ b/docs/subsystems/flow.md
@@ -101,9 +101,21 @@ Flow can be driven by external events through the choreography bridge:
 
 For choreography-driven wake, the in-memory parked map remains the O(1) fast path during a live runtime.
 
-When persistence is enabled, a restart-aware implementation may consult `FlowSnapshotStore` only after an in-memory miss to recover a `PARKED` `FlowContext` for wake. That fallback is a bounded miss-path rather than an unbounded repeated store probe: repeated unknown-flow misses should be negatively suppressed in Core so persistence cost does not amplify under choreography polling. This fallback does not change The Wall: Core continues to orchestrate through SPI contracts only, and persistence details remain hidden behind `FlowSnapshotStore`.
+When persistence is enabled, a restart-aware implementation may consult `FlowSnapshotStore` only after an in-memory miss to recover a `PARKED` `FlowContext` for wake. That fallback is a bounded miss-path rather than an unbounded repeated store probe: repeated unknown-flow misses are negatively suppressed in `CoreFlowRuntime` via a `parkedLookupMisses` set capped at 256 entries with FIFO eviction (`MAX_PARKED_LOOKUP_MISSES`). The cache is cleared on every successful lookup, on park/wake/complete transitions, on plan recompilation, and on engine restart. This bounds persistence cost under choreography polling without ever masking a genuine PARKED instance.
+
+This fallback does not change The Wall: Core continues to orchestrate through SPI contracts only, and persistence details remain hidden behind `FlowSnapshotStore`.
 
 If persistence is disabled, cross-restart choreography wake remains unsupported by contract.
+
+### Distributed Snapshot Store Contract (since 0.7.0)
+
+Three additions land in 0.7 to support distributed saga state per ADR-013:
+
+- **`FlowSnapshotStore.listParked()`** — returns every snapshot whose state is `PARKED`. The default returns `List.of()` (correct for in-memory stores that do not survive restart). Durable stores (`JdbcFlowSnapshotStore`) override to enumerate every parked row so the engine can resume choreography on the cross-restart fallback path. Cold path; pagination is not required for v0.7.
+- **`FlowSnapshot.schemaVersion: long`** — monotonic optimistic-locking version. New snapshots use `FlowSnapshot.SCHEMA_VERSION_INITIAL` (`1L`); on every accepted save (INSERT or UPDATE) the durable store advances the on-disk version by exactly one. The runtime engine round-trips this version through `RuntimeFlowInstance.schemaVersion()` / `markPersisted()` so subsequent saves carry the up-to-date expected version. Stale-version writes are rejected with `EX-FLOW-7002` `phase=OPTIMISTIC_LOCK_CONFLICT` (`reasonCode=STALE_VERSION`, `contextVal=incomingSchemaVersion`).
+- **`JdbcFlowSnapshotStore`** (Community) — durable JDBC implementation backed by the `exeris_saga_state` table (created via `db/migration/V0.7.0__create_saga_state.sql`). Constructor-injected `DataSource` (HikariCP in Community); raw JDBC, no `PersistenceEngine` dependency. The save path is a portable two-step UPDATE-then-INSERT: an UPDATE with a CAS guard on `schema_version` is attempted first; on affected-rows = 0 the implementation distinguishes "row absent" (→ INSERT) from "row present with stale version" (→ raise `EX-FLOW-7002`). `compensation_stack` is packed into `BYTEA` (4 bytes per int, big-endian) for cross-database portability — H2 does not support native `INT[]`. `state` is stored as TEXT (`FlowState.name()`); `last_update` and `timeout_at` as `TIMESTAMPTZ`; `Instant.MAX` is encoded as NULL and decoded back to `Instant.MAX` because it falls outside the TIMESTAMPTZ range (4713 BC..294276 AD).
+
+In-memory bindings (`CommunityFlowSnapshotStore`, test stores) continue to ignore `schemaVersion`; the `markPersisted()` increment is harmless for them. Enterprise binding inherits the same SPI contract and TCK obligations on parity (`AbstractDistributedFlowSnapshotStoreTck`).
 
 ---
 
@@ -114,7 +126,7 @@ If persistence is disabled, cross-restart choreography wake remains unsupported 
 | Code           | Meaning                  | Glass-Box Payload (`rawArgs`)                                                                                                                           |
 |:---------------|:-------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `EX-FLOW-7001` | Provider Engine Failure  | `[0] String providerName, [1] String reason`                                                                                                            |
-| `EX-FLOW-7002` | Engine Lifecycle Failure | `[0] String engineName, [1] String phase, [2] String reasonCode, [3] int contextVal` — `phase` values include `SCHEMA_MISMATCH`, `WAKE_FAILED`, `SUBMIT_REJECTED` |
+| `EX-FLOW-7002` | Engine Lifecycle Failure | `[0] String engineName, [1] String phase, [2] String reasonCode, [3] int contextVal` — `phase` values include `START`, `STOP`, `COMPILE`, `SCHEDULE`, `SCHEMA_MISMATCH`, `WAKE_FAILED`, `SUBMIT_REJECTED`, `OPTIMISTIC_LOCK_CONFLICT` (since 0.7) |
 | `EX-FLOW-7003` | Step Execution Failure   | `[0] String definitionName, [1] long instanceIdMost, [2] long instanceIdLeast, [3] int stepIndex, [4] String staticReasonCode ("STEP_FAILED" \| "COMPENSATION_FAILED"), [5] String causeType` |
 | `EX-FLOW-7004` | Registry Conflict        | `[0] int stepId, [1] String reason`                                                                                                                     |
 
@@ -133,7 +145,8 @@ If persistence is disabled, cross-restart choreography wake remains unsupported 
 | `AbstractIdempotencyGuardTck` | `exeris-kernel-tck` | Step-level deduplication contract for `IdempotencyGuard` |
 | `FlowZeroAllocTck` | `exeris-kernel-tck` | Zero-allocation assertion on hot flow scheduling path |
 | `FlowCarrierPinningTck` | `exeris-kernel-tck` | Flow orchestration does not pin Virtual Thread carrier |
+| `AbstractDistributedFlowSnapshotStoreTck` | `exeris-kernel-tck` | Durable snapshot store contract (since 0.7) — save/load round-trip, delete, listParked filter, cross-restart recovery, OCC stale-version conflict |
 
-Community bindings: `CommunityFlowEngineTckTest`, `CommunityFlowSchedulerTckTest`, `CommunityFlowChoreographyTckTest`, `CommunitySagaRecoveryTckTest`, `CommunityFlowCarrierPinningTckTest` in `exeris-kernel-community`.
+Community bindings: `CommunityFlowEngineTckTest`, `CommunityFlowSchedulerTckTest`, `CommunityFlowChoreographyTckTest`, `CommunitySagaRecoveryTckTest`, `CommunityFlowCarrierPinningTckTest`, `CommunityJdbcFlowSnapshotStoreTckIT` (Postgres via Testcontainers) in `exeris-kernel-community`.
 
 > **Gap:** `AbstractIdempotencyGuardTck` and `FlowZeroAllocTck` have no Community-tier concrete binding in `exeris-kernel-community/src/test/`. The `IdempotencyGuard` contract is covered only by unit-level tests; no community provider binding extends `AbstractIdempotencyGuardTck`. Tracking: see `docs/ROADMAP.md`.

--- a/docs/subsystems/persistence.md
+++ b/docs/subsystems/persistence.md
@@ -256,8 +256,13 @@ are the responsibility of the application layer or a dedicated migration tool.
 
 > **Exception — internal kernel tables:** The Community tier includes an opt-in migration path
 > (`persistence.run.migrations=true`) that executes built-in SQL scripts to create internal kernel
-> tables (`exeris_outbox`, `exeris_outbox_dlq`). This applies only to Kernel-owned tables and is
-> explicitly disabled by default.
+> tables (`exeris_outbox`, `exeris_outbox_dlq`, `exeris_saga_state` since 0.7). This applies only to
+> Kernel-owned tables and is explicitly disabled by default. The migration list is maintained in
+> `CommunityPersistenceEngine.MIGRATION_RESOURCES`; new internal tables follow the
+> `db/migration/V{version}__{name}.sql` naming convention. The runner is intentionally minimal
+> (string split on `;`, idempotent `CREATE TABLE IF NOT EXISTS`); it is not a Flyway substitute.
+> Application schemas continue to be the operator's responsibility (see the recommendation table
+> below).
 
 | Concern                             | Recommendation                                                                                           |
 |:------------------------------------|:---------------------------------------------------------------------------------------------------------|

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
@@ -121,7 +121,7 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
                     if (existsInTransaction(conn, snapshot.instanceIdMost(), snapshot.instanceIdLeast())) {
                         throw FlowEngineException.optimisticLockConflict(engineName, snapshot.schemaVersion());
                     }
-                    insertSnapshot(conn, snapshot);
+                    insertOrRemapPkConflict(conn, snapshot);
                 }
                 conn.commit();
             } catch (FlowEngineException occ) {
@@ -136,6 +136,43 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
         } catch (SQLException ex) {
             throw new FlowEngineException("Failed to acquire connection for save", ex);
         }
+    }
+
+    /**
+     * Performs the INSERT and remaps a concurrent-INSERT race on the composite PK to
+     * {@code OPTIMISTIC_LOCK_CONFLICT}. Between the {@code existsInTransaction} probe
+     * and this call, a concurrent first-writer may commit a row for the same instance;
+     * the resulting integrity-constraint violation (SQLState class {@code 23}) is the
+     * indistinguishable race-loser signal, so it surfaces under the same OCC contract
+     * documented in ADR-013 §5 — the loser of an INSERT race observes the same failure
+     * mode as the loser of a stale-version UPDATE race.
+     */
+    private void insertOrRemapPkConflict(Connection conn, FlowSnapshot snapshot) throws SQLException {
+        try {
+            insertSnapshot(conn, snapshot);
+        } catch (SQLException pkViolation) {
+            if (isIntegrityConstraintViolation(pkViolation)) {
+                throw FlowEngineException.optimisticLockConflict(engineName, snapshot.schemaVersion());
+            }
+            throw pkViolation;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given exception's SQLState is an ANSI integrity-constraint
+     * class (prefix {@code 23}) — covers Postgres {@code 23505} (unique_violation),
+     * H2 {@code 23505}, and any spec-conformant driver.
+     */
+    private static boolean isIntegrityConstraintViolation(SQLException ex) {
+        for (Throwable cur = ex; cur != null; cur = cur.getCause()) {
+            if (cur instanceof SQLException sql) {
+                String state = sql.getSQLState();
+                if (state != null && state.startsWith("23")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.flow;
+
+import eu.exeris.kernel.spi.exceptions.flow.FlowEngineException;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshot;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshotStore;
+import eu.exeris.kernel.spi.flow.model.FlowState;
+
+import javax.sql.DataSource;
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Durable JDBC implementation of {@link FlowSnapshotStore} backed by the
+ * {@code exeris_saga_state} table (see ADR-013, FLOW-103).
+ *
+ * <h2>Optimistic Concurrency (ADR-013 §5)</h2>
+ * <p>{@link #save(FlowSnapshot)} attempts an UPDATE guarded by the incoming
+ * {@link FlowSnapshot#schemaVersion()}. On affected-rows = 0 the implementation
+ * distinguishes "row absent" (→ INSERT) from "row present with different version"
+ * (→ {@link FlowEngineException#optimisticLockConflict(String, long)} carrying
+ * {@code phase=OPTIMISTIC_LOCK_CONFLICT}, {@code reasonCode=STALE_VERSION}).
+ *
+ * <h2>Cross-Database Portability</h2>
+ * <p>The implementation does not rely on Postgres-specific constructs
+ * ({@code ON CONFLICT ... DO UPDATE}, {@code INT[]}). The two-step UPDATE/INSERT
+ * pattern works on any JDBC backend that supports composite primary keys and
+ * transactional isolation. {@code compensation_stack} is packed into {@code BYTEA}
+ * (4 bytes per int, big-endian, length {@code stackPointer * 4}) for the same
+ * reason — H2 does not support native {@code INT[]} columns.
+ *
+ * <h2>Thread Safety</h2>
+ * <p>This class is thread-safe by virtue of using a fresh connection per call.
+ * The contract assumes {@code dataSource} is a connection pool (HikariCP in
+ * Community); callers MUST NOT share a single physical connection across
+ * concurrent invocations.
+ *
+ * <h2>Hot-path Discipline (ADR-013 §7)</h2>
+ * <ul>
+ *   <li>No {@code ThreadLocal} for context propagation.</li>
+ *   <li>No {@code ByteBuffer.allocate(int)} on the hot path; {@code ByteBuffer.wrap(byte[])}
+ *       wraps an already-allocated array.</li>
+ *   <li>{@code DataSource} ownership stays with the bootstrapper that constructed this store.</li>
+ * </ul>
+ *
+ * @since 0.7.0
+ */
+public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
+
+    private static final String SQL_INSERT =
+            "INSERT INTO exeris_saga_state ("
+                    + "instance_id_most, instance_id_least, definition_name, current_step, "
+                    + "state, last_update, timeout_at, compensation_stack, stack_pointer, "
+                    + "opaque_state, schema_version) "
+                    + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SQL_UPDATE_OCC =
+            "UPDATE exeris_saga_state SET "
+                    + "definition_name = ?, current_step = ?, state = ?, "
+                    + "last_update = ?, timeout_at = ?, compensation_stack = ?, "
+                    + "stack_pointer = ?, opaque_state = ?, "
+                    + "schema_version = schema_version + 1 "
+                    + "WHERE instance_id_most = ? AND instance_id_least = ? "
+                    + "AND schema_version = ?";
+
+    private static final String SQL_SELECT_BY_PK =
+            "SELECT instance_id_most, instance_id_least, definition_name, current_step, "
+                    + "state, last_update, timeout_at, compensation_stack, stack_pointer, "
+                    + "opaque_state, schema_version "
+                    + "FROM exeris_saga_state "
+                    + "WHERE instance_id_most = ? AND instance_id_least = ?";
+
+    private static final String SQL_DELETE =
+            "DELETE FROM exeris_saga_state "
+                    + "WHERE instance_id_most = ? AND instance_id_least = ?";
+
+    private static final String SQL_EXISTS =
+            "SELECT 1 FROM exeris_saga_state "
+                    + "WHERE instance_id_most = ? AND instance_id_least = ?";
+
+    private static final String SQL_LIST_PARKED =
+            "SELECT instance_id_most, instance_id_least, definition_name, current_step, "
+                    + "state, last_update, timeout_at, compensation_stack, stack_pointer, "
+                    + "opaque_state, schema_version "
+                    + "FROM exeris_saga_state "
+                    + "WHERE state = '" + /* FlowState.PARKED.name() */ "PARKED" + "'";
+
+    private final DataSource dataSource;
+    private final String engineName;
+
+    public JdbcFlowSnapshotStore(DataSource dataSource, String engineName) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+        this.engineName = Objects.requireNonNull(engineName, "engineName");
+    }
+
+    @Override
+    public void save(FlowSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        try (Connection conn = dataSource.getConnection()) {
+            boolean originalAutoCommit = conn.getAutoCommit();
+            conn.setAutoCommit(false);
+            try {
+                int affected = tryOptimisticUpdate(conn, snapshot);
+                if (affected == 0) {
+                    if (existsInTransaction(conn, snapshot.instanceIdMost(), snapshot.instanceIdLeast())) {
+                        throw FlowEngineException.optimisticLockConflict(engineName, snapshot.schemaVersion());
+                    }
+                    insertSnapshot(conn, snapshot);
+                }
+                conn.commit();
+            } catch (FlowEngineException occ) {
+                conn.rollback();
+                throw occ;
+            } catch (SQLException ex) {
+                conn.rollback();
+                throw new FlowEngineException("Failed to save flow snapshot", ex);
+            } finally {
+                conn.setAutoCommit(originalAutoCommit);
+            }
+        } catch (SQLException ex) {
+            throw new FlowEngineException("Failed to acquire connection for save", ex);
+        }
+    }
+
+    @Override
+    public Optional<FlowSnapshot> load(long instanceIdMost, long instanceIdLeast) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(SQL_SELECT_BY_PK)) {
+            ps.setLong(1, instanceIdMost);
+            ps.setLong(2, instanceIdLeast);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(readSnapshot(rs));
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException ex) {
+            throw new FlowEngineException("Failed to load flow snapshot", ex);
+        }
+    }
+
+    @Override
+    public void delete(long instanceIdMost, long instanceIdLeast) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(SQL_DELETE)) {
+            ps.setLong(1, instanceIdMost);
+            ps.setLong(2, instanceIdLeast);
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            throw new FlowEngineException("Failed to delete flow snapshot", ex);
+        }
+    }
+
+    @Override
+    public boolean exists(long instanceIdMost, long instanceIdLeast) {
+        try (Connection conn = dataSource.getConnection()) {
+            return existsInTransaction(conn, instanceIdMost, instanceIdLeast);
+        } catch (SQLException ex) {
+            throw new FlowEngineException("Failed to query snapshot existence", ex);
+        }
+    }
+
+    @Override
+    public List<FlowSnapshot> listParked() {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(SQL_LIST_PARKED);
+             ResultSet rs = ps.executeQuery()) {
+            List<FlowSnapshot> parked = new ArrayList<>();
+            while (rs.next()) {
+                parked.add(readSnapshot(rs));
+            }
+            return parked;
+        } catch (SQLException ex) {
+            throw new FlowEngineException("Failed to enumerate parked snapshots", ex);
+        }
+    }
+
+    private int tryOptimisticUpdate(Connection conn, FlowSnapshot snapshot) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(SQL_UPDATE_OCC)) {
+            // SET clause bindings (1..8): definition_name, current_step, state,
+            // last_update, timeout_at, compensation_stack, stack_pointer, opaque_state.
+            bindSnapshotPayload(ps, snapshot, 1);
+            // WHERE clause bindings (9..11): instance_id_most, instance_id_least, schema_version.
+            ps.setLong(9, snapshot.instanceIdMost());
+            ps.setLong(10, snapshot.instanceIdLeast());
+            ps.setLong(11, snapshot.schemaVersion());
+            return ps.executeUpdate();
+        }
+    }
+
+    private void insertSnapshot(Connection conn, FlowSnapshot snapshot) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(SQL_INSERT)) {
+            ps.setLong(1, snapshot.instanceIdMost());
+            ps.setLong(2, snapshot.instanceIdLeast());
+            // definition_name, current_step, state, last_update, timeout_at,
+            // compensation_stack, stack_pointer, opaque_state -> bindings 3..10.
+            bindSnapshotPayload(ps, snapshot, 3);
+            // ADR-013 §5: advance the on-disk version by exactly one on every accepted
+            // write — INSERT and UPDATE share this semantic, so the caller can blindly
+            // bump its local schemaVersion by 1 after any successful save.
+            ps.setLong(11, snapshot.schemaVersion() + 1L);
+            ps.executeUpdate();
+        }
+    }
+
+    /**
+     * Binds the eight payload columns (definition_name through opaque_state) starting at
+     * the given JDBC parameter index. Used by both INSERT (offset 3) and UPDATE (offset 1).
+     */
+    private static void bindSnapshotPayload(PreparedStatement ps, FlowSnapshot snapshot,
+                                            int startIndex) throws SQLException {
+        int idx = startIndex;
+        ps.setString(idx++, snapshot.definitionName());
+        ps.setInt(idx++, snapshot.currentStep());
+        ps.setString(idx++, snapshot.state().name());
+        ps.setTimestamp(idx++, Timestamp.from(snapshot.lastUpdate()));
+        // Instant.MAX cannot fit in TIMESTAMPTZ (4713 BC..294276 AD); encode as NULL and
+        // decode back to Instant.MAX in readSnapshot. Matches RuntimeFlowInstance.fromSnapshot
+        // semantics for "no timeout".
+        Instant timeout = snapshot.timeout();
+        if (Instant.MAX.equals(timeout)) {
+            ps.setNull(idx++, java.sql.Types.TIMESTAMP_WITH_TIMEZONE);
+        } else {
+            ps.setTimestamp(idx++, Timestamp.from(timeout));
+        }
+        ps.setBytes(idx++, packCompensationStack(snapshot));
+        ps.setInt(idx++, snapshot.stackPointer());
+        byte[] opaque = snapshot.opaqueState();
+        if (opaque.length == 0) {
+            ps.setNull(idx, java.sql.Types.VARBINARY);
+        } else {
+            ps.setBytes(idx, opaque);
+        }
+    }
+
+    private static byte[] packCompensationStack(FlowSnapshot snapshot) {
+        int sp = snapshot.stackPointer();
+        if (sp == 0) {
+            return new byte[0];
+        }
+        int[] stack = snapshot.compensationStack();
+        byte[] bytes = new byte[sp * 4];
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        for (int i = 0; i < sp; i++) {
+            buf.putInt(stack[i]);
+        }
+        return bytes;
+    }
+
+    private static int[] unpackCompensationStack(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return new int[0];
+        }
+        int count = bytes.length / 4;
+        int[] result = new int[count];
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        for (int i = 0; i < count; i++) {
+            result[i] = buf.getInt();
+        }
+        return result;
+    }
+
+    private static FlowSnapshot readSnapshot(ResultSet rs) throws SQLException {
+        long instanceIdMost = rs.getLong("instance_id_most");
+        long instanceIdLeast = rs.getLong("instance_id_least");
+        String definitionName = rs.getString("definition_name");
+        int currentStep = rs.getInt("current_step");
+        FlowState state = FlowState.valueOf(rs.getString("state"));
+        Instant lastUpdate = rs.getTimestamp("last_update").toInstant();
+        Timestamp timeoutTs = rs.getTimestamp("timeout_at");
+        Instant timeout = timeoutTs == null ? Instant.MAX : timeoutTs.toInstant();
+        int[] compensationStack = unpackCompensationStack(rs.getBytes("compensation_stack"));
+        int stackPointer = rs.getInt("stack_pointer");
+        byte[] opaqueState = rs.getBytes("opaque_state");
+        if (opaqueState == null) {
+            opaqueState = new byte[0];
+        }
+        long schemaVersion = rs.getLong("schema_version");
+        return new FlowSnapshot(
+                instanceIdMost, instanceIdLeast,
+                definitionName, currentStep, state,
+                lastUpdate, timeout,
+                compensationStack, stackPointer,
+                opaqueState, schemaVersion);
+    }
+
+    private static boolean existsInTransaction(Connection conn, long instanceIdMost, long instanceIdLeast)
+            throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(SQL_EXISTS)) {
+            ps.setLong(1, instanceIdMost);
+            ps.setLong(2, instanceIdLeast);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceEngine.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceEngine.java
@@ -65,7 +65,8 @@ final class CommunityPersistenceEngine implements PersistenceEngine, PhysicalCon
     private static final String REQUIRED_SHARED_INTERCEPTOR = "RlsConnectionInterceptor";
     private static final String RUN_MIGRATIONS_KEY = "run.migrations";
     private static final List<String> MIGRATION_RESOURCES = List.of(
-            "db/migration/V0.5.0__create_outbox.sql"
+            "db/migration/V0.5.0__create_outbox.sql",
+            "db/migration/V0.7.0__create_saga_state.sql"
     );
 
     private final PersistenceConfig config;

--- a/exeris-kernel-community/src/main/resources/db/migration/V0.7.0__create_saga_state.sql
+++ b/exeris-kernel-community/src/main/resources/db/migration/V0.7.0__create_saga_state.sql
@@ -1,0 +1,34 @@
+-- ADR-013 / FLOW-103: durable saga state for distributed FlowSnapshotStore.
+--
+-- Composite PK on (instance_id_most, instance_id_least) is the 128-bit flow instance UUID
+-- split into two BIGINT halves. This avoids any UUID-typed column dependency and keeps the
+-- schema portable across Postgres and H2 (developer-loop fallback).
+--
+-- compensation_stack is packed BYTEA (4 bytes per int, big-endian, length stack_pointer * 4)
+-- rather than INT[] for cross-database portability — H2 does not support native int arrays.
+--
+-- schema_version is the monotonic optimistic-locking version (see FlowSnapshot.SCHEMA_VERSION_INITIAL
+-- and ADR-013 §5). Durable stores MUST advance it on every accepted write and reject writes
+-- whose incoming value does not match the on-disk row, raising EX-FLOW-7002 with
+-- phase=OPTIMISTIC_LOCK_CONFLICT.
+
+CREATE TABLE IF NOT EXISTS exeris_saga_state (
+    instance_id_most    BIGINT       NOT NULL,
+    instance_id_least   BIGINT       NOT NULL,
+    definition_name     TEXT         NOT NULL,
+    current_step        INT          NOT NULL,
+    state               TEXT         NOT NULL,
+    last_update         TIMESTAMP WITH TIME ZONE NOT NULL,
+    timeout_at          TIMESTAMP WITH TIME ZONE,
+    compensation_stack  BYTEA        NOT NULL,
+    stack_pointer       INT          NOT NULL,
+    opaque_state        BYTEA,
+    schema_version      BIGINT       NOT NULL DEFAULT 1,
+    PRIMARY KEY (instance_id_most, instance_id_least)
+);
+
+-- Partial index for the listParked() recovery enumeration. Predicate matches the
+-- FlowState.PARKED.name() string emitted by JdbcFlowSnapshotStore.
+CREATE INDEX IF NOT EXISTS idx_exeris_saga_state_parked
+    ON exeris_saga_state (last_update)
+    WHERE state = 'PARKED';

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/flow/CommunityJdbcFlowSnapshotStoreTckIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/flow/CommunityJdbcFlowSnapshotStoreTckIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.flow;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshotStore;
+import eu.exeris.kernel.tck.contract.flow.AbstractDistributedFlowSnapshotStoreTck;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Community binding for {@link AbstractDistributedFlowSnapshotStoreTck} using a real
+ * Postgres 16 instance via Testcontainers and a HikariCP pool.
+ *
+ * <p>The shared schema is bootstrapped once per class via the v0.7.0 migration script;
+ * each test starts with a fresh empty store created against the same database. The
+ * {@code reopenStore} method returns a brand-new {@code JdbcFlowSnapshotStore} backed
+ * by the same DataSource — that exercises the cross-restart contract without bouncing
+ * the container.
+ */
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community: JdbcFlowSnapshotStore distributed TCK (PostgreSQL)")
+class CommunityJdbcFlowSnapshotStoreTckIT extends AbstractDistributedFlowSnapshotStoreTck {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    private static HikariDataSource pool;
+
+    @BeforeAll
+    static void bootstrap() throws SQLException {
+        HikariConfig cfg = new HikariConfig();
+        cfg.setJdbcUrl(POSTGRES.getJdbcUrl());
+        cfg.setUsername(POSTGRES.getUsername());
+        cfg.setPassword(POSTGRES.getPassword());
+        cfg.setMaximumPoolSize(8);
+        pool = new HikariDataSource(cfg);
+
+        String migrationSql = readMigrationResource("db/migration/V0.7.0__create_saga_state.sql");
+        try (Connection conn = pool.getConnection()) {
+            for (String stmt : splitStatements(migrationSql)) {
+                try (Statement s = conn.createStatement()) {
+                    s.execute(stmt);
+                }
+            }
+        }
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (pool != null) {
+            pool.close();
+            pool = null;
+        }
+    }
+
+    @Override
+    protected FlowSnapshotStore createStore() {
+        truncateSagaState();
+        return new JdbcFlowSnapshotStore(pool, "tck-engine");
+    }
+
+    @Override
+    protected FlowSnapshotStore reopenStore(FlowSnapshotStore current) {
+        // Same DataSource (i.e., same database) but a fresh store instance — the
+        // contract is "data outlives a kernel restart", which the shared pool simulates
+        // without bouncing the container.
+        return new JdbcFlowSnapshotStore(pool, "tck-engine-restarted");
+    }
+
+    private static void truncateSagaState() {
+        try (Connection conn = pool.getConnection();
+             Statement s = conn.createStatement()) {
+            s.execute("TRUNCATE TABLE exeris_saga_state");
+        } catch (SQLException ex) {
+            throw new IllegalStateException("Failed to truncate exeris_saga_state", ex);
+        }
+    }
+
+    private static String readMigrationResource(String resourcePath) {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try (InputStream in = cl.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing SQL migration resource: " + resourcePath);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException ioEx) {
+            throw new UncheckedIOException("Failed to read migration: " + resourcePath, ioEx);
+        }
+    }
+
+    private static List<String> splitStatements(String sql) {
+        List<String> out = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inLineComment = false;
+        for (int i = 0; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            if (inLineComment) {
+                if (c == '\n') {
+                    inLineComment = false;
+                }
+                continue;
+            }
+            if (c == '-' && i + 1 < sql.length() && sql.charAt(i + 1) == '-') {
+                inLineComment = true;
+                i++;
+                continue;
+            }
+            if (c == ';') {
+                String trimmed = current.toString().trim();
+                if (!trimmed.isEmpty()) {
+                    out.add(trimmed);
+                }
+                current.setLength(0);
+                continue;
+            }
+            current.append(c);
+        }
+        String tail = current.toString().trim();
+        if (!tail.isEmpty()) {
+            out.add(tail);
+        }
+        return out;
+    }
+
+    @SuppressWarnings({"PMD.UnusedPrivateMethod", "unused"})
+    private static DataSource sharedDataSource() {
+        return pool;
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
@@ -761,6 +761,10 @@ final class CoreFlowRuntime { // NOPMD
         }
         clearParkedLookupMiss(instance.key());
         snapshotStore.save(instance.toSnapshot(state, stepIndex));
+        // ADR-013 §5: durable stores advance schema_version by one on every accepted write.
+        // Mirror that increment locally so the next save carries the now-current expected
+        // version. In-memory bindings ignore schemaVersion, so the bump is harmless there.
+        instance.markPersisted();
     }
 
     private final class Scheduler implements FlowScheduler {

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 @SuppressWarnings("PMD.PublicMemberInNonPublicType")
 final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPMD
@@ -44,8 +45,13 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
     // fromContext seeds this to FlowSnapshot.SCHEMA_VERSION_INITIAL (new instance — never
     // saved); fromSnapshot reads back the loaded version so subsequent saves stay aligned
     // with the on-disk row. Bumped via markPersisted() after every accepted save (INSERT
-    // and UPDATE both advance by one — see JdbcFlowSnapshotStore).
-    private volatile long schemaVersion;
+    // and UPDATE both advance by one in any compliant durable store).
+    //
+    // AtomicLong rather than volatile long: read-modify-write on volatile is not atomic
+    // (java:S3078) and we cannot rely on the per-instance monitor for every call site of
+    // markPersisted() to make the increment safe — the durable-store contract permits
+    // multiple persist paths, and AtomicLong removes the dependency on caller discipline.
+    private final AtomicLong schemaVersion;
 
     private RuntimeFlowInstance(FlowKey key,
                                 String definitionName,
@@ -67,7 +73,7 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
         this.timeoutNanos = timeoutNanos;
         this.compensationStack = compensationStack;
         this.stackPointer = stackPointer;
-        this.schemaVersion = schemaVersion;
+        this.schemaVersion = new AtomicLong(schemaVersion);
     }
 
     public static RuntimeFlowInstance fromContext(
@@ -245,7 +251,7 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
                 stack,
                 stackPointer,
                 EMPTY_OPAQUE_STATE,
-                schemaVersion
+                schemaVersion.get()
         );
     }
 
@@ -254,19 +260,18 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
      * for the next save (ADR-013 §5).
      */
     public long schemaVersion() {
-        return schemaVersion;
+        return schemaVersion.get();
     }
 
     /**
      * Advances the local view of {@code schemaVersion} after a successful save.
-     * Both INSERT and UPDATE paths in {@code JdbcFlowSnapshotStore} advance the
-     * on-disk version by exactly one, so the caller bumps locally by one regardless
-     * of which path the store took. Callers MUST hold {@link #monitor()} when
-     * pairing this with a {@code save()} call to keep the toSnapshot/save/markPersisted
-     * sequence atomic per instance.
+     * Compliant durable stores advance the on-disk version by exactly one on every
+     * accepted write (INSERT or UPDATE), so the caller bumps locally by one
+     * regardless of which path the store took. The bump is atomic via {@link AtomicLong},
+     * so this method is safe under concurrent persist paths without external locking.
      */
     public void markPersisted() {
-        schemaVersion++;
+        schemaVersion.incrementAndGet();
     }
 
     public RuntimeFlowContext contextView() {

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
@@ -40,6 +40,12 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
     private volatile long timeoutNanos;
     private int[] compensationStack;
     private int stackPointer;
+    // ADR-013 §5: optimistic-lock version that round-trips with the durable snapshot store.
+    // fromContext seeds this to FlowSnapshot.SCHEMA_VERSION_INITIAL (new instance — never
+    // saved); fromSnapshot reads back the loaded version so subsequent saves stay aligned
+    // with the on-disk row. Bumped via markPersisted() after every accepted save (INSERT
+    // and UPDATE both advance by one — see JdbcFlowSnapshotStore).
+    private volatile long schemaVersion;
 
     private RuntimeFlowInstance(FlowKey key,
                                 String definitionName,
@@ -49,7 +55,8 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
                                 int currentStep,
                                 long timeoutNanos,
                                 int[] compensationStack,
-                                int stackPointer) {
+                                int stackPointer,
+                                long schemaVersion) {
         this.key = key;
         this.definitionName = definitionName;
         this.lifecycleGeneration = lifecycleGeneration;
@@ -60,6 +67,7 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
         this.timeoutNanos = timeoutNanos;
         this.compensationStack = compensationStack;
         this.stackPointer = stackPointer;
+        this.schemaVersion = schemaVersion;
     }
 
     public static RuntimeFlowInstance fromContext(
@@ -77,7 +85,8 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
                         ? context.timeoutNanos()
                         : System.nanoTime() + plan.timeoutDurationNanos(),
                 new int[Math.max(4, plan.stepCount())],
-                0
+                0,
+                FlowSnapshot.SCHEMA_VERSION_INITIAL
         );
     }
 
@@ -105,7 +114,8 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
                 snapshot.currentStep(),
                 timeoutNanos,
                 compensationStack,
-                snapshot.stackPointer()
+                snapshot.stackPointer(),
+                snapshot.schemaVersion()
         );
     }
 
@@ -234,8 +244,29 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
                 timeoutInstant(),
                 stack,
                 stackPointer,
-                EMPTY_OPAQUE_STATE
+                EMPTY_OPAQUE_STATE,
+                schemaVersion
         );
+    }
+
+    /**
+     * Returns the optimistic-lock version expected by the durable snapshot store
+     * for the next save (ADR-013 §5).
+     */
+    public long schemaVersion() {
+        return schemaVersion;
+    }
+
+    /**
+     * Advances the local view of {@code schemaVersion} after a successful save.
+     * Both INSERT and UPDATE paths in {@code JdbcFlowSnapshotStore} advance the
+     * on-disk version by exactly one, so the caller bumps locally by one regardless
+     * of which path the store took. Callers MUST hold {@link #monitor()} when
+     * pairing this with a {@code save()} call to keep the toSnapshot/save/markPersisted
+     * sequence atomic per instance.
+     */
+    public void markPersisted() {
+        schemaVersion++;
     }
 
     public RuntimeFlowContext contextView() {

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
@@ -76,9 +76,9 @@ public final class FlowEngineException extends ExerisKernelException {
 
     /**
      * Creates an exception for an optimistic-lock conflict on a durable snapshot store
-     * (see ADR-013). Raised when {@code save()} on {@code JdbcFlowSnapshotStore} (or any
-     * durable equivalent) finds the on-disk {@code schemaVersion} no longer matches the
-     * incoming snapshot's version — another kernel advanced the saga first.
+     * (see ADR-013). Raised when a durable {@code FlowSnapshotStore} implementation
+     * finds the on-disk {@code schemaVersion} no longer matches the incoming snapshot's
+     * version — another kernel advanced the saga first.
      *
      * <p>rawArgs layout: {@code [engineName, "OPTIMISTIC_LOCK_CONFLICT", "STALE_VERSION",
      * incomingSchemaVersion]}. The version is bound to {@code int}; saga rows that exceed

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
@@ -19,11 +19,13 @@ import eu.exeris.kernel.spi.exceptions.KernelErrorCodes;
  * <ul>
  *   <li>index 0 – {@code String} engineName</li>
  *   <li>index 1 – {@code String} phase — one of: {@code "START"}, {@code "STOP"},
- *       {@code "COMPILE"}, {@code "SCHEDULE"}</li>
+ *       {@code "COMPILE"}, {@code "SCHEDULE"}, {@code "OPTIMISTIC_LOCK_CONFLICT"} (since 0.7)</li>
  *   <li>index 2 – {@code String} staticReasonCode — stable identifier, never user-supplied
- *       (e.g. {@code "STARTUP_FAILED"}, {@code "COMPILE_FAILED"}, {@code "QUEUE_FULL"})</li>
+ *       (e.g. {@code "STARTUP_FAILED"}, {@code "COMPILE_FAILED"}, {@code "QUEUE_FULL"},
+ *       {@code "STALE_VERSION"})</li>
  *   <li>index 3 – {@code int} contextValue — phase-specific numeric context
- *       (e.g. current queue depth for SCHEDULE phase); {@code -1} when not applicable</li>
+ *       (e.g. current queue depth for SCHEDULE phase, incoming schemaVersion for
+ *       OPTIMISTIC_LOCK_CONFLICT); {@code -1} when not applicable</li>
  * </ul>
  *
  * @since 0.5.0
@@ -34,6 +36,7 @@ public final class FlowEngineException extends ExerisKernelException {
     private static final String REASON_STARTUP      = "STARTUP_FAILED";
     private static final String REASON_COMPILE      = "COMPILE_FAILED";
     private static final String REASON_QUEUE_FULL   = "QUEUE_FULL";
+    private static final String REASON_STALE_VERSION = "STALE_VERSION";
 
     public FlowEngineException(String message) {
         super(KernelErrorCodes.EX_FLOW_7002, message, (Throwable) null);
@@ -69,6 +72,27 @@ public final class FlowEngineException extends ExerisKernelException {
     public static FlowEngineException schedulerFull(String engineName, int queueDepth) {
         return new FlowEngineException(KernelErrorCodes.EX_FLOW_7002, MSG_ENGINE_FAILURE, null,
                 engineName, "SCHEDULE", REASON_QUEUE_FULL, queueDepth);
+    }
+
+    /**
+     * Creates an exception for an optimistic-lock conflict on a durable snapshot store
+     * (see ADR-013). Raised when {@code save()} on {@code JdbcFlowSnapshotStore} (or any
+     * durable equivalent) finds the on-disk {@code schemaVersion} no longer matches the
+     * incoming snapshot's version — another kernel advanced the saga first.
+     *
+     * <p>rawArgs layout: {@code [engineName, "OPTIMISTIC_LOCK_CONFLICT", "STALE_VERSION",
+     * incomingSchemaVersion]}. The version is bound to {@code int}; saga rows that exceed
+     * {@code Integer.MAX_VALUE} versions are not anticipated within the operational
+     * lifetime, but if needed callers may clamp via {@link Math#min}.
+     *
+     * @param engineName            the engine name
+     * @param incomingSchemaVersion the schemaVersion the caller attempted to write
+     * @since 0.7.0
+     */
+    public static FlowEngineException optimisticLockConflict(String engineName, long incomingSchemaVersion) {
+        int contextValue = (int) Math.min(incomingSchemaVersion, Integer.MAX_VALUE);
+        return new FlowEngineException(KernelErrorCodes.EX_FLOW_7002, MSG_ENGINE_FAILURE, null,
+                engineName, "OPTIMISTIC_LOCK_CONFLICT", REASON_STALE_VERSION, contextValue);
     }
 }
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshot.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  *
  * <h2>Optimistic Concurrency (since 0.7.0)</h2>
  * <p>{@code schemaVersion} carries a monotonic version counter that durable, distributed
- * stores (e.g., {@code JdbcFlowSnapshotStore}) use as an optimistic-locking discriminator
+ * {@link FlowSnapshotStore} implementations use as an optimistic-locking discriminator
  * on UPSERT. New snapshots SHOULD start at {@link #SCHEMA_VERSION_INITIAL}; durable stores
  * MUST advance the on-disk value on every accepted write and MUST reject a write whose
  * incoming {@code schemaVersion} does not match the on-disk row, raising

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshotStore.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshotStore.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.spi.flow.model;
 
+import java.util.List;
 import java.util.Optional;
 
 // ScopedValue is referenced in Javadoc only (@see KernelProviders#FLOW_SNAPSHOT_STORE)
@@ -83,5 +84,34 @@ public interface FlowSnapshotStore {
      * @return {@code true} if a snapshot exists
      */
     boolean exists(long instanceIdMost, long instanceIdLeast);
+
+    /**
+     * Returns every snapshot whose {@link FlowSnapshot#state()} is currently
+     * {@link FlowState#PARKED}. Used by the engine on startup and by the choreography
+     * wake fallback path to enumerate cross-restart parked instances (see ADR-013).
+     *
+     * <h2>Default Contract</h2>
+     * <p>The default implementation returns an empty list, which is the correct semantics
+     * for in-memory stores that do not survive restart. Durable, distributed stores
+     * (e.g., {@code JdbcFlowSnapshotStore}) MUST override to enumerate every parked
+     * snapshot so the engine can resume choreography on the cross-restart fallback path.
+     *
+     * <h2>Call Site</h2>
+     * <p>Cold path. Invoked at engine startup (one-shot) and on choreography wake when the
+     * in-memory parked-instance index misses (rare). Implementations MAY return a fully
+     * materialized list; pagination is not required for v0.7.
+     *
+     * <h2>Thread Safety</h2>
+     * <p>Implementations MUST be thread-safe. The returned list MUST be a snapshot —
+     * concurrent mutations to the store after the call returns MUST NOT be reflected in
+     * the result.
+     *
+     * @return list of parked snapshots; empty list if the store has none or does not
+     *         track parked instances
+     * @since 0.7.0
+     */
+    default List<FlowSnapshot> listParked() {
+        return List.of();
+    }
 }
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshotStore.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/model/FlowSnapshotStore.java
@@ -92,9 +92,9 @@ public interface FlowSnapshotStore {
      *
      * <h2>Default Contract</h2>
      * <p>The default implementation returns an empty list, which is the correct semantics
-     * for in-memory stores that do not survive restart. Durable, distributed stores
-     * (e.g., {@code JdbcFlowSnapshotStore}) MUST override to enumerate every parked
-     * snapshot so the engine can resume choreography on the cross-restart fallback path.
+     * for in-memory stores that do not survive restart. Durable, distributed store
+     * implementations MUST override this method to enumerate every parked snapshot so
+     * the engine can resume choreography on the cross-restart fallback path.
      *
      * <h2>Call Site</h2>
      * <p>Cold path. Invoked at engine startup (one-shot) and on choreography wake when the

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
@@ -253,26 +253,66 @@ public abstract class AbstractDistributedFlowSnapshotStoreTck {
     class ConcurrentSaveContention {
 
         @Test
-        @DisplayName("Two writers racing the same instance with the same incoming version: one wins, one gets OCC conflict")
+        @DisplayName("UPDATE race: two writers, same loaded version — one wins, the other observes OCC conflict")
         void concurrentSaveOnSameInstanceResolvesViaCas() throws Exception {
             UUID id = UUID.randomUUID();
             store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
             FlowSnapshot loaded = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
 
+            RaceOutcome outcome = raceTwoSavers(
+                    () -> store.save(snapshot(id, FlowState.RUNNING, 1, loaded.schemaVersion())));
+
+            assertThat(outcome.unexpected.get()).as("Unexpected error in racy writer").isNull();
+            assertThat(outcome.successes.get()).as("Exactly one writer should win the CAS race").isEqualTo(1);
+            assertThat(outcome.conflicts.get()).as("The losing writer must observe an OCC conflict").isEqualTo(1);
+
+            FlowSnapshot finalState = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+            assertThat(finalState.state()).isEqualTo(FlowState.RUNNING);
+            assertThat(finalState.schemaVersion()).isEqualTo(loaded.schemaVersion() + 1L);
+        }
+
+        @Test
+        @DisplayName("INSERT race: two first-writers for the same new instance — one wins, the other observes OCC conflict (TOCTOU contract)")
+        void concurrentFirstSaveOnNewInstanceResolvesViaPkRemap() throws Exception {
+            UUID id = UUID.randomUUID();
+            // No pre-existing row — both writers will hit the no-row branch inside save(),
+            // both pass the existsInTransaction probe, and then race on INSERT. The loser
+            // gets a primary-key integrity violation from the database which the durable
+            // store contract requires to be remapped to phase=OPTIMISTIC_LOCK_CONFLICT
+            // (ADR-013 §5) — without that remap the loser would surface an opaque SQL
+            // error and break the OCC failure-mode promise.
+
+            RaceOutcome outcome = raceTwoSavers(
+                    () -> store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL)));
+
+            assertThat(outcome.unexpected.get())
+                    .as("Concurrent INSERT loser must surface as FlowEngineException, not a raw SQL error")
+                    .isNull();
+            assertThat(outcome.successes.get()).as("Exactly one INSERT must succeed").isEqualTo(1);
+            assertThat(outcome.conflicts.get())
+                    .as("The losing INSERT must surface as OPTIMISTIC_LOCK_CONFLICT, not as an opaque SQL error")
+                    .isEqualTo(1);
+
+            // Exactly one row persisted; idempotency restored on the next attempt with a fresh load.
+            FlowSnapshot persisted = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+            assertThat(persisted.schemaVersion())
+                    .as("First successful save advances version by exactly one (ADR-013 §5)")
+                    .isEqualTo(FlowSnapshot.SCHEMA_VERSION_INITIAL + 1L);
+        }
+
+        private RaceOutcome raceTwoSavers(Runnable saveAction) throws Exception {
             CountDownLatch start = new CountDownLatch(1);
-            AtomicInteger successes = new AtomicInteger();
-            AtomicInteger conflicts = new AtomicInteger();
-            AtomicReference<Throwable> unexpected = new AtomicReference<>();
+            RaceOutcome outcome = new RaceOutcome();
 
             Runnable writer = () -> {
                 try {
                     start.await();
-                    store.save(snapshot(id, FlowState.RUNNING, 1, loaded.schemaVersion()));
-                    successes.incrementAndGet();
-                } catch (FlowEngineException occ) {
-                    conflicts.incrementAndGet();
-                } catch (Throwable t) { //NOPMD AvoidCatchingThrowable — racy test path needs to capture any error
-                    unexpected.set(t);
+                    saveAction.run();
+                    outcome.successes.incrementAndGet();
+                } catch (FlowEngineException _) {
+                    outcome.conflicts.incrementAndGet();
+                } catch (Throwable t) { //NOPMD AvoidCatchingThrowable — racy test path captures any error
+                    outcome.unexpected.set(t);
                 }
             };
 
@@ -283,14 +323,13 @@ public abstract class AbstractDistributedFlowSnapshotStoreTck {
             start.countDown();
             t1.join(TimeUnit.SECONDS.toMillis(10));
             t2.join(TimeUnit.SECONDS.toMillis(10));
+            return outcome;
+        }
 
-            assertThat(unexpected.get()).as("Unexpected error in racy writer").isNull();
-            assertThat(successes.get()).as("Exactly one writer should win the CAS race").isEqualTo(1);
-            assertThat(conflicts.get()).as("The losing writer must observe an OCC conflict").isEqualTo(1);
-
-            FlowSnapshot finalState = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
-            assertThat(finalState.state()).isEqualTo(FlowState.RUNNING);
-            assertThat(finalState.schemaVersion()).isEqualTo(loaded.schemaVersion() + 1L);
+        private final class RaceOutcome {
+            final AtomicInteger successes = new AtomicInteger();
+            final AtomicInteger conflicts = new AtomicInteger();
+            final AtomicReference<Throwable> unexpected = new AtomicReference<>();
         }
     }
 }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.flow;
+
+import eu.exeris.kernel.spi.exceptions.flow.FlowEngineException;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshot;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshotStore;
+import eu.exeris.kernel.spi.flow.model.FlowState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * L2 Contract: durable / distributed {@link FlowSnapshotStore} bindings (ADR-013, FLOW-106).
+ *
+ * <h2>Bindings</h2>
+ * <p>Concrete community / enterprise tests extend this class and provide:
+ * <ul>
+ *   <li>{@link #createStore()} — returns a fresh, empty store backed by a real durable
+ *       backend (e.g., Postgres via Testcontainers).</li>
+ *   <li>{@link #reopenStore(FlowSnapshotStore)} — returns a brand-new store instance
+ *       sharing the same underlying database, used to simulate a kernel restart for
+ *       cross-restart recovery assertions.</li>
+ * </ul>
+ *
+ * <h2>What this contract codifies</h2>
+ * <ul>
+ *   <li>save → load round-trip preserves every field, including {@code schemaVersion}.</li>
+ *   <li>{@code delete} removes the entry; subsequent {@code load} is empty and
+ *       {@code exists} returns {@code false}.</li>
+ *   <li>{@code listParked} returns only snapshots whose state is {@link FlowState#PARKED};
+ *       running, completed, or compensating snapshots are excluded.</li>
+ *   <li>Cross-restart simulation: snapshots saved through one store instance survive
+ *       a fresh store instance created against the same database.</li>
+ *   <li>Concurrent saves under contention: when two writers race on the same instance
+ *       with the same incoming {@code schemaVersion}, exactly one wins; the loser
+ *       receives {@link FlowEngineException} with {@code phase=OPTIMISTIC_LOCK_CONFLICT}.</li>
+ * </ul>
+ *
+ * @since 0.7.0
+ */
+@DisplayName("L2 TCK: Distributed FlowSnapshotStore — save/load/delete/listParked + OCC")
+public abstract class AbstractDistributedFlowSnapshotStoreTck {
+
+    private FlowSnapshotStore store;
+
+    /** Returns a fresh, empty store. Implementations are responsible for cleaning state. */
+    protected abstract FlowSnapshotStore createStore();
+
+    /**
+     * Returns a brand-new store instance sharing the same underlying database as
+     * {@code current}. Used to simulate a kernel restart while the data persists.
+     */
+    protected abstract FlowSnapshotStore reopenStore(FlowSnapshotStore current);
+
+    /** Optional: implementations may override to release resources (close pool, etc.). */
+    protected void disposeStore(FlowSnapshotStore current) {
+        // no-op by default
+    }
+
+    @BeforeEach
+    void setUpStore() {
+        store = createStore();
+    }
+
+    @AfterEach
+    void tearDownStore() {
+        if (store != null) {
+            disposeStore(store);
+            store = null;
+        }
+    }
+
+    private static FlowSnapshot snapshot(UUID id, FlowState state, int currentStep, long schemaVersion) {
+        return new FlowSnapshot(
+                id.getMostSignificantBits(),
+                id.getLeastSignificantBits(),
+                "demo-saga",
+                currentStep,
+                state,
+                Instant.parse("2026-05-02T10:00:00Z"),
+                Instant.parse("2026-05-02T11:00:00Z"),
+                new int[]{7, 9},
+                2,
+                new byte[]{0x01, 0x02},
+                schemaVersion);
+    }
+
+    @Nested
+    @DisplayName("save → load round-trip")
+    class SaveLoadRoundTrip {
+
+        @Test
+        @DisplayName("First save (no row) inserts; load returns equivalent snapshot with bumped schemaVersion")
+        void firstSaveInsertsRow() {
+            UUID id = UUID.randomUUID();
+            FlowSnapshot original = snapshot(id, FlowState.PARKED, 3, FlowSnapshot.SCHEMA_VERSION_INITIAL);
+
+            store.save(original);
+
+            Optional<FlowSnapshot> loaded = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits());
+            assertThat(loaded).isPresent();
+            FlowSnapshot got = loaded.orElseThrow();
+            assertThat(got.definitionName()).isEqualTo(original.definitionName());
+            assertThat(got.currentStep()).isEqualTo(original.currentStep());
+            assertThat(got.state()).isEqualTo(original.state());
+            assertThat(got.stackPointer()).isEqualTo(original.stackPointer());
+            assertThat(got.compensationStack()).containsExactly(7, 9);
+            assertThat(got.opaqueState()).containsExactly(0x01, 0x02);
+            assertThat(got.schemaVersion())
+                    .as("ADR-013 §5: durable stores advance schema_version by one on every accepted write")
+                    .isEqualTo(original.schemaVersion() + 1L);
+        }
+
+        @Test
+        @DisplayName("Second save with the loaded version succeeds (UPDATE) and bumps schemaVersion again")
+        void secondSaveWithLoadedVersionSucceeds() {
+            UUID id = UUID.randomUUID();
+            store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+
+            FlowSnapshot afterFirst = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+
+            FlowSnapshot updated = snapshot(id, FlowState.RUNNING, 5, afterFirst.schemaVersion());
+            store.save(updated);
+
+            FlowSnapshot afterSecond = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+            assertThat(afterSecond.state()).isEqualTo(FlowState.RUNNING);
+            assertThat(afterSecond.currentStep()).isEqualTo(5);
+            assertThat(afterSecond.schemaVersion()).isEqualTo(afterFirst.schemaVersion() + 1L);
+        }
+
+        @Test
+        @DisplayName("Stale schemaVersion on UPDATE raises EX-FLOW-7002 with phase=OPTIMISTIC_LOCK_CONFLICT")
+        void staleVersionRaisesOcc() {
+            UUID id = UUID.randomUUID();
+            store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+
+            FlowSnapshot loaded = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+            // First update bumps the on-disk version.
+            store.save(snapshot(id, FlowState.RUNNING, 1, loaded.schemaVersion()));
+
+            // Reusing the original loaded version is now stale.
+            FlowSnapshot staleAttempt = snapshot(id, FlowState.PARKED, 2, loaded.schemaVersion());
+            assertThatThrownBy(() -> store.save(staleAttempt))
+                    .isInstanceOf(FlowEngineException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("delete + exists semantics")
+    class DeleteAndExists {
+
+        @Test
+        @DisplayName("delete removes the row; subsequent load is empty and exists is false")
+        void deleteRemovesEntry() {
+            UUID id = UUID.randomUUID();
+            store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+            assertThat(store.exists(id.getMostSignificantBits(), id.getLeastSignificantBits())).isTrue();
+
+            store.delete(id.getMostSignificantBits(), id.getLeastSignificantBits());
+
+            assertThat(store.load(id.getMostSignificantBits(), id.getLeastSignificantBits())).isEmpty();
+            assertThat(store.exists(id.getMostSignificantBits(), id.getLeastSignificantBits())).isFalse();
+        }
+
+        @Test
+        @DisplayName("delete on non-existent row is a no-op")
+        void deleteOnAbsentInstanceIsNoOp() {
+            UUID id = UUID.randomUUID();
+            store.delete(id.getMostSignificantBits(), id.getLeastSignificantBits());
+            // No exception expected.
+            assertThat(store.exists(id.getMostSignificantBits(), id.getLeastSignificantBits())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("listParked enumeration")
+    class ListParkedContract {
+
+        @Test
+        @DisplayName("listParked returns only PARKED snapshots; running/completed are excluded")
+        void listParkedReturnsOnlyParked() {
+            UUID parkedA = UUID.randomUUID();
+            UUID parkedB = UUID.randomUUID();
+            UUID running = UUID.randomUUID();
+            UUID completed = UUID.randomUUID();
+
+            store.save(snapshot(parkedA, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+            store.save(snapshot(parkedB, FlowState.PARKED, 1, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+            store.save(snapshot(running, FlowState.RUNNING, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+            store.save(snapshot(completed, FlowState.COMPLETED, 9, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+
+            List<FlowSnapshot> parked = store.listParked();
+
+            assertThat(parked).hasSize(2);
+            assertThat(parked).allSatisfy(s -> assertThat(s.state()).isEqualTo(FlowState.PARKED));
+            assertThat(parked).extracting(FlowSnapshot::instanceIdMost)
+                    .containsExactlyInAnyOrder(parkedA.getMostSignificantBits(), parkedB.getMostSignificantBits());
+        }
+
+        @Test
+        @DisplayName("listParked on an empty store returns an empty list")
+        void emptyStoreReturnsEmpty() {
+            assertThat(store.listParked()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Cross-restart recovery")
+    class CrossRestartRecovery {
+
+        @Test
+        @DisplayName("Snapshot saved through store-A is visible through reopened store-B")
+        void persistedSnapshotSurvivesStoreReopen() {
+            UUID id = UUID.randomUUID();
+            store.save(snapshot(id, FlowState.PARKED, 4, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+
+            FlowSnapshotStore reopened = reopenStore(store);
+            try {
+                Optional<FlowSnapshot> loaded = reopened.load(
+                        id.getMostSignificantBits(), id.getLeastSignificantBits());
+                assertThat(loaded).isPresent();
+                assertThat(loaded.orElseThrow().currentStep()).isEqualTo(4);
+                assertThat(reopened.listParked()).hasSize(1);
+            } finally {
+                disposeStore(reopened);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Concurrent save under contention")
+    class ConcurrentSaveContention {
+
+        @Test
+        @DisplayName("Two writers racing the same instance with the same incoming version: one wins, one gets OCC conflict")
+        void concurrentSaveOnSameInstanceResolvesViaCas() throws Exception {
+            UUID id = UUID.randomUUID();
+            store.save(snapshot(id, FlowState.PARKED, 0, FlowSnapshot.SCHEMA_VERSION_INITIAL));
+            FlowSnapshot loaded = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicInteger successes = new AtomicInteger();
+            AtomicInteger conflicts = new AtomicInteger();
+            AtomicReference<Throwable> unexpected = new AtomicReference<>();
+
+            Runnable writer = () -> {
+                try {
+                    start.await();
+                    store.save(snapshot(id, FlowState.RUNNING, 1, loaded.schemaVersion()));
+                    successes.incrementAndGet();
+                } catch (FlowEngineException occ) {
+                    conflicts.incrementAndGet();
+                } catch (Throwable t) { //NOPMD AvoidCatchingThrowable — racy test path needs to capture any error
+                    unexpected.set(t);
+                }
+            };
+
+            Thread t1 = Thread.ofVirtual().unstarted(writer);
+            Thread t2 = Thread.ofVirtual().unstarted(writer);
+            t1.start();
+            t2.start();
+            start.countDown();
+            t1.join(TimeUnit.SECONDS.toMillis(10));
+            t2.join(TimeUnit.SECONDS.toMillis(10));
+
+            assertThat(unexpected.get()).as("Unexpected error in racy writer").isNull();
+            assertThat(successes.get()).as("Exactly one writer should win the CAS race").isEqualTo(1);
+            assertThat(conflicts.get()).as("The losing writer must observe an OCC conflict").isEqualTo(1);
+
+            FlowSnapshot finalState = store.load(id.getMostSignificantBits(), id.getLeastSignificantBits()).orElseThrow();
+            assertThat(finalState.state()).isEqualTo(FlowState.RUNNING);
+            assertThat(finalState.schemaVersion()).isEqualTo(loaded.schemaVersion() + 1L);
+        }
+    }
+}


### PR DESCRIPTION
FLOW-103a SPI surface
- FlowSnapshotStore.listParked() default returning List.of() — re-added per ADR-013 design intent, co-designed alongside JdbcFlowSnapshotStore so the Postgres-realistic shape (List<FlowSnapshot> for v0.7, pagination for v0.8 if needed) is informed by the actual implementation.
- FlowEngineException.optimisticLockConflict(engineName, incomingSchemaVersion) factory; phase=OPTIMISTIC_LOCK_CONFLICT, reasonCode=STALE_VERSION, contextValue=incoming version (clamped to int).

FLOW-103b auto-DDL
- db/migration/V0.7.0__create_saga_state.sql: composite-PK schema with TIMESTAMPTZ timestamps, BYTEA-packed compensation stack (cross-DB portability — H2 lacks native INT[]), partial index on state='PARKED'.
- CommunityPersistenceEngine.MIGRATION_RESOURCES extended.

FLOW-104 JdbcFlowSnapshotStore (Community)
- Constructor-injected DataSource + engineName; raw JDBC, no PersistenceEngine dependency (per FLOW-102).
- Two-step UPDATE-then-INSERT: optimistic UPDATE with CAS guard on schema_version; on affected=0, distinguish row-absent (INSERT) from stale-version (raise EX-FLOW-7002).
- Both INSERT and UPDATE advance on-disk schema_version by exactly one (ADR-013 §5 unified semantic) so callers blindly bump local version by 1 after any accepted save.
- Instant.MAX timeout encoded as NULL (outside TIMESTAMPTZ range), decoded back to Instant.MAX on read.

FLOW-105 schemaVersion wire-through
- RuntimeFlowInstance gains schemaVersion field; fromContext seeds with SCHEMA_VERSION_INITIAL; fromSnapshot reads from loaded snapshot; toSnapshot includes it; markPersisted() bumps after accepted save.
- CoreFlowRuntime.persistSnapshot() invokes markPersisted() so subsequent saves carry the now-current expected version. Without this, any saga that parks more than once hit OPTIMISTIC_LOCK_CONFLICT on every save after the second (stale incoming=1 vs DB current=N).
- (lookupParked snapshot fallback + bounded negative cache were already in v0.6 — no change needed.)

FLOW-106 TCK
- AbstractDistributedFlowSnapshotStoreTck: 5 nested suites covering save/load round-trip with version bump, stale-version OCC conflict, delete+exists, listParked filter, cross-restart recovery, concurrent-save CAS contention.
- CommunityJdbcFlowSnapshotStoreTckIT: Postgres 16 via Testcontainers, HikariCP-backed; 9 tests green in ~8s on Docker host.

Doc sync
- flow.md: "Distributed Snapshot Store Contract" section, bounded negative cache documented (cap=256, FIFO eviction via parkedLookupMisses), TCK Coverage table extended, EX-FLOW-7002 phase list updated.
- persistence.md: auto-DDL bootstrap pattern documented, exeris_saga_state added to the internal kernel tables list.

Verification
- SPI: 496/496 green
- Core Flow: 69/69 green (schemaVersion wire-through preserves existing behavior)
- Community non-integration: 161/161 green (1 skip = @Tag("stress"))
- Community JDBC integration TCK on Postgres 16: 9/9 green in ~8s