### PR TITLE
v0.7 Sprint 4: Flow lifecycle / TCK closure / saga TTL (EPIC-1 part 2)

### DIFF
--- a/docs/subsystems/flow.md
+++ b/docs/subsystems/flow.md
@@ -83,7 +83,8 @@ Flow can be driven by external events through the choreography bridge:
 |---|---|---|---|
 | `FlowBootstrapSelectedEvent` | `eu.exeris.kernel.flow.BootstrapSelected` | `FlowBootstrap.loadWithProvider()` | `providerClass`, `priority`, `providerId`, `engineName` |
 | `FlowStepFailedEvent` | `eu.exeris.kernel.flow.StepFailed` | `CoreFlowRuntime` on step exception | `definitionName`, `stepIndex`, `instanceIdMost`, `instanceIdLeast`, `failureReason` |
-| `FlowEngineShutdownEvent` | `eu.exeris.kernel.flow.Shutdown` | `CoreFlowEngine.close()` after runtime close and bounded shutdown join; captures the stable shutdown counter view even if late workers finalize snapshots afterward | `engineName`, `activeFlows`, `parkedFlows`, `completedFlows`, `failedFlows`, `persistenceEnabled`, `compensationEnabled` |
+| `FlowEngineShutdownEvent` | `eu.exeris.kernel.flow.Shutdown` | `CoreFlowEngine.close()` after runtime close and bounded shutdown join; captures the stable shutdown counter view even if late workers finalize snapshots afterward | `engineName`, `activeFlows`, `parkedFlows`, `completedFlows`, `failedFlows`, `persistenceEnabled`, `compensationEnabled`, `shutdownDurationNs` (since 0.7) |
+| `FlowTimeoutEvent` (since 0.7) | `eu.exeris.kernel.flow.Timeout` | `CoreFlowRuntime.runStep()` when a flow's absolute deadline has passed; the engine then drives compensation and routes the instance to `FAILED_ROLLEDBACK` | `engineName`, `definitionName`, `instanceIdMost`, `instanceIdLeast`, `currentStep`, `overrunNanos` |
 
 ---
 
@@ -93,9 +94,33 @@ Flow can be driven by external events through the choreography bridge:
 
 `CoreFlowRuntime` maintains a `terminalStateCatalog` map that records every flow that reaches a terminal state (`COMPLETED`, `FAILED_ROLLEDBACK`). This map serves as an in-process idempotency fence — it prevents re-scheduling or re-waking already-terminal flows within a single runtime lifetime.
 
-**Sprint 1 contract lock:** entries still accumulate from `start()` until `close()`, and the map is still cleared on `close()`. Any future bounded retention, cap, or eviction policy MUST preserve this fence and MUST NOT allow re-execution or re-wake of a flow that has already reached a terminal state.
+**Two operating modes (since 0.7.0)** selected by `FlowEngineConfig.terminalCatalogMaxSize`:
 
-**Operational stance:** the current runtime-lifetime scope remains acceptable for the present operational model. If a bounded policy is introduced later, it must be correctness-first and remain implementation-blind at the SPI boundary.
+- **`maxSize == 0` — unbounded (default).** Backward-compatible with v0.6: entries accumulate from `start()` until `close()` and the map is cleared on `close()`. The durable snapshot is deleted on `complete()`.
+- **`maxSize  > 0` — bounded LRU.** Backed by an access-order `LinkedHashMap`; the least-recently-accessed entry is evicted when the cap is reached. To preserve the idempotency fence under eviction, the engine **does not** delete the durable `FlowSnapshotStore` row on `complete()` in bounded mode — the persisted COMPLETED row is the cross-eviction proof of completion. Lifetime of those rows is governed by saga TTL retention (DIST-303); operators choosing bounded mode without persistence accept best-effort idempotency once an entry is evicted.
+
+On a resubmit miss against the in-memory catalog the engine restores the snapshot through `FlowSnapshotStore.load()`, observes the terminal state, re-caches the entry into the catalog, and short-circuits the schedule. Subsequent resubmits then hit the in-memory fast path again.
+
+**Correctness invariant (preserved in both modes):** an evicted entry MUST remain recoverable from `FlowSnapshotStore` so the engine can reject a resubmit. Bounded mode without persistence weakens this invariant by design — operators MUST pair it with `persistenceEnabled = true` for production runtimes.
+
+### Saga Timeout Enforcement (since 0.7.0)
+
+`FlowEngineConfig` exposes two informational defaults for callers to choose from when constructing a `FlowContext`:
+
+- `DEFAULT_SAGA_TIMEOUT_SHORT_NANOS` — 30 s, transactional sagas.
+- `DEFAULT_SAGA_TIMEOUT_LONG_NANOS` — 30 days, business-process sagas.
+
+The actual deadline carried by the engine is the absolute `timeoutNanos` on the `FlowContext` (or, if zero, `plan.timeoutDurationNanos()` evaluated at `RuntimeFlowInstance.fromContext`). On every step iteration `CoreFlowRuntime.runStep()` checks the deadline; if it has passed, the engine emits `FlowTimeoutEvent` and drives the instance through the compensation path to `FAILED_ROLLEDBACK`. `Instant.MAX` (encoded as `Long.MAX_VALUE`) means "no timeout" and skips the check.
+
+The check is binding-agnostic — both Community (heap) and Enterprise (off-heap) implementations are obliged via `AbstractFlowEngineTck.SagaTimeoutContract`.
+
+### FlowEngine Restart Semantics (since 0.7.0)
+
+`AbstractFlowEngineTck.RestartAwareSemantics` lifts three cross-restart obligations into the binding-agnostic TCK:
+
+- **Counter reset.** `FlowEngineStats` returned by `engine.stats()` reflects the current lifecycle generation; `close()` followed by `start()` resets `activeFlows`, `completedFlows`, `failedFlows`, `parkedFlows`, `compensationsRun`, and `stepExecutions` to zero (PERF-064 baseline gating, not `LongAdder.reset()`).
+- **Parked-reschedule no-op.** Scheduling a context whose `state()` is already `PARKED` MUST register the instance in the parked map without spawning step execution (`PARKED_SCHEDULE_NOOP` path).
+- **Unknown-instance lookup.** `FlowScheduler.lookupParked(...)` for an instance that was never scheduled MUST return `Optional.empty()` without throwing, regardless of whether persistence is bound.
 
 ### Cross-Restart Choreography Wake
 
@@ -138,7 +163,7 @@ In-memory bindings (`CommunityFlowSnapshotStore`, test stores) continue to ignor
 
 | TCK Suite | Module | Description |
 |:---------|:-------|:------------|
-| `AbstractFlowEngineTck` | `exeris-kernel-tck` | Full flow lifecycle: submit, run, park, wake, complete, compensate |
+| `AbstractFlowEngineTck` | `exeris-kernel-tck` | Full flow lifecycle: submit, run, park, wake, complete, compensate; JFR shutdown event (TCK-062), restart-aware semantics (TCK-063), saga timeout enforcement (DIST-303) |
 | `AbstractFlowSchedulerTck` | `exeris-kernel-tck` | Scheduler contract: schedule, cancel, peek parked, drain |
 | `AbstractFlowChoreographyTck` | `exeris-kernel-tck` | Choreography mapper registration and event-driven wake |
 | `AbstractSagaRecoveryTck` | `exeris-kernel-tck` | Crash-recovery replay semantics from snapshot store |

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
@@ -61,6 +61,18 @@ import java.util.Optional;
  *
  * @since 0.7.0
  */
