### PR TITLE
v0.7 Sprint 5a: Events stream SPI + registry TCK closure (EPIC-2 part 1)

### DIFF
--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -40,11 +40,15 @@ operates on local memory, a PostgreSQL partition, or a Kafka cluster. (The SPI i
 - **`CommunityEventBusOutboxBrokerPort`** — Outbox delivery port that publishes to the local in-memory `CommunityEventBus` (NOT to Kafka/Redpanda)
 - **`CommunityEventProvider`** — `ServiceLoader` entry point
 
+**Implemented in 0.7 (Sprint 5a — SPI groundwork):**
+- `EventStreamReader` / `EventStreamAppender` / `EventStream` / `StreamId` SPI contracts (`exeris-kernel-spi`) — implementation-blind replay/append surface targeted at the upcoming Kafka driver and the existing PostgreSQL outbox path. `KernelProviders.EVENT_STREAM_READER` / `KernelProviders.EVENT_STREAM_APPENDER` ScopedValue slots are wired for bootstrapper hand-off.
+- `AbstractEventRegistryTck` (EVENT-205a) — binding-agnostic contract for `EX-EVENT-6003` ordinal conflict with `rawArgs == [eventType, ordinal]`. Community binding green.
+
 **Not yet implemented:**
-- Kafka or Redpanda driver — **no binding exists in the repository**
-- `EventStreamReader` / `EventStreamAppender` SPI contracts
-- Per-subscription retry configuration on `EventBus`
-- Operator-triggered DLQ replay API (`EventEngine.replayFromDlq(dlqId)`)
+- Kafka or Redpanda driver — **no binding exists in the repository** (planned: Sprint 5b — `exeris-kernel-community-kafka` module + Core `KafkaSessionOrchestrator` + `KafkaEventEngine` + `AbstractKafkaEventEngineTck`).
+- `AbstractEventBackpressureTck` for `EX-EVENT-6002` — deferred to Sprint 5b. The current Community `EventQueue` blocks on full via `LinkedBlockingDeque.putLast()`; aligning with the doc'd throw-on-full contract requires a `EventEngineConfig.busPublishFailFast` knob to preserve backward compatibility.
+- Per-subscription retry configuration on `EventBus`.
+- Operator-triggered DLQ replay API (`EventEngine.replayFromDlq(dlqId)`).
 
 ---
 
@@ -108,7 +112,7 @@ in the `EventDescriptor` primitive layout.
 **What Events SPI DOES:**
 
 1. Define `EventDescriptor` (primitive-only routing metadata) and `EventPayload` (ref-counted off-heap bytes).
-2. Provide `EventStreamReader` and `EventStreamAppender` interfaces *(Target State — not yet implemented)*.
+2. Provide `EventStreamReader` and `EventStreamAppender` interfaces (since 0.7.0, EVENT-203) plus the `StreamId` / `EventStream` carriers used to query and stream events. Implementation-blind — bindings (PostgreSQL outbox, Kafka driver, Enterprise off-heap log) provide the cursor.
 3. Define `EventRegistry` ordinal contract for O(1) type routing.
 4. Define conflict-resolution routing via `EventDescriptor.flags` (PERSISTENT, ORDERED, ASYNC, BROADCAST). Note: optimistic concurrency version enforcement is a Persistence SPI concern (`PersistenceEngine.append(streamId, expectedVersion, …)`), not an Events routing concern.
 
@@ -238,29 +242,40 @@ fields: `eventType (String)`, `streamIdHigh (long)`, `streamIdLow (long)`, `reas
 
 ## Event Replay API
 
-> **Target State — not yet implemented.** `EventStreamReader`, `EventStreamAppender`, `StreamId`, and
-> `EventStream` SPI contracts do not yet exist in `exeris-kernel-spi`. This section describes a planned
-> capability.
-
-The `EventStreamReader` SPI supports replay from a specific position in the Event Store.
-This enables CQRS projection rebuilds without external tooling.
+The `EventStreamReader` / `EventStreamAppender` SPI (since 0.7.0, EVENT-203) defines a binding-agnostic replay and direct-append surface that brokers (PostgreSQL outbox, Kafka, Enterprise off-heap log) implement and bootstrappers wire via `KernelProviders.EVENT_STREAM_READER` / `KernelProviders.EVENT_STREAM_APPENDER`. Application code consults `KernelProviders.eventStreamReader()` / `KernelProviders.eventStreamAppender()` and treats an empty `Optional` as "broker does not support this capability" — never as a hard error.
 
 ```java
 public interface EventStreamReader extends AutoCloseable {
-    // Replay all events from a specific timestamp (inclusive)
+    // Replay all events for a specific stream from a timestamp (inclusive)
     EventStream replayFrom(StreamId streamId, Instant fromTimestamp);
 
-    // Replay from a specific event version/offset
+    // Replay from a specific stream version (broker-defined offset semantics)
     EventStream replayFromVersion(StreamId streamId, long fromVersion);
 
-    // Replay all events for an aggregate type (cross-stream)
+    // Cross-stream replay of every event of a given type (projection rebuild)
     EventStream replayByType(String eventType, Instant fromTimestamp);
+
+    @Override void close(); // releases shared driver resources; idempotent
 }
+
+@FunctionalInterface
+public interface EventStreamAppender {
+    // Same RAII ownership transfer as EventBus.publish(...)
+    void append(StreamId streamId, EventDescriptor descriptor, EventPayload payload);
+}
+
+public record StreamId(long streamIdHigh, long streamIdLow, String streamType) { ... }
 ```
 
-**Zero-allocation replay path:** Events are streamed directly from the PostgreSQL WAL or Kafka
-topic into `LoanedBuffer` slabs — no intermediate `List<Event>` materialisation.
-`EventStream` implements `Iterable<EventPayload>` and closes each payload on `Iterator.next()`.
+`StreamId` is wire-compatible with `EventDescriptor.streamIdHigh()` / `streamIdLow()` so the same routing index serves both descriptor dispatch and stream-scoped queries.
+
+**Zero-allocation replay path:** Events are streamed directly from the PostgreSQL WAL or Kafka topic into `LoanedBuffer` slabs — no intermediate `List<Event>` materialisation. `EventStream extends Iterable<EventPayload>, AutoCloseable`; each payload arrives at refCount 1 and the consumer closes it (no broadcast retain protocol on replay). The cursor is released via `EventStream.close()`.
+
+**Bindings (status):**
+
+- PostgreSQL outbox replay — planned (no current binding).
+- Kafka driver — planned for Sprint 5b in the new `exeris-kernel-community-kafka` module.
+- Enterprise off-heap log — out-of-repo, target-state.
 
 ---
 
@@ -311,9 +326,9 @@ operational differences relevant to a future Exeris Kafka/Redpanda driver:
 - `EventDescriptor` scalarization: verify no heap objects are created during descriptor construction.
 - `EventPayload` ref-count correctness: N subscribers → ref-count N; last `close()` → pool return.
 - `EventRegistry` ordinal conflicts: `EX-EVENT-6003` thrown on duplicate registration.
-  > **(TCK gap — not yet implemented)**
+  > **Closed in 0.7 (EVENT-205a).** Covered by `AbstractEventRegistryTck`; Community binding `CommunityEventRegistryTckTest` green. Asserts both error code and `rawArgs == [String eventType, int ordinal]` per the documented Glass-Box layout.
 - Backpressure: `EX-EVENT-6002` thrown with correct `rawArgs` when queue is at capacity.
-  > **(TCK gap — not yet implemented)**
+  > **(TCK gap — deferred to Sprint 5b.)** Reconciliation requires `EventEngineConfig.busPublishFailFast` because the current Community `EventQueue` blocks on full via `LinkedBlockingDeque.putLast()` (safe for virtual threads, but inconsistent with the throw-on-full contract documented above).
 
 ### Integration Tests (TCK)
 

--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -46,6 +46,7 @@ operates on local memory, a PostgreSQL partition, or a Kafka cluster. (The SPI i
 
 **Not yet implemented:**
 - Kafka or Redpanda driver — **no binding exists in the repository** (planned: Sprint 5b — `exeris-kernel-community-kafka` module + Core `KafkaSessionOrchestrator` + `KafkaEventEngine` + `AbstractKafkaEventEngineTck`).
+- `AbstractEventStreamReaderTck` and `AbstractEventStreamAppenderTck` — the SPI contracts ship in 0.7 (Sprint 5a) but the abstract TCK suites and Community bindings are deferred to Sprint 5b together with the first concrete binding (Kafka driver) so the assertions can verify real cursor / append behaviour rather than a stub.
 - `AbstractEventBackpressureTck` for `EX-EVENT-6002` — deferred to Sprint 5b. The current Community `EventQueue` blocks on full via `LinkedBlockingDeque.putLast()`; aligning with the doc'd throw-on-full contract requires a `EventEngineConfig.busPublishFailFast` knob to preserve backward compatibility.
 - Per-subscription retry configuration on `EventBus`.
 - Operator-triggered DLQ replay API (`EventEngine.replayFromDlq(dlqId)`).

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/events/CommunityEventRegistryTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/events/CommunityEventRegistryTckTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.events;
+
+import eu.exeris.kernel.spi.events.EventEngine;
+import eu.exeris.kernel.spi.events.EventEngineConfig;
+import eu.exeris.kernel.tck.contract.events.AbstractEventRegistryTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Community: EventRegistry TCK (EVENT-205 ordinal conflict)")
+class CommunityEventRegistryTckTest extends AbstractEventRegistryTck {
+
+    @Override
+    protected EventEngine createEngine() {
+        return new CommunityEventProvider().createEngine(EventEngineConfig.communityDefaults());
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/context/KernelProviders.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/context/KernelProviders.java
@@ -12,6 +12,8 @@ import eu.exeris.kernel.spi.config.ConfigProvider;
 import eu.exeris.kernel.spi.crypto.KernelCryptoProvider;
 import eu.exeris.kernel.spi.events.EventEngine;
 import eu.exeris.kernel.spi.events.EventProvider;
+import eu.exeris.kernel.spi.events.EventStreamAppender;
+import eu.exeris.kernel.spi.events.EventStreamReader;
 import eu.exeris.kernel.spi.exceptions.security.PrincipalContextMissingException;
 import eu.exeris.kernel.spi.exceptions.security.StorageContextMissingException;
 import eu.exeris.kernel.spi.flow.FlowEngine;
@@ -266,6 +268,30 @@ public final class KernelProviders {
      * @see eu.exeris.kernel.spi.events.EventProvider
      */
     public static final ScopedValue<EventEngine> EVENT_ENGINE = ScopedValue.newInstance();
+
+    /**
+     * Optional {@link EventStreamReader} for replay over the durable event log
+     * (since 0.7.0). Bound by the bootstrapper before {@link EventEngine#start()} when
+     * a binding (e.g. PostgreSQL outbox replay, Kafka consumer-seek driver) is on the
+     * classpath. Application code should consult {@link #eventStreamReader()} and treat
+     * an empty {@link Optional} as "broker does not support replay" — never as a hard error.
+     *
+     * @since 0.7.0
+     * @see EventStreamReader
+     */
+    public static final ScopedValue<EventStreamReader> EVENT_STREAM_READER = ScopedValue.newInstance();
+
+    /**
+     * Optional {@link EventStreamAppender} for direct durable append (since 0.7.0).
+     * Bound by the bootstrapper before {@link EventEngine#start()} when a binding
+     * (e.g. Kafka producer with explicit partition control) is on the classpath. Most
+     * callers route through the transactional outbox; direct use is reserved for sites
+     * that need topic/partition routing.
+     *
+     * @since 0.7.0
+     * @see EventStreamAppender
+     */
+    public static final ScopedValue<EventStreamAppender> EVENT_STREAM_APPENDER = ScopedValue.newInstance();
 
     // =========================================================================
     // Flow Slots (L4 Saga / Flow Orchestration)
@@ -555,6 +581,32 @@ public final class KernelProviders {
      */
     public static EventProvider eventProvider() {
         return EVENT_PROVIDER.get();
+    }
+
+    /**
+     * Returns the optional {@link EventStreamReader} from the current scope.
+     *
+     * @return an {@link Optional} containing the reader if a binding is present and
+     *         the slot was bound; empty otherwise
+     * @since 0.7.0
+     */
+    public static Optional<EventStreamReader> eventStreamReader() {
+        return EVENT_STREAM_READER.isBound()
+                ? Optional.of(EVENT_STREAM_READER.get())
+                : Optional.empty();
+    }
+
+    /**
+     * Returns the optional {@link EventStreamAppender} from the current scope.
+     *
+     * @return an {@link Optional} containing the appender if a binding is present and
+     *         the slot was bound; empty otherwise
+     * @since 0.7.0
+     */
+    public static Optional<EventStreamAppender> eventStreamAppender() {
+        return EVENT_STREAM_APPENDER.isBound()
+                ? Optional.of(EVENT_STREAM_APPENDER.get())
+                : Optional.empty();
     }
 
     /**

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStream.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.events;
+
+/**
+ * SPI: streamed iterator over events returned by {@link EventStreamReader}.
+ *
+ * <h2>The Wall (SPI Compliance)</h2>
+ * <p>Implementation-blind. The community binding may be backed by a JDBC cursor
+ * (PostgreSQL WAL replay), the Kafka driver may be backed by a partitioned consumer
+ * seeking from offset/timestamp; neither leaks here. Callers see only an
+ * {@code Iterable<EventPayload>} that releases the underlying cursor on {@link #close()}.
+ *
+ * <h2>RAII Per-Payload Lifecycle</h2>
+ * <p>Each {@link EventPayload} returned by the iterator has reference count {@code 1}
+ * on hand-off. Callers MUST call {@link EventPayload#close()} on every payload they
+ * consume — typically via {@code try-with-resources} on the payload itself. The bus's
+ * broadcast retain protocol does not apply here: replay delivers single-consumer payloads.
+ *
+ * <h2>Cursor Lifecycle</h2>
+ * <p>The stream owns an underlying cursor (DB result set, broker consumer, etc.).
+ * Callers MUST call {@link #close()} when done — typically via {@code try-with-resources}
+ * on the {@code EventStream} itself — to release the cursor; failing to do so leaks
+ * driver resources. {@code close()} is idempotent.
+ *
+ * <h2>Allocation Discipline</h2>
+ * <p>Implementations SHOULD reuse a single {@link EventPayload} carrier per
+ * {@code Iterator.next()} call — or hand the caller a payload whose backing slab is
+ * lazily filled — so the per-event allocation budget on a hot replay path is bounded
+ * by the descriptor footprint, not by the payload size.
+ *
+ * @since 0.7.0
+ * @see EventStreamReader
+ * @see EventPayload
+ */
+public interface EventStream extends Iterable<EventPayload>, AutoCloseable {
+
+    /**
+     * Releases the underlying cursor (DB result set, broker consumer, etc.).
+     * Idempotent. Overridden to remove the {@code throws Exception} clause from
+     * {@link AutoCloseable} — implementations MUST NOT raise checked exceptions
+     * here; lift any internal failure to a runtime kernel exception (e.g.
+     * {@link eu.exeris.kernel.spi.exceptions.events.EventEngineException}).
+     */
+    @Override
+    void close();
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamAppender.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamAppender.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.events;
+
+/**
+ * SPI: durable append API for distributed event-log bindings.
+ *
+ * <h2>Role vs {@link EventBus}</h2>
+ * <p>{@link EventBus#publish(EventDescriptor, EventPayload)} is the in-process pub/sub
+ * dispatch path; it does not guarantee durability beyond the local engine. {@code
+ * EventStreamAppender} is the explicit durable-append path that bindings (Kafka producer,
+ * PostgreSQL outbox writer, Enterprise off-heap log) implement to commit an event to the
+ * shared distributed log. Most callers route through the transactional outbox and the
+ * orchestrator picks the broker port; direct use of this SPI is reserved for sites that
+ * need topic/partition control (e.g. choreography emit on a non-default partition).
+ *
+ * <h2>The Wall (SPI Compliance)</h2>
+ * <p>Implementation-blind. No Kafka {@code ProducerRecord}, no JDBC {@code PreparedStatement},
+ * no Panama {@code MemorySegment} layout escapes the contract.
+ *
+ * <h2>Discovery &amp; Wiring</h2>
+ * <p>An implementation is bound to
+ * {@link eu.exeris.kernel.spi.context.KernelProviders#EVENT_STREAM_APPENDER}
+ * by the bootstrapper before {@link EventEngine#start()}. When unbound, callers MUST
+ * fall back to the {@link EventBus} dispatch path; absence is not a hard error.
+ *
+ * <h2>RAII Ownership</h2>
+ * <p>Same protocol as {@link EventBus#publish}: the appender takes ownership of
+ * {@code payload} on entry. After the call returns (success or thrown exception),
+ * the caller MUST NOT call {@link EventPayload#close()} on the same reference.
+ *
+ * @since 0.7.0
+ * @see EventStreamReader
+ */
+@FunctionalInterface
+public interface EventStreamAppender {
+
+    /**
+     * Appends a single event to the durable log identified by {@code streamId}.
+     *
+     * <p>Synchronous on the contract surface — the call returns only after the binding
+     * has accepted ownership of the payload (Kafka producer enqueue, JDBC outbox INSERT
+     * commit, etc.). Implementations MAY perform the actual broker round-trip
+     * asynchronously off the caller thread.
+     *
+     * @param streamId   target stream; {@link StreamId#streamIdHigh()} /
+     *                   {@link StreamId#streamIdLow()} MUST match the stream UUID carried
+     *                   by {@code descriptor}
+     * @param descriptor routing metadata (non-null)
+     * @param payload    event payload; ownership transfers to the appender (non-null;
+     *                   use {@link EventPayload#empty()} for no-data events)
+     * @throws eu.exeris.kernel.spi.exceptions.events.EventEngineException
+     *         when the binding cannot accept the append (broker disconnected, outbox
+     *         INSERT rejected, etc.)
+     */
+    void append(StreamId streamId, EventDescriptor descriptor, EventPayload payload);
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamReader.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamReader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.events;
+
+import java.time.Instant;
+
+/**
+ * SPI: replay query API over the durable event log.
+ *
+ * <h2>The Wall (SPI Compliance)</h2>
+ * <p>Implementation-blind. Bindings (PostgreSQL outbox, Kafka consumer, Enterprise
+ * off-heap log) provide the cursor; callers see only {@link EventStream} hand-off.
+ *
+ * <h2>Discovery &amp; Wiring</h2>
+ * <p>An implementation is bound to
+ * {@link eu.exeris.kernel.spi.context.KernelProviders#EVENT_STREAM_READER}
+ * by the bootstrapper before {@link EventEngine#start()} (analogous to
+ * {@link eu.exeris.kernel.spi.flow.model.FlowSnapshotStore}). When unbound, replay
+ * APIs are not available — application code SHOULD treat the absence as
+ * "broker does not support replay" rather than as a hard error.
+ *
+ * <h2>Use Cases</h2>
+ * <ul>
+ *   <li>CQRS projection rebuild — re-read all events for a projection's source streams.</li>
+ *   <li>Saga forensic replay — reconstruct a saga's effective inbound event log after
+ *       a cross-restart wake on a different node.</li>
+ *   <li>Audit / compliance — replay every event of a given type within a timestamp window.</li>
+ * </ul>
+ *
+ * <h2>Cursor Lifecycle</h2>
+ * <p>Each method returns a fresh {@link EventStream} that owns an underlying cursor.
+ * Callers MUST close every returned stream. {@link #close()} on the reader itself
+ * releases shared driver resources (connection pool slot, consumer group session) and
+ * is idempotent.
+ *
+ * @since 0.7.0
+ * @see EventStream
+ * @see EventStreamAppender
+ */
+public interface EventStreamReader extends AutoCloseable {
+
+    /**
+     * Replays every event for the given stream whose {@code occurredAt} is at or after
+     * {@code fromTimestamp}.
+     *
+     * @param streamId      the stream to replay; must not be {@code null}
+     * @param fromTimestamp inclusive lower bound on {@code occurredAt}; must not be {@code null}
+     * @return live {@link EventStream}; the caller MUST close it
+     * @throws eu.exeris.kernel.spi.exceptions.events.EventEngineException
+     *         on driver-level failure (connection lost, cursor open rejected, etc.)
+     */
+    EventStream replayFrom(StreamId streamId, Instant fromTimestamp);
+
+    /**
+     * Replays every event for the given stream whose monotonic version is at or after
+     * {@code fromVersion}.
+     *
+     * <p>Bindings that do not maintain a per-stream monotonic version (e.g. raw Kafka
+     * topic without an aggregate-version offset) MAY map this query onto their native
+     * offset semantics; bindings that do (PostgreSQL outbox, Enterprise off-heap log)
+     * use the version directly.
+     *
+     * @param streamId    the stream to replay; must not be {@code null}
+     * @param fromVersion inclusive lower bound on the per-stream version; {@code >= 0}
+     * @return live {@link EventStream}; the caller MUST close it
+     * @throws eu.exeris.kernel.spi.exceptions.events.EventEngineException
+     *         on driver-level failure
+     */
+    EventStream replayFromVersion(StreamId streamId, long fromVersion);
+
+    /**
+     * Cross-stream replay of every event of the given type since {@code fromTimestamp}.
+     *
+     * <p>Used for projection rebuilds where the projection observes events from many
+     * stream instances of the same {@code eventType}.
+     *
+     * @param eventType     non-blank event type name as registered in {@link EventRegistry}
+     * @param fromTimestamp inclusive lower bound on {@code occurredAt}; must not be {@code null}
+     * @return live {@link EventStream}; the caller MUST close it
+     * @throws eu.exeris.kernel.spi.exceptions.events.EventEngineException
+     *         on driver-level failure
+     */
+    EventStream replayByType(String eventType, Instant fromTimestamp);
+
+    /**
+     * Releases shared driver resources held by the reader.
+     * Idempotent. Open {@link EventStream} instances returned earlier remain valid
+     * until they themselves are closed; {@code close()} on the reader does not
+     * cancel them.
+     */
+    @Override
+    void close();
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/StreamId.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/StreamId.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.events;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Valhalla-ready identifier of an event stream (aggregate root).
+ *
+ * <h2>Design Intent</h2>
+ * <p>{@code StreamId} mirrors the high/low {@code long} pair that {@link EventDescriptor}
+ * already carries for stream UUIDs, plus a non-blank {@code streamType} qualifier
+ * (e.g. {@code "Order"}, {@code "User"}) that brokers and replay APIs use to scope a
+ * query without re-deriving the type from a per-event field.
+ *
+ * <h2>Valhalla Readiness (JEP 401)</h2>
+ * <ul>
+ *   <li>Two primitive {@code long} fields plus one {@link String}; no identity-sensitive
+ *       collaborators. Adding the {@code value} modifier requires zero field changes.</li>
+ *   <li>{@link #toUuid()} allocates a {@link UUID} and is for diagnostics / logging only —
+ *       do NOT call from a hot dispatch loop.</li>
+ * </ul>
+ *
+ * <h2>Routing Compatibility</h2>
+ * <p>{@code streamIdHigh} and {@code streamIdLow} are wire-compatible with
+ * {@link EventDescriptor#streamIdHigh()} and {@link EventDescriptor#streamIdLow()}, so a
+ * stream-scoped query can be answered by the same off-heap routing index that the bus uses
+ * for descriptor dispatch.
+ *
+ * @param streamIdHigh high 64 bits of the stream UUID
+ * @param streamIdLow  low 64 bits of the stream UUID
+ * @param streamType   non-blank stream type qualifier (e.g. {@code "Order"})
+ *
+ * @since 0.7.0
+ * @see EventStreamReader
+ * @see EventStreamAppender
+ */
+public record StreamId(long streamIdHigh, long streamIdLow, String streamType) {
+
+    /**
+     * Compact constructor — validates {@code streamType} is non-null and non-blank.
+     */
+    public StreamId {
+        Objects.requireNonNull(streamType, "streamType must not be null");
+        if (streamType.isBlank()) {
+            throw new IllegalArgumentException("streamType must not be blank");
+        }
+    }
+
+    /**
+     * Convenience factory that splits a {@link UUID} into the primitive high/low pair.
+     *
+     * <p><b>Allocates</b> nothing beyond the returned record itself — but the {@code UUID}
+     * argument is itself heap-allocated, so prefer the canonical primitive constructor on
+     * hot paths.
+     *
+     * @param uuid       the stream UUID; must not be {@code null}
+     * @param streamType non-blank stream type qualifier
+     * @return new {@code StreamId} carrying {@code uuid}'s high/low bits
+     */
+    // 'of' is a standard Java factory idiom (cf. List.of, Map.of, EventDescriptor.of)
+    @SuppressWarnings("PMD.ShortMethodName")
+    public static StreamId of(UUID uuid, String streamType) {
+        Objects.requireNonNull(uuid, "uuid must not be null");
+        return new StreamId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits(), streamType);
+    }
+
+    /**
+     * Reconstructs the stream {@link UUID}.
+     *
+     * <p><b>Allocates</b> — diagnostic / logging path only. Use the high/low primitive
+     * accessors directly on the dispatch / replay hot path.
+     *
+     * @return new {@link UUID} composed of {@code streamIdHigh}/{@code streamIdLow}
+     */
+    public UUID toUuid() {
+        return new UUID(streamIdHigh, streamIdLow);
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventRegistryTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventRegistryTck.java
@@ -148,7 +148,7 @@ public abstract class AbstractEventRegistryTck {
         }
 
         @Test
-        @DisplayName("Same name with a different ordinal throws EX-EVENT-6003")
+        @DisplayName("Same name with a different ordinal throws EX-EVENT-6003 with rawArgs [name, newOrdinal]")
         void sameNameDifferentOrdinalThrowsConflict() {
             registry.register(EventTypeSpec.of(TYPE_USER_CREATED, ORDINAL_USER_CREATED));
 
@@ -159,11 +159,14 @@ public abstract class AbstractEventRegistryTck {
                         EventRegistryException registryEx = (EventRegistryException) ex;
                         assertThat(registryEx.errorCode())
                                 .isEqualTo(KernelErrorCodes.EX_EVENT_6003);
+                        // rawArgs MUST identify the *new* (conflicting) registration so operators
+                        // can distinguish from the existing entry. A buggy impl that reports the
+                        // pre-existing ordinal in slot 1 would silently mislead diagnostics —
+                        // assert both slots, not just rawArgs[0].
                         assertThat(registryEx.rawArgs())
-                                .as("rawArgs index 0 MUST be the conflicting type name")
-                                .isNotEmpty();
-                        assertThat(registryEx.rawArgs()[0])
-                                .isEqualTo(TYPE_USER_CREATED);
+                                .as("rawArgs MUST follow the [String eventType, int ordinal] layout "
+                                        + "carrying the conflicting registration")
+                                .containsExactly(TYPE_USER_CREATED, ORDINAL_ORDER_PLACED);
                     });
         }
     }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventRegistryTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventRegistryTck.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.events;
+
+import eu.exeris.kernel.spi.events.EventEngine;
+import eu.exeris.kernel.spi.events.EventRegistry;
+import eu.exeris.kernel.spi.events.EventTypeSpec;
+import eu.exeris.kernel.spi.exceptions.KernelErrorCodes;
+import eu.exeris.kernel.spi.exceptions.events.EventRegistryException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: Abstract base for {@link EventRegistry} contract verification.
+ *
+ * <h2>EVENT-205 — Closing the Registry TCK Gap</h2>
+ * <p>The {@code events.md} subsystem doc has long flagged
+ * {@code EX-EVENT-6003} (registry conflict) as a TCK gap; this suite is the binding-agnostic
+ * contract that every {@link EventRegistry} implementation must satisfy.
+ *
+ * <h2>Verified Constraints</h2>
+ * <ol>
+ *   <li>Registering a type with a fresh name + fresh ordinal succeeds and is observable
+ *       via {@link EventRegistry#resolve}, {@link EventRegistry#ordinalOf} and
+ *       {@link EventRegistry#size}.</li>
+ *   <li>Re-registering the <em>identical</em> {@link EventTypeSpec} is idempotent
+ *       (no-op; no exception).</li>
+ *   <li>Registering a different type name with an ordinal already in use throws
+ *       {@link EventRegistryException} carrying error code
+ *       {@value KernelErrorCodes#EX_EVENT_6003} and {@code rawArgs == [conflictingName, ordinal]}.</li>
+ *   <li>Registering the same name with a different ordinal throws
+ *       {@link EventRegistryException} with the same error code; rawArgs carry the
+ *       conflicting registration shape.</li>
+ * </ol>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * class CommunityEventRegistryTckTest extends AbstractEventRegistryTck {
+ *     \@Override protected EventEngine createEngine() {
+ *         return new CommunityEventProvider().createEngine(EventEngineConfig.defaults());
+ *     }
+ * }
+ * }</pre>
+ *
+ * @since 0.7.0
+ */
+@DisplayName("EventRegistry TCK — EVENT-205 ordinal conflict contract")
+public abstract class AbstractEventRegistryTck {
+
+    /** Creates a fresh, not-yet-started {@link EventEngine}. The TCK does not call {@code start()}. */
+    protected abstract EventEngine createEngine();
+
+    private static final int    ORDINAL_USER_CREATED  = 1_001;
+    private static final int    ORDINAL_ORDER_PLACED  = 1_002;
+    private static final String TYPE_USER_CREATED     = "RegistryTckUserCreated";
+    private static final String TYPE_ORDER_PLACED     = "RegistryTckOrderPlaced";
+    private static final String TYPE_DIFFERENT        = "RegistryTckDifferent";
+
+    private EventEngine engine;
+    private EventRegistry registry;
+
+    @BeforeEach
+    final void setUp() {
+        engine = createEngine();
+        registry = engine.registry();
+    }
+
+    @AfterEach
+    final void tearDown() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Successful registration")
+    class SuccessfulRegistration {
+
+        @Test
+        @DisplayName("register() with a fresh name and ordinal is observable via resolve/ordinalOf/size")
+        void registerFreshTypeIsObservable() {
+            int sizeBefore = registry.size();
+
+            registry.register(EventTypeSpec.of(TYPE_USER_CREATED, ORDINAL_USER_CREATED));
+
+            assertThat(registry.resolve(TYPE_USER_CREATED))
+                    .as("resolve() MUST return the registered spec")
+                    .isNotNull();
+            assertThat(registry.ordinalOf(TYPE_USER_CREATED))
+                    .as("ordinalOf() MUST return the registered ordinal")
+                    .isEqualTo(ORDINAL_USER_CREATED);
+            assertThat(registry.size())
+                    .as("size() MUST grow by 1 after a fresh registration")
+                    .isEqualTo(sizeBefore + 1);
+        }
+
+        @Test
+        @DisplayName("register() is idempotent for the IDENTICAL EventTypeSpec — no exception, size unchanged")
+        void registerSameSpecTwiceIsIdempotent() {
+            EventTypeSpec spec = EventTypeSpec.of(TYPE_ORDER_PLACED, ORDINAL_ORDER_PLACED);
+            registry.register(spec);
+            int sizeAfterFirst = registry.size();
+
+            assertThatCode(() -> registry.register(spec))
+                    .as("Re-registering the identical EventTypeSpec MUST NOT throw")
+                    .doesNotThrowAnyException();
+
+            assertThat(registry.size())
+                    .as("size() MUST be unchanged after idempotent re-registration")
+                    .isEqualTo(sizeAfterFirst);
+        }
+    }
+
+    @Nested
+    @DisplayName("Ordinal conflict — EX-EVENT-6003")
+    class OrdinalConflict {
+
+        @Test
+        @DisplayName("Different name with an ordinal already in use throws EX-EVENT-6003 with rawArgs [name, ordinal]")
+        void differentNameSameOrdinalThrowsConflict() {
+            registry.register(EventTypeSpec.of(TYPE_USER_CREATED, ORDINAL_USER_CREATED));
+
+            assertThatThrownBy(() -> registry.register(EventTypeSpec.of(TYPE_DIFFERENT, ORDINAL_USER_CREATED)))
+                    .as("EventRegistry MUST raise EX-EVENT-6003 on duplicate-ordinal registration")
+                    .isInstanceOf(EventRegistryException.class)
+                    .satisfies(ex -> {
+                        EventRegistryException registryEx = (EventRegistryException) ex;
+                        assertThat(registryEx.errorCode())
+                                .as("errorCode MUST be %s", KernelErrorCodes.EX_EVENT_6003)
+                                .isEqualTo(KernelErrorCodes.EX_EVENT_6003);
+                        assertThat(registryEx.rawArgs())
+                                .as("rawArgs MUST follow the [String eventType, int ordinal] layout")
+                                .containsExactly(TYPE_DIFFERENT, ORDINAL_USER_CREATED);
+                    });
+        }
+
+        @Test
+        @DisplayName("Same name with a different ordinal throws EX-EVENT-6003")
+        void sameNameDifferentOrdinalThrowsConflict() {
+            registry.register(EventTypeSpec.of(TYPE_USER_CREATED, ORDINAL_USER_CREATED));
+
+            assertThatThrownBy(() -> registry.register(EventTypeSpec.of(TYPE_USER_CREATED, ORDINAL_ORDER_PLACED)))
+                    .as("Re-registering the same name with a different ordinal MUST raise EX-EVENT-6003")
+                    .isInstanceOf(EventRegistryException.class)
+                    .satisfies(ex -> {
+                        EventRegistryException registryEx = (EventRegistryException) ex;
+                        assertThat(registryEx.errorCode())
+                                .isEqualTo(KernelErrorCodes.EX_EVENT_6003);
+                        assertThat(registryEx.rawArgs())
+                                .as("rawArgs index 0 MUST be the conflicting type name")
+                                .isNotEmpty();
+                        assertThat(registryEx.rawArgs()[0])
+                                .isEqualTo(TYPE_USER_CREATED);
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 5 (EPIC-2 Kafka EventEngine) is the largest in v0.7 (~1.5–2 weeks). I split it into two PRs mirroring the Sprint 1 → Sprint 3 pattern from EPIC-1:

- **5a (this PR)** — SPI groundwork + ordinal-conflict TCK gap closure + doc sync.
- **5b (next PR)** — `exeris-kernel-community-kafka` module, Core `KafkaSessionOrchestrator`, `KafkaEventEngine`, `AbstractKafkaEventEngineTck`, plus `busPublishFailFast` reconciliation for `EX-EVENT-6002`.

| Item | Surface | Layer |
|:--|:--|:--|
| EVENT-202 | gap analysis (events.md) | docs |
| EVENT-203 | `StreamId`, `EventStream`, `EventStreamReader`, `EventStreamAppender` + `KernelProviders` slots | SPI |
| EVENT-205a | `AbstractEventRegistryTck` + Community binding | TCK |
| Doc sync | `docs/subsystems/events.md` (Replay API, Repo Reality, TCK gaps) | docs |

## EVENT-202 — gap analysis

**Question:** does the existing SPI surface (`EventBus`, `EventLoop`, `EventQueue`, `EventRegistry`, `OutboxBrokerPort`) suffice for a Kafka backend, or are new SPI types needed?

**Outcome:** The bus/queue/loop are sufficient for Kafka session orchestration — Core handles producer/consumer wiring through `OutboxBrokerPort` (already in `exeris-kernel-core`). The only contracts `events.md` had marked "Target State — not yet implemented" and that the Kafka driver actually needs are the replay/append surface (EVENT-203). Those land here.

## EVENT-203 — replay & append SPI

Four new types in `eu.exeris.kernel.spi.events`:

| Type | Shape | Notes |
|:--|:--|:--|
| `StreamId` | `record(long streamIdHigh, long streamIdLow, String streamType)` | Valhalla-ready; wire-compatible with `EventDescriptor.streamIdHigh()` / `streamIdLow()`. `of(UUID, String)` factory provided. |
| `EventStream` | `extends Iterable<EventPayload>, AutoCloseable` | Per-payload refCount=1 hand-off, no broadcast retain on replay. `close()` releases the underlying cursor (DB result set, broker consumer) and is idempotent. |
| `EventStreamReader` | `replayFrom(StreamId, Instant)` / `replayFromVersion(StreamId, long)` / `replayByType(String, Instant)` | Returned `EventStream` owns the cursor; reader's own `close()` releases shared driver resources. |
| `EventStreamAppender` | `append(StreamId, EventDescriptor, EventPayload)` | `@FunctionalInterface`. Same RAII ownership transfer as `EventBus.publish`. |

All four are implementation-blind — zero references to Kafka/JDBC/Panama types in the SPI module.

`KernelProviders` gets two new `ScopedValue` slots (`EVENT_STREAM_READER`, `EVENT_STREAM_APPENDER`) plus the matching `Optional`-returning accessors `eventStreamReader()` and `eventStreamAppender()`. The pattern follows `FlowSnapshotStore` from Sprint 1: bootstrappers bind, callers consult the `Optional` and treat empty as "broker does not support this capability" — never as a hard error.

## EVENT-205a — AbstractEventRegistryTck

Closes the `EX-EVENT-6003` ordinal-conflict TCK gap that's been flagged in `events.md` since 0.5. The new abstract suite verifies:

1. Fresh `register()` is observable via `resolve` / `ordinalOf` / `size`.
2. Idempotent re-registration of an identical `EventTypeSpec`.
3. Different name + ordinal already in use → `EventRegistryException` with `errorCode == "EX-EVENT-6003"` and `rawArgs == [eventType, ordinal]`.
4. Same name + different ordinal → same `errorCode`.

`CommunityEventRegistryTckTest` extends the suite. The existing `CommunityEventRegistry` already uses `EventRegistryException.duplicateConflict(name, ordinal)` so the implementation passes unchanged.

## EVENT-205b backpressure TCK — deferred

`events.md` documents `EX-EVENT-6002` with `rawArgs == [eventType, queueDepth, queueCapacity]`, intended for queue-overflow on publish. The current `CommunityEventQueue.push` uses `LinkedBlockingDeque.putLast()`, which is VT-safe (no carrier pinning) but **blocks** on full instead of throwing.

Reconciling that deviation isn't a one-line change — it needs a `EventEngineConfig.busPublishFailFast` config knob so that existing callers depending on blocking semantics aren't broken, plus the corresponding wiring in `CommunityEventEngine.enqueuePersistent` to call `EventBusException.publishOverflow(eventType, queueDepth, queueCapacity)` when the knob is true.

That belongs alongside the Kafka driver (where the same knob naturally maps onto Kafka producer `buffer.memory` overflow) — deferred to Sprint 5b.

## Doc sync — `docs/subsystems/events.md`

- **Current Repo Reality** — split into "Implemented in 0.7 (Sprint 5a — SPI groundwork)" vs "Not yet implemented", with explicit Sprint 5b pointers.
- **Responsibilities** — `EventStreamReader` / `EventStreamAppender` are no longer flagged "Target State".
- **Event Replay API** — rewritten to describe the actually-shipped SPI, including the `Bindings (status)` sublist (PostgreSQL outbox: planned; Kafka: 5b; Enterprise: OOR).
- **Testing Strategy** — `EX-EVENT-6003` gap marker replaced with "Closed in 0.7 (EVENT-205a)"; `EX-EVENT-6002` gap marker re-marked with the deferred-to-5b reconciliation rationale.

## Test plan

- [x] `mvn install -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am` (full PMD + Checkstyle, no `-Dpmd.skip`, no `-Dcheckstyle.skip`)
- [x] **2556 tests, 0 failures, 0 errors**
  - SPI: 496
  - TCK: 27
  - Core: 1073
  - Community: 960 unit (+4 new from `CommunityEventRegistryTckTest`)
- [x] No regressions in existing flow / events / persistence TCKs.

## Boundary notes

- SPI module is the only one that gains source-code surface; Core and Community see no changes.
- The new `KernelProviders` slots default to unbound — every existing bootstrapper that never reads `eventStreamReader()` / `eventStreamAppender()` compiles and runs unchanged. Sprint 5b will populate the slots in the new Kafka bootstrap path.
- `@FunctionalInterface` on `EventStreamAppender` is intentional — bindings often fan out to multiple lambdas (per-topic, per-partition, etc.) before the durable write path.

## Out of scope (Sprint 5b)

- `exeris-kernel-community-kafka` module (BOM + reactor + `kafka-clients` transitive isolation from main Community classpath).
- Core `KafkaSessionOrchestrator` (no `org.apache.kafka.*` allowed in Core).
- `EVENT-204` `KafkaEventEngine` + Community provider.
- `EVENT-205b` `AbstractEventBackpressureTck` + `EventEngineConfig.busPublishFailFast` knob.