+@SuppressWarnings({
+        // Durable JDBC store inherently exposes the full FlowSnapshotStore SPI plus internal
+        // helpers for the two-step UPDATE-then-INSERT pattern. Decomposition is tracked under
+        // Sprint 8 SQ-006 (alongside CoreFlowRuntime) — premature splitting here would
+        // fragment the OCC contract documented in ADR-013 §5.
+        "PMD.GodClass",
+        "PMD.TooManyMethods",
+        "PMD.CyclomaticComplexity",
+        // `ps` / `rs` / `sp` are the de-facto JDBC convention (PreparedStatement / ResultSet /
+        // stack-pointer); renaming them to longer identifiers obscures rather than clarifies.
+        "PMD.ShortVariable"
+})
 public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
 
     private static final String SQL_INSERT =
@@ -109,7 +121,16 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
         this.engineName = Objects.requireNonNull(engineName, "engineName");
     }
 
+    // The two-step UPSERT (UPDATE-CAS → distinguish absent vs stale → INSERT) plus
+    // commit/rollback ladder yields ~7 decision points; splitting further fragments
+    // the transactional boundary that ADR-013 §5 hangs the OCC contract on. The class-level
+    // `PMD.CyclomaticComplexity` suppression covers this method.
+    //
+    // `catch (FlowEngineException occ)` is intentional: the OCC failure raised by
+    // `optimisticLockConflict` MUST trigger rollback and re-throw without wrapping.
+    // This is transactional control flow, not error-control-flow misuse.
     @Override
+    @SuppressWarnings("PMD.ExceptionAsFlowControl")
     public void save(FlowSnapshot snapshot) {
         Objects.requireNonNull(snapshot, "snapshot");
         try (Connection conn = dataSource.getConnection()) {
@@ -152,7 +173,8 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
             insertSnapshot(conn, snapshot);
         } catch (SQLException pkViolation) {
             if (isIntegrityConstraintViolation(pkViolation)) {
-                throw FlowEngineException.optimisticLockConflict(engineName, snapshot.schemaVersion());
+                throw FlowEngineException.optimisticLockConflict(
+                        engineName, snapshot.schemaVersion(), pkViolation);
             }
             throw pkViolation;
         }
@@ -260,6 +282,7 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
      * Binds the eight payload columns (definition_name through opaque_state) starting at
      * the given JDBC parameter index. Used by both INSERT (offset 3) and UPDATE (offset 1).
      */
+    @SuppressWarnings("PMD.AssignmentInOperand") // idx++ is the canonical JDBC binding pattern
     private static void bindSnapshotPayload(PreparedStatement ps, FlowSnapshot snapshot,
                                             int startIndex) throws SQLException {
         int idx = startIndex;
@@ -313,6 +336,9 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
         return result;
     }
 
+    // ResultSet.getTimestamp returns java.sql.Timestamp by JDBC contract; we convert
+    // to Instant on the next line, never holding the Timestamp beyond decoding.
+    @SuppressWarnings("PMD.ReplaceJavaUtilDate")
     private static FlowSnapshot readSnapshot(ResultSet rs) throws SQLException {
         long instanceIdMost = rs.getLong("instance_id_most");
         long instanceIdLeast = rs.getLong("instance_id_least");

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -473,6 +473,12 @@ final class NativeTcpStream implements TransportStream {
         return ensureTlsReady(true);
     }
 
+    // PERF-062: try-with-resources is intentionally NOT used here. The success path transfers
+    // ownership of `plaintext` to the caller (returned at refcount 1, freed by the queue
+    // consumer); only the failure path closes via the `transferred` ownership flag. A
+    // try-with-resources would force an extra retain()/close() ceremony per TLS record on the
+    // hot ingress path. Same pattern in decryptIngress below.
+    @SuppressWarnings("PMD.UseTryWithResources")
     /* default */ LoanedBuffer readTlsIngressFromFd() {
         if (tlsEngine == null) {
             return null;
@@ -517,6 +523,7 @@ final class NativeTcpStream implements TransportStream {
         }
     }
 
+    @SuppressWarnings("PMD.UseTryWithResources") // see readTlsIngressFromFd above — transferred-flag ownership
     /* default */ LoanedBuffer decryptIngress(LoanedBuffer ciphertext, int length) {
         // PERF-062: fast-fail before allocation when offerIngress would reject.
         // Saves the network buffer borrow + TLS unwrap on backpressured / closing-stream paths.

--- a/exeris-kernel-community/src/main/resources/db/migration/V0.7.0__create_saga_state.sql
+++ b/exeris-kernel-community/src/main/resources/db/migration/V0.7.0__create_saga_state.sql
@@ -27,8 +27,12 @@ CREATE TABLE IF NOT EXISTS exeris_saga_state (
     PRIMARY KEY (instance_id_most, instance_id_least)
 );
 
--- Partial index for the listParked() recovery enumeration. Predicate matches the
--- FlowState.PARKED.name() string emitted by JdbcFlowSnapshotStore.
+-- Composite index for the listParked() recovery enumeration. Leading column on `state` lets
+-- both Postgres and H2 narrow to PARKED rows on the listParked SELECT (`WHERE state = 'PARKED'`);
+-- secondary column orders by `last_update` for the hot resume path. A Postgres-only partial
+-- index (`WHERE state = 'PARKED'`) would be marginally tighter but H2 (developer-loop fallback,
+-- and the in-memory persistence smoke path) does not support partial-index predicates, so this
+-- migration deliberately stays portable. JdbcFlowSnapshotStore retains its `WHERE state = 'PARKED'`
+-- query, which benefits from the leading column either way.
 CREATE INDEX IF NOT EXISTS idx_exeris_saga_state_parked
-    ON exeris_saga_state (last_update)
-    WHERE state = 'PARKED';
+    ON exeris_saga_state (state, last_update);

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowEngine.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowEngine.java
@@ -89,6 +89,7 @@ public final class CoreFlowEngine implements FlowEngine {
         if (!closeInitiated.compareAndSet(false, true)) {
             return;
         }
+        long startNanos = System.nanoTime();
         for (Map.Entry<EventBus, SubscriptionToken> entry : choreographySubscriptions) {
             try {
                 entry.getKey().unsubscribe(entry.getValue());
@@ -98,7 +99,7 @@ public final class CoreFlowEngine implements FlowEngine {
         }
         choreographySubscriptions.clear();
         runtime.close();
-        FlowEngineShutdownEvent.emit(config, runtime.stats());
+        FlowEngineShutdownEvent.emit(config, runtime.stats(), System.nanoTime() - startNanos);
     }
 
     @Override

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
@@ -25,6 +25,8 @@ import eu.exeris.kernel.spi.flow.model.FlowStepDescriptor;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -37,7 +39,10 @@ import java.util.concurrent.atomic.LongAdder;
 @SuppressWarnings("PMD.PublicMemberInNonPublicType")
 final class CoreFlowRuntime { // NOPMD
 
-    private static final int MAX_PARKED_LOOKUP_MISSES = 256;
+    private static final int  MAX_PARKED_LOOKUP_MISSES = 256;
+    private static final long NO_TIMEOUT_OVERRUN       = 0L;
+    private static final int  STEP_PROCEED             = Integer.MIN_VALUE;
+    private static final int  EXIT_RUN_LOOP            = -1;
 
     private final FlowEngineConfig config;
     private final FlowProgressPublisher progressPublisher;
@@ -45,7 +50,7 @@ final class CoreFlowRuntime { // NOPMD
     private final ConcurrentMap<FlowKey, RuntimeFlowInstance> liveInstances = new ConcurrentHashMap<>();
     private final ConcurrentMap<FlowKey, RuntimeFlowInstance> parkedInstances = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, CoreFlowExecutionPlan> planCatalog = new ConcurrentHashMap<>();
-    private final ConcurrentMap<FlowKey, FlowState> terminalStateCatalog = new ConcurrentHashMap<>();
+    private final TerminalStateCatalog terminalStateCatalog;
     private final Set<FlowKey> parkedLookupMisses = ConcurrentHashMap.newKeySet();
     private final Deque<FlowKey> parkedLookupMissOrder = new ArrayDeque<>();
     private final Object parkedLookupMissLock = new Object();
@@ -77,6 +82,7 @@ final class CoreFlowRuntime { // NOPMD
     /* default */ CoreFlowRuntime(FlowEngineConfig config, FlowProgressPublisher progressPublisher) {
         this.config = Objects.requireNonNull(config, "config");
         this.progressPublisher = Objects.requireNonNull(progressPublisher, "progressPublisher");
+        this.terminalStateCatalog = new TerminalStateCatalog(config.terminalCatalogMaxSize());
     }
 
     public FlowScheduler scheduler() {
@@ -234,7 +240,7 @@ final class CoreFlowRuntime { // NOPMD
         ensureStarted();
         FlowKey key = FlowKey.from(context);
         clearParkedLookupMiss(key);
-        if (terminalStateCatalog.containsKey(key)) {
+        if (terminalStateCatalog.isTerminal(key)) {
             return;
         }
 
@@ -249,7 +255,13 @@ final class CoreFlowRuntime { // NOPMD
                     : RuntimeFlowInstance.fromContext(plan, context, lifecycleGeneration.get());
         });
 
-        if (instance.isTerminal() || terminalStateCatalog.containsKey(key)) {
+        if (instance.isTerminal() || terminalStateCatalog.isTerminal(key)) {
+            // FLOW-107: catalog miss with a terminal snapshot row means the in-memory entry
+            // was evicted under bounded LRU. Re-cache the terminal state so subsequent
+            // resubmits short-circuit on the in-memory fast path.
+            if (instance.isTerminal()) {
+                terminalStateCatalog.recordTerminal(key, instance.state());
+            }
             liveInstances.remove(key, instance);
             return;
         }
@@ -298,13 +310,13 @@ final class CoreFlowRuntime { // NOPMD
         ensureStarted();
         FlowKey key = FlowKey.from(context);
         clearParkedLookupMiss(key);
-        if (terminalStateCatalog.containsKey(key)) {
+        if (terminalStateCatalog.isTerminal(key)) {
             return;
         }
 
         RuntimeFlowInstance instance = resolveParkedInstance(key, context.state());
 
-        if (instance.isTerminal() || terminalStateCatalog.containsKey(key)) {
+        if (instance.isTerminal() || terminalStateCatalog.isTerminal(key)) {
             liveInstances.remove(key, instance);
             return;
         }
@@ -514,21 +526,41 @@ final class CoreFlowRuntime { // NOPMD
      * Executes one step of the flow loop within the context of a running instance.
      * Called by {@link #runInstance} on each while-loop iteration.
      *
-     * <p>Returns the next step index to process, or {@code -1} to terminate the loop.
+     * <p>Returns the next step index to process, or {@link #EXIT_RUN_LOOP} to terminate.
      * Must be called from OUTSIDE any synchronized block.
      */
     private int runStep(RuntimeFlowInstance instance, int stepIndex) {
-        FlowStepDescriptor step;
-        FlowStepAction stepAction;
+        StepPlan plan = prepareStep(instance, stepIndex);
+        if (plan.exitCode != STEP_PROCEED) {
+            return plan.exitCode;
+        }
+        if (plan.timeoutOverrunNanos != NO_TIMEOUT_OVERRUN) {
+            return failOnTimeout(instance, stepIndex, plan.timeoutOverrunNanos);
+        }
+        FlowOutcome outcome = executeStep(instance, stepIndex, plan.action);
+        return finalizeStep(instance, plan.step, stepIndex, outcome);
+    }
 
+    /**
+     * Synchronized prep phase: bounds-check, snapshot the step, enforce the absolute saga
+     * deadline (DIST-303), and consult the {@code IdempotencyGuard}. Returns a {@link StepPlan}
+     * describing whether to proceed, time-out, or short-circuit with an exit code.
+     */
+    private StepPlan prepareStep(RuntimeFlowInstance instance, int stepIndex) {
         synchronized (instance.monitor()) {
             if (stepIndex >= instance.plan().stepCount()) {
                 complete(instance);
-                return -1;
+                return StepPlan.exit(EXIT_RUN_LOOP);
             }
             instance.currentStep(stepIndex);
-            step = instance.plan().stepAt(stepIndex);
+            FlowStepDescriptor step = instance.plan().stepAt(stepIndex);
 
+            // DIST-303: timeoutNanos == Long.MAX_VALUE encodes Instant.MAX (no timeout).
+            long now = System.nanoTime();
+            long deadline = instance.timeoutNanos();
+            if (deadline != Long.MAX_VALUE && deadline < now) {
+                return StepPlan.timedOut(step, now - deadline);
+            }
             if (guard != null && !guard.tryClaimStep(
                     instance.key().instanceIdMost(),
                     instance.key().instanceIdLeast(),
@@ -536,23 +568,76 @@ final class CoreFlowRuntime { // NOPMD
                 int nextGuardIndex = instance.plan().nextStep(stepIndex);
                 if (nextGuardIndex < 0) {
                     complete(instance);
-                    return -1;
+                    return StepPlan.exit(EXIT_RUN_LOOP);
                 }
-                return nextGuardIndex;
+                return StepPlan.exit(nextGuardIndex);
             }
-            stepAction = step.action();
+            return StepPlan.proceed(step, step.action());
         }
+    }
 
-        FlowOutcome outcome = executeStep(instance, stepIndex, stepAction);
-
+    /**
+     * Synchronized post-execution phase: re-check lifecycle and dispatch the outcome through
+     * {@link #applyOutcome}.
+     */
+    private int finalizeStep(
+            RuntimeFlowInstance instance, FlowStepDescriptor step, int stepIndex, FlowOutcome outcome) {
         synchronized (instance.monitor()) {
             if (!isCurrentLifecycle(instance)) {
                 if (outcome == FlowOutcome.COMPLETE) {
                     complete(instance);
                 }
-                return -1;
+                return EXIT_RUN_LOOP;
             }
             return applyOutcome(instance, step, stepIndex, outcome);
+        }
+    }
+
+    /**
+     * Emits {@link FlowTimeoutEvent} and drives the instance through the compensation path
+     * to {@link FlowState#FAILED_ROLLEDBACK}. Always returns {@link #EXIT_RUN_LOOP}.
+     */
+    private int failOnTimeout(RuntimeFlowInstance instance, int stepIndex, long overrunNanos) {
+        FlowTimeoutEvent.emit(
+                config.engineName(),
+                instance.definitionName(),
+                instance.key().instanceIdMost(),
+                instance.key().instanceIdLeast(),
+                stepIndex,
+                overrunNanos);
+        fail(instance, stepIndex);
+        return EXIT_RUN_LOOP;
+    }
+
+    /**
+     * Carrier for {@link #prepareStep} → {@link #runStep} hand-off.
+     *
+     * <ul>
+     *   <li>{@code exitCode == STEP_PROCEED}: caller MUST execute {@code action}.</li>
+     *   <li>otherwise: caller MUST short-circuit with {@code exitCode}.</li>
+     *   <li>{@code timeoutOverrunNanos != NO_TIMEOUT_OVERRUN}: caller MUST run the timeout path.</li>
+     * </ul>
+     *
+     * <p>Allocated once per step iteration on the cold prep path (already inside
+     * {@code synchronized}); JIT escape analysis routinely scalarizes this carrier on the
+     * Loom virtual-thread dispatch loop, so no heap pressure is introduced on the hot path.
+     */
+    private record StepPlan(
+            FlowStepDescriptor step,
+            FlowStepAction     action,
+            int                exitCode,
+            long               timeoutOverrunNanos) {
+
+        /* default */ static StepPlan proceed(FlowStepDescriptor step, FlowStepAction action) {
+            return new StepPlan(step, action, STEP_PROCEED, NO_TIMEOUT_OVERRUN);
+        }
+
+        /* default */ static StepPlan timedOut(FlowStepDescriptor step, long overrunNanos) {
+            return new StepPlan(step, null, STEP_PROCEED, overrunNanos);
+        }
+
+        /* default */ static StepPlan exit(int exitCode) {
+            return new StepPlan(null, null, exitCode, NO_TIMEOUT_OVERRUN);
         }
     }
 
@@ -703,7 +788,7 @@ final class CoreFlowRuntime { // NOPMD
         clearParkedLookupMiss(instance.key());
         if (!cleanupOnly) {
             failedFlows.increment();
-            terminalStateCatalog.put(instance.key(), FlowState.FAILED_ROLLEDBACK);
+            terminalStateCatalog.recordTerminal(instance.key(), FlowState.FAILED_ROLLEDBACK);
         }
         if (!staleLifecycle) {
             persistSnapshot(instance, FlowState.FAILED_ROLLEDBACK, stepIndex);
@@ -723,7 +808,7 @@ final class CoreFlowRuntime { // NOPMD
         instance.state(FlowState.COMPLETED);
         clearParkedLookupMiss(instance.key());
         if (!cleanupOnly) {
-            terminalStateCatalog.put(instance.key(), FlowState.COMPLETED);
+            terminalStateCatalog.recordTerminal(instance.key(), FlowState.COMPLETED);
         }
         releaseInstanceClaims(instance, staleLifecycle);
         if (!cleanupOnly) {
@@ -746,6 +831,12 @@ final class CoreFlowRuntime { // NOPMD
 
     private void deleteSnapshot(RuntimeFlowInstance instance, boolean staleLifecycle) {
         if (staleLifecycle || snapshotStore == null) {
+            return;
+        }
+        // FLOW-107: in bounded-catalog mode the durable snapshot is the idempotency fence
+        // for COMPLETED entries that may have been evicted from the in-memory catalog.
+        // Retain the snapshot here; lifetime is governed by DIST-303 saga TTL retention.
+        if (terminalStateCatalog.isBounded()) {
             return;
         }
         try {
@@ -796,7 +887,7 @@ final class CoreFlowRuntime { // NOPMD
         @Override
         public Optional<FlowContext> lookupParked(long instanceIdMost, long instanceIdLeast) {
             FlowKey key = new FlowKey(instanceIdMost, instanceIdLeast);
-            if (terminalStateCatalog.containsKey(key)) {
+            if (terminalStateCatalog.isTerminal(key)) {
                 return Optional.empty();
             }
             RuntimeFlowInstance parked = parkedInstances.get(key);
@@ -822,6 +913,81 @@ final class CoreFlowRuntime { // NOPMD
                         "Unsupported FlowExecutionPlan implementation: " + plan.getClass().getName());
             }
             return corePlan;
+        }
+    }
+
+    /**
+     * In-memory idempotency fence for terminal flow instances.
+     *
+     * <p>Two operating modes selected at construction by {@link FlowEngineConfig#terminalCatalogMaxSize()}:
+     * <ul>
+     *   <li><b>{@code maxSize == 0} — unbounded.</b> Backed by {@link ConcurrentHashMap}; entries
+     *       accumulate for the lifetime of the engine. Backward-compatible with v0.6 behavior.</li>
+     *   <li><b>{@code maxSize  > 0} — bounded LRU.</b> Backed by {@link LinkedHashMap} with
+     *       access-order; the least-recently-accessed entry is evicted when the cap is reached.
+     *       Snapshot deletion is suppressed in this mode (see {@link #deleteSnapshot}) so that
+     *       the durable {@link FlowSnapshotStore} retains the COMPLETED row as the persistent
+     *       idempotency fence; long-running runtimes therefore stay memory-bounded without
+     *       weakening idempotency.</li>
+     * </ul>
+     *
+     * <p>Lookups in bounded mode go through {@code synchronized} on a dedicated lock — the path is
+     * cold (resubmit guard, called once per schedule attempt), so the lock cost is acceptable; a
+     * read-write lock can be introduced if profiling later shows contention.
+     */
+    private static final class TerminalStateCatalog {
+
+        private final int maxSize;
+        private final Map<FlowKey, FlowState> map;
+        private final Object lock = new Object();
+
+        /* default */ TerminalStateCatalog(int maxSize) {
+            this.maxSize = maxSize;
+            if (maxSize == 0) {
+                this.map = new ConcurrentHashMap<>();
+            } else {
+                this.map = new LinkedHashMap<>(16, 0.75f, true) {
+                    private static final long serialVersionUID = 1L;
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<FlowKey, FlowState> eldest) {
+                        return size() > maxSize;
+                    }
+                };
+            }
+        }
+
+        /* default */ boolean isBounded() {
+            return maxSize > 0;
+        }
+
+        /* default */ boolean isTerminal(FlowKey key) {
+            if (maxSize == 0) {
+                return map.containsKey(key);
+            }
+            synchronized (lock) {
+                // get() — not containsKey — to mark the entry as recently accessed under accessOrder=true.
+                return map.get(key) != null;
+            }
+        }
+
+        /* default */ void recordTerminal(FlowKey key, FlowState state) {
+            if (maxSize == 0) {
+                map.put(key, state);
+                return;
+            }
+            synchronized (lock) {
+                map.put(key, state);
+            }
+        }
+
+        /* default */ void clear() {
+            if (maxSize == 0) {
+                map.clear();
+                return;
+            }
+            synchronized (lock) {
+                map.clear();
+            }
         }
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/FlowEngineShutdownEvent.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/FlowEngineShutdownEvent.java
@@ -52,7 +52,11 @@ final class FlowEngineShutdownEvent extends Event {
     @Description("Whether compensation support was enabled for this engine")
     /* default */ boolean compensationEnabled;
 
-    /* default */ static void emit(FlowEngineConfig config, FlowEngineStats stats) {
+    @Label("Shutdown Duration (ns)")
+    @Description("Wall-clock time elapsed inside FlowEngine.close() — drain + interrupt + join")
+    /* default */ long shutdownDurationNs;
+
+    /* default */ static void emit(FlowEngineConfig config, FlowEngineStats stats, long shutdownDurationNs) {
         FlowEngineShutdownEvent event = new FlowEngineShutdownEvent();
         if (!event.isEnabled()) {
             return;
@@ -65,6 +69,7 @@ final class FlowEngineShutdownEvent extends Event {
         event.failedFlows = stats.failedFlows();
         event.persistenceEnabled = config.persistenceEnabled();
         event.compensationEnabled = config.compensationEnabled();
+        event.shutdownDurationNs = shutdownDurationNs;
         event.commit();
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/FlowTimeoutEvent.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/FlowTimeoutEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.flow;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("eu.exeris.kernel.flow.Timeout")
+@Label("Flow Saga Timeout")
+@Category({"Exeris Kernel", "Flow"})
+@Description("Emitted when a flow instance is detected past its absolute timeout deadline;" + 
+    " the engine drives compensation.")
+@StackTrace(false)
+final class FlowTimeoutEvent extends Event {
+
+    @Label("Engine Name")
+    @Description("Human-readable engine name from FlowEngineConfig.engineName()")
+    /* default */ String engineName;
+
+    @Label("Definition Name")
+    @Description("FlowDefinition name of the timed-out instance")
+    /* default */ String definitionName;
+
+    @Label("Instance Id (most)")
+    @Description("Most-significant 64 bits of the flow instance UUID")
+    /* default */ long instanceIdMost;
+
+    @Label("Instance Id (least)")
+    @Description("Least-significant 64 bits of the flow instance UUID")
+    /* default */ long instanceIdLeast;
+
+    @Label("Current Step")
+    @Description("Step index the instance was attempting to execute when the timeout was detected")
+    /* default */ int currentStep;
+
+    @Label("Timeout Overrun (ns)")
+    @Description("Nanoseconds elapsed past the deadline at the moment of detection (>= 0)")
+    /* default */ long overrunNanos;
+
+    /* default */ static void emit(
+            String engineName,
+            String definitionName,
+            long instanceIdMost,
+            long instanceIdLeast,
+            int currentStep,
+            long overrunNanos) {
+        FlowTimeoutEvent event = new FlowTimeoutEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.begin();
+        event.engineName = engineName;
+        event.definitionName = definitionName;
+        event.instanceIdMost = instanceIdMost;
+        event.instanceIdLeast = instanceIdLeast;
+        event.currentStep = currentStep;
+        event.overrunNanos = overrunNanos;
+        event.commit();
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/flow/FlowEngineException.java
@@ -90,8 +90,25 @@ public final class FlowEngineException extends ExerisKernelException {
      * @since 0.7.0
      */
     public static FlowEngineException optimisticLockConflict(String engineName, long incomingSchemaVersion) {
+        return optimisticLockConflict(engineName, incomingSchemaVersion, null);
+    }
+
+    /**
+     * Cause-preserving variant of {@link #optimisticLockConflict(String, long)}. Used when the
+     * conflict surfaces through an underlying driver exception — for example, a composite-PK
+     * integrity-constraint violation raised by a concurrent INSERT race-loser in a durable
+     * binding. The original {@code SQLException}-shaped chain is preserved for diagnostics;
+     * the caller still observes the same OCC contract from ADR-013 §5.
+     *
+     * @param engineName            the engine name
+     * @param incomingSchemaVersion the schemaVersion the caller attempted to write
+     * @param cause                 underlying driver exception that surfaced the conflict; may be {@code null}
+     * @since 0.7.0
+     */
+    public static FlowEngineException optimisticLockConflict(
+            String engineName, long incomingSchemaVersion, Throwable cause) {
         int contextValue = (int) Math.min(incomingSchemaVersion, Integer.MAX_VALUE);
-        return new FlowEngineException(KernelErrorCodes.EX_FLOW_7002, MSG_ENGINE_FAILURE, null,
+        return new FlowEngineException(KernelErrorCodes.EX_FLOW_7002, MSG_ENGINE_FAILURE, cause,
                 engineName, "OPTIMISTIC_LOCK_CONFLICT", REASON_STALE_VERSION, contextValue);
     }
 }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/FlowEngineConfig.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/FlowEngineConfig.java
@@ -9,6 +9,7 @@
 package eu.exeris.kernel.spi.flow;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Immutable configuration for the {@link FlowEngine}.
@@ -39,9 +40,29 @@ import java.util.Objects;
  * @param partitionBytes         total bytes to claim for the flow memory partition (Enterprise)
  * @param persistenceEnabled     whether flow snapshot persistence via SPI is enabled
  * @param compensationEnabled    whether backward compensation (saga rollback) is enabled
+ * @param terminalCatalogMaxSize maximum number of entries retained in the in-memory terminal-state
+ *                               catalog used as the idempotency fence for COMPLETED /
+ *                               FAILED_ROLLEDBACK resubmits; {@code 0} = unbounded (default,
+ *                               backward-compatible). When {@code > 0}, the catalog evicts the
+ *                               least-recently-accessed entry; the engine then falls back to the
+ *                               durable {@link eu.exeris.kernel.spi.flow.model.FlowSnapshotStore}
+ *                               (when {@code persistenceEnabled = true}) to honor the idempotency
+ *                               fence — see {@code flow.md} §Lifecycle. (since 0.7.0)
+ * @param defaultSagaTimeoutShortNanos baseline timeout for short-lived (transactional) sagas;
+ *                                     {@link #DEFAULT_SAGA_TIMEOUT_SHORT_NANOS} = 30 s. Exposed for
+ *                                     callers that classify saga lifetimes when constructing a
+ *                                     {@link eu.exeris.kernel.spi.flow.model.FlowContext}; the engine
+ *                                     itself enforces whatever {@code timeoutNanos} the context carries.
+ *                                     (since 0.7.0)
+ * @param defaultSagaTimeoutLongNanos  baseline timeout for long-running (business-process) sagas;
+ *                                     {@link #DEFAULT_SAGA_TIMEOUT_LONG_NANOS} = 30 days. Exposed for
+ *                                     callers that classify saga lifetimes when constructing a
+ *                                     {@link eu.exeris.kernel.spi.flow.model.FlowContext}.
+ *                                     (since 0.7.0)
  *
  * @since 0.5.0
  */
+@SuppressWarnings("PMD.ExcessiveParameterList") // 14 fields — flat-record config carrier;
 public record FlowEngineConfig(
         String  engineName,
         int     maxConcurrentFlows,
@@ -53,8 +74,18 @@ public record FlowEngineConfig(
         String  partitionName,
         long    partitionBytes,
         boolean persistenceEnabled,
-        boolean compensationEnabled
+        boolean compensationEnabled,
+        int     terminalCatalogMaxSize,
+        long    defaultSagaTimeoutShortNanos,
+        long    defaultSagaTimeoutLongNanos
 ) {
+
+    /** Default short-lived (transactional) saga timeout — 30 seconds. @since 0.7.0 */
+    public static final long DEFAULT_SAGA_TIMEOUT_SHORT_NANOS = TimeUnit.SECONDS.toNanos(30L);
+
+    /** Default long-running (business-process) saga timeout — 30 days. @since 0.7.0 */
+    public static final long DEFAULT_SAGA_TIMEOUT_LONG_NANOS = TimeUnit.DAYS.toNanos(30L);
+
 
     /** Compact constructor — validates invariants eagerly (fail-fast bootstrap). */
     public FlowEngineConfig {
@@ -90,6 +121,52 @@ public record FlowEngineConfig(
                     + "(Enterprise ring buffer), got: " + schedulerQueueCapacity);
         }
         validatePartition(partitionName, partitionBytes);
+        if (terminalCatalogMaxSize < 0) {
+            throw new IllegalArgumentException(
+                    "terminalCatalogMaxSize must be >= 0, got: " + terminalCatalogMaxSize);
+        }
+        if (defaultSagaTimeoutShortNanos <= 0) {
+            throw new IllegalArgumentException(
+                    "defaultSagaTimeoutShortNanos must be > 0, got: " + defaultSagaTimeoutShortNanos);
+        }
+        if (defaultSagaTimeoutLongNanos <= 0) {
+            throw new IllegalArgumentException(
+                    "defaultSagaTimeoutLongNanos must be > 0, got: " + defaultSagaTimeoutLongNanos);
+        }
+        if (defaultSagaTimeoutLongNanos < defaultSagaTimeoutShortNanos) {
+            throw new IllegalArgumentException(
+                    "defaultSagaTimeoutLongNanos (" + defaultSagaTimeoutLongNanos
+                    + ") must be >= defaultSagaTimeoutShortNanos (" + defaultSagaTimeoutShortNanos + ')');
+        }
+    }
+
+    /**
+     * Backward-compatible 11-arg constructor — preserves the v0.6 call shape so existing callers
+     * (community bootstrap, tests, external operators) compile unchanged. Defaults the new 0.7
+     * fields to: {@code terminalCatalogMaxSize = 0} (unbounded — preserves prior behavior),
+     * {@link #DEFAULT_SAGA_TIMEOUT_SHORT_NANOS}, and {@link #DEFAULT_SAGA_TIMEOUT_LONG_NANOS}.
+     *
+     * @since 0.7.0
+     */
+    public FlowEngineConfig(
+            String  engineName,
+            int     maxConcurrentFlows,
+            long    timeoutDurationNanos,
+            int     maxSteps,
+            int     maxTransitions,
+            int     maxExecutionPlans,
+            int     schedulerQueueCapacity,
+            String  partitionName,
+            long    partitionBytes,
+            boolean persistenceEnabled,
+            boolean compensationEnabled
+    ) {
+        this(engineName, maxConcurrentFlows, timeoutDurationNanos, maxSteps, maxTransitions,
+             maxExecutionPlans, schedulerQueueCapacity, partitionName, partitionBytes,
+             persistenceEnabled, compensationEnabled,
+             0,
+             DEFAULT_SAGA_TIMEOUT_SHORT_NANOS,
+             DEFAULT_SAGA_TIMEOUT_LONG_NANOS);
     }
 
     private static void validatePartition(String name, long bytes) {
@@ -122,7 +199,10 @@ public record FlowEngineConfig(
                 null,               // no off-heap partition — Community heap path
                 0L,                 // partitionBytes=0 → heap-only
                 false,              // persistence disabled by default for Community
-                true
+                true,
+                0,                  // unbounded terminal catalog (backward-compatible default)
+                DEFAULT_SAGA_TIMEOUT_SHORT_NANOS,
+                DEFAULT_SAGA_TIMEOUT_LONG_NANOS
         );
     }
 
@@ -145,7 +225,10 @@ public record FlowEngineConfig(
                 "flow",
                 32L * 1024 * 1024,  // 32 MB off-heap partition
                 true,
-                true
+                true,
+                100_000,            // bounded LRU terminal catalog — Enterprise long-running runtime
+                DEFAULT_SAGA_TIMEOUT_SHORT_NANOS,
+                DEFAULT_SAGA_TIMEOUT_LONG_NANOS
         );
     }
 }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowEngineTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowEngineTck.java
@@ -9,11 +9,17 @@
 package eu.exeris.kernel.tck.contract.flow;
 
 import eu.exeris.kernel.spi.flow.FlowEngine;
+import eu.exeris.kernel.spi.flow.FlowEngineStats;
 import eu.exeris.kernel.spi.flow.FlowExecutionPlanFactory;
 import eu.exeris.kernel.spi.flow.FlowScheduler;
+import eu.exeris.kernel.spi.flow.model.FlowContext;
 import eu.exeris.kernel.spi.flow.model.FlowDefinition;
 import eu.exeris.kernel.spi.flow.model.FlowExecutionPlan;
+import eu.exeris.kernel.spi.flow.model.FlowOutcome;
+import eu.exeris.kernel.spi.flow.model.FlowState;
 import eu.exeris.kernel.spi.flow.model.FlowStepAction;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +27,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -225,5 +238,262 @@ public abstract class AbstractFlowEngineTck {
             }).as("Same FlowExecutionPlan MUST be schedulable for multiple instances (immutable)")
               .doesNotThrowAnyException();
         }
+    }
+
+    // =========================================================================
+    // TCK-062 — JFR shutdown event contract (FLOW-108)
+    // =========================================================================
+
+    /**
+     * TCK-062: every {@link FlowEngine} binding MUST emit the
+     * {@code eu.exeris.kernel.flow.Shutdown} JFR event on {@link FlowEngine#close()},
+     * carrying engine name, lifecycle counter snapshot, persistence/compensation flags,
+     * and the elapsed shutdown duration. The contract is binding-agnostic — both Community
+     * (heap) and Enterprise (off-heap) implementations are obliged.
+     */
+    @Nested
+    @DisplayName("FlowEngine JFR shutdown contract — eu.exeris.kernel.flow.Shutdown")
+    class JfrShutdownContract {
+
+        private static final String SHUTDOWN_EVENT = "eu.exeris.kernel.flow.Shutdown";
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("close() emits the Shutdown JFR event with engine name + duration + counters")
+        void closeEmitsShutdownEventOnce() throws Exception {
+            CountDownLatch eventReceived = new CountDownLatch(1);
+            AtomicInteger eventCount = new AtomicInteger();
+            AtomicReference<RecordedEvent> captured = new AtomicReference<>();
+
+            try (RecordingStream rs = new RecordingStream()) {
+                rs.enable(SHUTDOWN_EVENT);
+                rs.onEvent(SHUTDOWN_EVENT, event -> {
+                    eventCount.incrementAndGet();
+                    captured.compareAndSet(null, event);
+                    eventReceived.countDown();
+                });
+                rs.startAsync();
+
+                engine.start();
+
+                FlowDefinition def = engine.plans().newDefinition("shutdown-tck")
+                        .step("noop", _ -> FlowOutcome.CONTINUE, null)
+                        .build();
+                FlowExecutionPlan plan = engine.plans().compile(def);
+                engine.scheduler().schedule(plan, TestFlowContexts.create(
+                        UUID.randomUUID().toString(), "shutdown-tck"));
+
+                engine.close();
+
+                assertThat(eventReceived.await(5, TimeUnit.SECONDS))
+                        .as("eu.exeris.kernel.flow.Shutdown MUST be emitted within 5 s of close()")
+                        .isTrue();
+
+                RecordedEvent event = captured.get();
+                assertThat(event.getString("engineName"))
+                        .as("Shutdown event MUST carry a non-blank engineName")
+                        .isNotBlank();
+                assertThat(event.getLong("activeFlows"))
+                        .as("activeFlows MUST be reported as a final post-quiesce counter")
+                        .isGreaterThanOrEqualTo(0L);
+                assertThat(event.getLong("shutdownDurationNs"))
+                        .as("shutdownDurationNs MUST capture wall-clock time spent in close() and be >= 0")
+                        .isGreaterThanOrEqualTo(0L);
+                // Field presence checks — implementations MUST publish these fields even if zero.
+                assertThat(event.getLong("parkedFlows")).isGreaterThanOrEqualTo(0L);
+                assertThat(event.getLong("completedFlows")).isGreaterThanOrEqualTo(0L);
+                assertThat(event.getLong("failedFlows")).isGreaterThanOrEqualTo(0L);
+                assertThat(eventCount.get())
+                        .as("Single close() MUST emit exactly one Shutdown event")
+                        .isEqualTo(1);
+            }
+        }
+    }
+
+    // =========================================================================
+    // TCK-063 — Restart-aware semantics (counter reset, parked-reschedule, lookupParked)
+    // =========================================================================
+
+    /**
+     * TCK-063: cross-restart semantics that every {@link FlowEngine} binding MUST honor.
+     *
+     * <ul>
+     *   <li>Lifecycle counters reset across {@code close()} → {@code start()}.</li>
+     *   <li>Scheduling a context whose state is already {@link FlowState#PARKED} is a no-op
+     *       — no step is executed; the engine MUST treat it as registration only.</li>
+     *   <li>{@code lookupParked} for an unknown instance returns {@link Optional#empty()}
+     *       without throwing, regardless of whether persistence is bound.</li>
+     * </ul>
+     */
+    @Nested
+    @DisplayName("FlowEngine restart-aware semantics")
+    class RestartAwareSemantics {
+
+        @BeforeEach
+        void startEngine() {
+            engine.start();
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("Lifecycle counters reset to zero after close() then start()")
+        void lifecycleCountersResetAcrossRestart() {
+            FlowDefinition def = engine.plans().newDefinition("restart-counter-flow")
+                    .step("done", _ -> FlowOutcome.CONTINUE, null)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            for (int i = 0; i < 3; i++) {
+                engine.scheduler().schedule(plan, TestFlowContexts.create(
+                        UUID.randomUUID().toString(), "restart-counter-flow"));
+            }
+
+            assertThat(awaitCondition(() -> engine.stats().completedFlows() >= 3L, 5))
+                    .as("Three flows must complete before observing counters")
+                    .isTrue();
+
+            FlowEngineStats before = engine.stats();
+            assertThat(before.completedFlows())
+                    .as("completedFlows MUST be > 0 before restart")
+                    .isGreaterThan(0L);
+
+            engine.close();
+            engine.start();
+
+            FlowEngineStats after = engine.stats();
+            assertThat(after.completedFlows())
+                    .as("completedFlows MUST reset to 0 after close() → start() (lifecycle generation)")
+                    .isZero();
+            assertThat(after.failedFlows())
+                    .as("failedFlows MUST reset to 0 after close() → start()")
+                    .isZero();
+            assertThat(after.activeFlows())
+                    .as("activeFlows MUST be 0 after close() → start()")
+                    .isZero();
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("Scheduling a PARKED context is a no-op — step is not executed")
+        void parkedRescheduleDoesNotExecuteStep() {
+            AtomicInteger executions = new AtomicInteger();
+
+            FlowDefinition def = engine.plans().newDefinition("parked-reschedule-flow")
+                    .step("must-not-execute", _ -> {
+                        executions.incrementAndGet();
+                        return FlowOutcome.CONTINUE;
+                    }, null)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            FlowContext parkedCtx = TestFlowContexts.createWithState(
+                    UUID.randomUUID().toString(),
+                    "parked-reschedule-flow",
+                    FlowState.PARKED);
+
+            engine.scheduler().schedule(plan, parkedCtx);
+            // Give any spurious dispatch time to manifest.
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(300L));
+
+            assertThat(executions.get())
+                    .as("Scheduling a PARKED context MUST NOT execute the step (no-op semantics)")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("lookupParked for an unknown instance returns empty() without throwing")
+        void lookupParkedUnknownReturnsEmpty() {
+            FlowContext unknown = TestFlowContexts.create(
+                    UUID.randomUUID().toString(), "never-scheduled-flow");
+
+            Optional<FlowContext> result = engine.scheduler().lookupParked(
+                    unknown.instanceIdMost(), unknown.instanceIdLeast());
+
+            assertThat(result)
+                    .as("lookupParked for an unknown instance MUST return Optional.empty()")
+                    .isEmpty();
+        }
+    }
+
+    // =========================================================================
+    // DIST-303 — Saga timeout enforcement (FlowTimeoutEvent + compensation)
+    // =========================================================================
+
+    /**
+     * DIST-303: a flow whose absolute timeout has already passed at scheduling time
+     * MUST NOT execute its first step; the engine MUST drive the instance to
+     * {@link FlowState#FAILED_ROLLEDBACK} via the compensation path and emit a
+     * {@code eu.exeris.kernel.flow.Timeout} JFR event. The check is binding-agnostic —
+     * both Community (heap) and Enterprise (off-heap) implementations are obliged.
+     */
+    @Nested
+    @DisplayName("FlowEngine saga timeout contract")
+    class SagaTimeoutContract {
+
+        private static final String TIMEOUT_EVENT = "eu.exeris.kernel.flow.Timeout";
+
+        @BeforeEach
+        void startEngine() {
+            engine.start();
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("Already-expired deadline routes the flow to FAILED_ROLLEDBACK without executing the step")
+        void expiredDeadlineFailsWithoutExecutingStep() throws Exception {
+            CountDownLatch timeoutEventReceived = new CountDownLatch(1);
+            AtomicInteger executions = new AtomicInteger();
+
+            try (RecordingStream rs = new RecordingStream()) {
+                rs.enable(TIMEOUT_EVENT);
+                rs.onEvent(TIMEOUT_EVENT, _ -> timeoutEventReceived.countDown());
+                rs.startAsync();
+
+                FlowDefinition def = engine.plans().newDefinition("timeout-flow")
+                        .step("must-not-execute", _ -> {
+                            executions.incrementAndGet();
+                            return FlowOutcome.CONTINUE;
+                        }, null)
+                        .build();
+                FlowExecutionPlan plan = engine.plans().compile(def);
+
+                FlowContext expired = expiredCtx(UUID.randomUUID().toString(), "timeout-flow");
+                engine.scheduler().schedule(plan, expired);
+
+                assertThat(awaitCondition(() -> engine.stats().failedFlows() >= 1L, 5))
+                        .as("Expired flow MUST transition to FAILED_ROLLEDBACK within 5 s")
+                        .isTrue();
+                assertThat(executions.get())
+                        .as("Step MUST NOT execute when the absolute deadline has already passed")
+                        .isZero();
+                assertThat(timeoutEventReceived.await(3, TimeUnit.SECONDS))
+                        .as("eu.exeris.kernel.flow.Timeout MUST fire on deadline detection")
+                        .isTrue();
+            }
+        }
+
+        private static FlowContext expiredCtx(String instanceId, String definitionName) {
+            UUID uuid = UUID.nameUUIDFromBytes(
+                    instanceId.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return new FlowContext() {
+                @Override public long instanceIdMost()   { return uuid.getMostSignificantBits(); }
+                @Override public long instanceIdLeast()  { return uuid.getLeastSignificantBits(); }
+                @Override public String definitionName() { return definitionName; }
+                @Override public int currentStep()       { return 0; }
+                @Override public FlowState state()       { return FlowState.RUNNING; }
+                @Override public long timeoutNanos()     { return 1L; }
+            };
+        }
+    }
+
+    private static boolean awaitCondition(BooleanSupplier condition, int timeoutSeconds) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            LockSupport.parkNanos(1_000_000L);
+        }
+        return condition.getAsBoolean();
     }
 }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/TestFlowContexts.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/TestFlowContexts.java
@@ -18,13 +18,16 @@ import java.util.UUID;
 final class TestFlowContexts {
     private TestFlowContexts() {}
     static FlowContext create(String instanceId, String definitionName) {
+        return createWithState(instanceId, definitionName, FlowState.RUNNING);
+    }
+    static FlowContext createWithState(String instanceId, String definitionName, FlowState state) {
         UUID uuid = UUID.nameUUIDFromBytes(instanceId.getBytes(StandardCharsets.UTF_8));
         return new FlowContext() {
             @Override public long instanceIdMost()    { return uuid.getMostSignificantBits(); }
             @Override public long instanceIdLeast()   { return uuid.getLeastSignificantBits(); }
             @Override public String definitionName()  { return definitionName; }
             @Override public int currentStep()        { return 0; }
-            @Override public FlowState state()        { return FlowState.RUNNING; }
+            @Override public FlowState state()        { return state; }
             @Override public long timeoutNanos()      { return System.nanoTime() + 30_000_000_000L; }
         };
     }


### PR DESCRIPTION
## Summary

EPIC-1 closure for v0.7. Three runtime additions (bounded terminal-state catalog, shutdown duration, saga timeout enforcement), two TCK lifts (shutdown event + restart-aware semantics), and a Sprint 3 H2 regression fix.

| Item | Surface | Layer |
|:--|:--|:--|
| FLOW-107 | `FlowEngineConfig.terminalCatalogMaxSize`; `CoreFlowRuntime.TerminalStateCatalog` | SPI / Core |
| FLOW-108 | `FlowEngineShutdownEvent.shutdownDurationNs` | Core JFR |
| DIST-303 | `FlowEngineConfig.DEFAULT_SAGA_TIMEOUT_{SHORT,LONG}_NANOS`; `FlowTimeoutEvent`; deadline check in `runStep()` | SPI / Core |
| TCK-062 | `AbstractFlowEngineTck.JfrShutdownContract` | TCK |
| TCK-063 | `AbstractFlowEngineTck.RestartAwareSemantics` (3 tests) + `SagaTimeoutContract` (1 test) | TCK |
| Sprint 3 fix | `V0.7.0__create_saga_state.sql` portable composite index | Community migration |

## FLOW-107 — bounded terminal-state catalog

Long-running Community runtimes accumulated terminal-state entries forever (one entry per saga that ever completed). The catalog is the in-process idempotency fence — it cannot just be evicted blindly without breaking re-execution guarantees.

**Two operating modes** selected by `FlowEngineConfig.terminalCatalogMaxSize`:

- **`maxSize == 0` (default, backward compatible).** `ConcurrentHashMap`; entries accumulate from `start()` until `close()`. Snapshot is deleted on `complete()`.
- **`maxSize > 0` (bounded LRU).** Access-order `LinkedHashMap` evicts the eldest entry when the cap is reached. `deleteSnapshot()` becomes a no-op in this mode — the durable `FlowSnapshotStore` row for `COMPLETED` is the cross-eviction proof. On a resubmit miss against the in-memory catalog, `CoreFlowRuntime` restores the snapshot, observes the terminal state, re-caches the entry, and short-circuits the schedule. Subsequent resubmits hit the fast path again.

**Correctness invariant (preserved in both modes):** an evicted entry MUST remain recoverable from `FlowSnapshotStore` so the engine can reject a resubmit. Bounded mode without persistence is permitted but documented as best-effort idempotency.

## FLOW-108 — shutdown duration on `FlowEngineShutdownEvent`

`CoreFlowEngine.close()` now times the wall-clock spent in unsubscribe + `runtime.close()` (interrupt + 5 s join window) and publishes it as `shutdownDurationNs` on the existing `eu.exeris.kernel.flow.Shutdown` JFR event. Operators can use this to flag deployments where the bounded join window is consistently exhausted.

## DIST-303 — saga timeout enforcement

Two informational defaults exposed on `FlowEngineConfig` for callers classifying transactional (30 s) vs business-process (30 days) sagas. The actual deadline carried by the engine is the absolute `timeoutNanos` on the `FlowContext` (or `plan.timeoutDurationNanos()` evaluated at `RuntimeFlowInstance.fromContext`).

`CoreFlowRuntime.runStep()` checks the deadline before each step:

- If `timeoutNanos == Long.MAX_VALUE` (encodes `Instant.MAX`) → no check.
- If `deadline < System.nanoTime()` → emit `FlowTimeoutEvent` (`eu.exeris.kernel.flow.Timeout`, fields: `engineName`, `definitionName`, `instanceId{Most,Least}`, `currentStep`, `overrunNanos`) and drive the instance through the compensation path to `FAILED_ROLLEDBACK` via the existing `fail()` machinery.

The check happens **before** `tryClaimStep` so a timed-out flow does not consume an idempotency slot.

## TCK-062 + TCK-063 — binding-agnostic obligations

| Nested class | Tests | Asserts |
|:--|:--|:--|
| `JfrShutdownContract` | 1 | `eu.exeris.kernel.flow.Shutdown` fires within 5 s of `close()` with non-blank `engineName`, `shutdownDurationNs >= 0`, all counter fields published; emitted exactly once per `close()`. |
| `RestartAwareSemantics` | 3 | Counter reset across `close()` → `start()`; PARKED-state schedule is a no-op; `lookupParked(unknownId)` returns `Optional.empty()` without throwing. |
| `SagaTimeoutContract` | 1 | Already-expired deadline routes the flow to `FAILED_ROLLEDBACK` without executing the step; `eu.exeris.kernel.flow.Timeout` JFR event fires. |

`TestFlowContexts.createWithState(...)` is added to support PARKED-context construction for TCK-063.

## Sprint 3 H2 regression — portable index

`V0.7.0__create_saga_state.sql` shipped a Postgres-only partial index (`CREATE INDEX … WHERE state = 'PARKED'`) which H2 — used by `CommunityOutboxGuaranteeTckTest`'s in-memory persistence smoke path — does not support. Replaced with a portable composite `(state, last_update)`; `JdbcFlowSnapshotStore.listParked` continues to benefit from the leading column on Postgres.

## Doc sync

`docs/subsystems/flow.md`:

- Rewrites **Terminal-State Catalog Retention** to document both modes and the bounded-mode invariant.
- New **Saga Timeout Enforcement (since 0.7.0)** subsection.
- New **FlowEngine Restart Semantics (since 0.7.0)** subsection summarising the TCK-063 obligations.
- Updates the JFR events table: `FlowEngineShutdownEvent` gets `shutdownDurationNs`; `FlowTimeoutEvent` is added.
- TCK Coverage row for `AbstractFlowEngineTck` annotated with TCK-062 / TCK-063 / DIST-303.

## Test plan

- [x] `mvn install -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am -Dpmd.skip=true -Dcheckstyle.skip=true` — SPI 496, TCK 27, Core 1073, Community 966 = **2562 tests, 0 failures, 0 errors**.
- [x] `CommunityFlowEngineTckTest` — 15/15 green (5 new from this sprint).
- [x] `CommunityJdbcFlowSnapshotStoreTckIT` (Postgres 16 / Testcontainers) — 10/10 green.
- [x] `CommunityOutboxGuaranteeTckTest` — 5/5 green after H2 index fix.
- [x] `CommunitySagaRecoveryTckTest` and `CommunityFlowSchedulerTckTest` unaffected.

## Boundary notes

- SPI surface: `FlowEngineConfig` gains 3 fields + a backward-compat 11-arg constructor (Sprint 1 precedent — same shape as `FlowSnapshot.SCHEMA_VERSION_INITIAL` shim). No driver leakage; `terminalCatalogMaxSize` is implementation-blind (Community uses heap LRU, Enterprise can use off-heap with the same contract).
- Core: `TerminalStateCatalog` is a private nested class in `CoreFlowRuntime`. Hot path unchanged for `maxSize == 0` (still `ConcurrentHashMap`). Bounded mode takes a `synchronized` per containsKey/put on a cold idempotency-fence path.
- No `ThreadLocal`, no `ExecutorService`, no `MemorySegment` lifecycle changes. JFR-first instrumentation preserved.

## Out of scope (deferred)

- DB-side TTL sweeper for `exeris_saga_state` (DIST-303 phase 2) — current implementation enforces timeouts on the runtime path; periodic eviction of long-since-completed rows is a separate, non-blocking concern.