### PR TITLE
v0.7 Sprint 7b: HealthEndpointHandler + HealthProbe SPI (Sprint 7 part 2)

### DIFF
--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -239,7 +239,7 @@ with deterministic hard timeouts at each layer boundary (see Diagram 2).
 - Defines `BootstrapSelector` (immutable record: which subsystems to activate)
 - Defines `BootstrapPhase` enum (`FOUNDATION`, `SERVICES`, `RUNTIME`)
 - Config is NOT a Subsystem — resolved by `KernelBootstrap` via `ServiceLoader<ConfigProvider>` before the orchestrator runs
-- Health state is tracked by `KernelHealthMonitor` (Core), not an SPI type
+- Health state is tracked by `KernelHealthMonitor` (Core). The class implements the SPI read-only contract `eu.exeris.kernel.spi.bootstrap.HealthProbe` (introduced in 0.7.0) so HTTP handlers, sidecar reporters, and Enterprise observers can consume probe state without coupling to the Core orchestrator class.
 
 ### What Bootstrap Core **does**
 
@@ -350,48 +350,66 @@ at all times.
 
 ## Kubernetes Health Probes
 
-> **Status: 🚧 Planned (TRL-4 target). No embedded HTTP health server exists in the current TRL-3 prototype.**
-> The design below describes the target behavior. Operators deploying TRL-3 builds should rely on process-level
-> liveness checks (e.g., `exec` probes or TCP socket probes) until the health server is implemented.
+> **Status (0.7.0):** Probe state and an HTTP handler are implemented; an auto-bound embedded HTTP health server on a dedicated port is still **🚧 Planned (TRL-4 target)**. Operators wire the handler into their HTTP server engine themselves until the auto-bind landing.
 
-Bootstrap will register an embedded HTTP health server on a dedicated, non-data-plane port. The server will bind
-before the Boot DAG executes — K8s can observe lifecycle state from the very first millisecond.
+### Probe contract
 
-| Probe            | Path            | Port (default) | Behaviour                                                                                                          |
-|:-----------------|:----------------|:--------------:|:-------------------------------------------------------------------------------------------------------------------|
-| **Liveness**     | `/health/live`  | `9090`         | Returns `HTTP 200 {"status":"UP"}` once `KernelBootstrap` has transitioned past `INIT`. Returns `HTTP 503` only if the JVM is in `FAILED` state (unrecoverable). Never returns 503 during normal boot — K8s must not restart a pod that is still starting. |
-| **Readiness**    | `/health/ready` | `9090`         | Returns `HTTP 200 {"status":"READY"}` **only** after all L4 subsystems have reached `READY` state (Boot DAG complete). Returns `HTTP 503 {"status":"STARTING"}` during boot. K8s routes traffic to this pod only when the readiness probe is 200. |
-| **Startup probe**| `/health/ready` | `9090`         | Use as K8s `startupProbe` target. Prevents liveness probe from timing out during a slow cold start (native lib loading). |
+`KernelHealthMonitor` (Core) implements `eu.exeris.kernel.spi.bootstrap.HealthProbe` and exposes two snapshots:
 
-**Kubernetes manifest snippet:**
+- **Readiness** — UP only when the kernel has transitioned to `STARTED` and every required subsystem is `RUNNING`. Returns `STARTING` while the Boot DAG is in progress, while a required subsystem is still initializing, and during `SHUTTING_DOWN`. Returns `FAILED` after `FAILED` state.
+- **Liveness** — UP after the kernel has transitioned to `INITIALIZED`. Returns `STARTING` before that point. Returns `DOWN` only after `FAILED` state.
+
+### `HealthEndpointHandler` (Community)
+
+`eu.exeris.kernel.community.health.HealthEndpointHandler` is an `HttpHandler` that surfaces the probe over HTTP. Construct it with any `HealthProbe` implementation (the orchestrator-owned `KernelHealthMonitor` is the canonical caller) and register it with the HTTP server engine:
+
+```java
+HealthEndpointHandler health = new HealthEndpointHandler(orchestrator.healthMonitor());
+httpServerEngine.setHandler(health);   // or compose into an application router
+httpServerEngine.start();
+```
+
+| Probe         | Default path             | Healthy            | Not healthy                                            |
+|:--------------|:-------------------------|:-------------------|:-------------------------------------------------------|
+| **Readiness** | `/healthz/readiness`     | `200 OK`           | `503 Service Unavailable`                              |
+| **Liveness**  | `/healthz/liveness`      | `200 OK`           | `503 Service Unavailable`                              |
+
+Custom paths are available via `new HealthEndpointHandler(probe, readinessPath, livenessPath)`. The textual probe status (`READY`, `STARTING`, `UP`, `DOWN`, `FAILED`) is mirrored into the response header `X-Exeris-Health` for human diagnostics — Kubernetes probes evaluate the status code only, so responses are bodyless.
+
+The handler returns:
+- `404 Not Found` for paths that match neither probe, without invoking the probe;
+- `405 Method Not Allowed` with `Allow: GET` for non-`GET` methods on a probe path.
+
+The contract is pinned by `eu.exeris.kernel.tck.contract.health.AbstractHealthEndpointTck` plus the Community binding `CommunityHealthEndpointTckTest`. End-to-end behavior with the real `KernelHealthMonitor` is pinned by `HealthEndpointHandlerKernelMonitorIntegrationTest`.
+
+### Kubernetes manifest snippet
 
 ```yaml
 livenessProbe:
   httpGet:
-    path: /health/live
-    port: 9090
-  initialDelaySeconds: 0     # Probe starts immediately
+    path: /healthz/liveness
+    port: 8080                     # data-plane port, until the auto-bound health port lands
+  initialDelaySeconds: 0
   periodSeconds: 5
   failureThreshold: 3
 
 readinessProbe:
   httpGet:
-    path: /health/ready
-    port: 9090
+    path: /healthz/readiness
+    port: 8080
   initialDelaySeconds: 0
   periodSeconds: 2
-  failureThreshold: 60       # 60 × 2s = 120s max tolerated boot time
+  failureThreshold: 60             # 60 × 2s = 120s max tolerated boot time
 
 startupProbe:
   httpGet:
-    path: /health/ready
-    port: 9090
+    path: /healthz/readiness
+    port: 8080
   failureThreshold: 30
-  periodSeconds: 5           # 30 × 5s = 150s budget before K8s kills the pod
+  periodSeconds: 5                 # 30 × 5s = 150s cold-start budget
 ```
 
-> **Port override:** The health port is configurable via `exeris.bootstrap.healthPort` (default `9090`).
-> The data-plane transport port is configured separately — never share ports between health and data traffic.
+> **Dedicated port (planned, TRL-4):** A future revision will auto-bind the handler on a dedicated, non-data-plane port (`exeris.bootstrap.healthPort`, default `9090`) so probes can observe lifecycle state from the very first millisecond — even before the data-plane transport binds. Until then, operators register the handler with the application HTTP engine and probe the data-plane port.
 
 ---
 

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -86,6 +86,7 @@ HTTP abstract TCK suites present:
 - `AbstractHttpHandlerTck`
 - `AbstractHttpExchangeTck`
 - `AbstractHttpProviderLoopbackTck` — verifies real transport round-trip; bound at Community tier (`CommunityHttpProviderLoopbackTckTest`)
+- `AbstractHealthEndpointTck` (since 0.7.0) — pins the readiness/liveness endpoint contract for any `HttpHandler` binding that surfaces a `HealthProbe`. Bound at Community tier (`CommunityHealthEndpointTckTest`).
 
 These verify SPI-level HTTP contract behavior and ServiceLoader/provider semantics.
 
@@ -146,3 +147,11 @@ Current `exeris-kernel-core` HTTP package focuses on codec/wire primitives:
 - Root Maven modules are currently: `build-config`, `bom`, `parent`, `spi`, `tck`, `core`, `community`.
 - Documentation and design discussions that mention dedicated `exeris-kernel-http` module
   should be treated as target/roadmap unless that module appears in the root reactor.
+
+---
+
+## Operational Endpoints
+
+### `HealthEndpointHandler` (Community, since 0.7.0)
+
+`eu.exeris.kernel.community.health.HealthEndpointHandler` is an `HttpHandler` that surfaces an SPI `HealthProbe` (canonically `KernelHealthMonitor`) over HTTP for Kubernetes-style readiness/liveness probes. Default paths: `/healthz/readiness`, `/healthz/liveness`. Status code carries the probe verdict (`200` healthy / `503` not). The textual status from the probe snapshot is mirrored into the `X-Exeris-Health` response header. Non-matching paths return `404`; non-`GET` methods on a probe path return `405` with `Allow: GET`. Full operational contract — including the K8s manifest snippet — lives in [`bootstrap.md` § Kubernetes Health Probes](bootstrap.md#kubernetes-health-probes).

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/health/HealthEndpointHandler.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/health/HealthEndpointHandler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.health;
+
+import eu.exeris.kernel.spi.bootstrap.HealthProbe;
+import eu.exeris.kernel.spi.bootstrap.HealthProbe.ProbeSnapshot;
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Community {@link HttpHandler} that surfaces a {@link HealthProbe} as
+ * Kubernetes-friendly readiness and liveness endpoints.
+ *
+ * <h2>Routing</h2>
+ * <ul>
+ *   <li>{@code GET <readinessPath>} → {@code 200 OK} when readiness is healthy,
+ *       {@code 503 Service Unavailable} otherwise.</li>
+ *   <li>{@code GET <livenessPath>} → {@code 200 OK} when liveness is healthy,
+ *       {@code 503 Service Unavailable} otherwise.</li>
+ *   <li>Any other path → {@code 404 Not Found}.</li>
+ *   <li>Non-{@code GET} method on a probe path → {@code 405 Method Not Allowed}.</li>
+ * </ul>
+ *
+ * <p>Default paths are {@value #DEFAULT_READINESS_PATH} and {@value #DEFAULT_LIVENESS_PATH}.
+ * Both responses are bodyless — Kubernetes readiness/liveness probes evaluate the
+ * status code only. The textual status reported by the monitor (e.g. {@code "READY"},
+ * {@code "STARTING"}, {@code "FAILED"}, {@code "DOWN"}) is mirrored into the
+ * {@value #STATUS_HEADER} response header for human diagnostics.
+ *
+ * <h2>No magic DI</h2>
+ * <p>Constructor-injected. The kernel orchestrator owns the {@link HealthProbe}
+ * (via {@code KernelHealthMonitor}) and is the canonical caller; tests inject any
+ * stub probe and assert the response shape.
+ *
+ * @since 0.7.0
+ */
+public final class HealthEndpointHandler implements HttpHandler {
+
+    /** Default URI for Kubernetes-style readiness probes. */
+    public static final String DEFAULT_READINESS_PATH = "/healthz/readiness";
+
+    /** Default URI for Kubernetes-style liveness probes. */
+    public static final String DEFAULT_LIVENESS_PATH = "/healthz/liveness";
+
+    /** Response header that mirrors the textual status string from the probe snapshot. */
+    public static final String STATUS_HEADER = "X-Exeris-Health";
+
+    private final HealthProbe probe;
+    private final String readinessPath;
+    private final String livenessPath;
+
+    /**
+     * Creates a handler with the default probe paths.
+     *
+     * @param probe non-null kernel health probe
+     */
+    public HealthEndpointHandler(HealthProbe probe) {
+        this(probe, DEFAULT_READINESS_PATH, DEFAULT_LIVENESS_PATH);
+    }
+
+    /**
+     * Creates a handler with custom probe paths.
+     *
+     * @param probe         non-null kernel health probe
+     * @param readinessPath non-null, non-blank readiness probe path (must start with {@code '/'})
+     * @param livenessPath  non-null, non-blank liveness probe path (must start with {@code '/'})
+     */
+    public HealthEndpointHandler(HealthProbe probe, String readinessPath, String livenessPath) {
+        this.probe = Objects.requireNonNull(probe, "probe");
+        this.readinessPath = validatePath(readinessPath, "readinessPath");
+        this.livenessPath = validatePath(livenessPath, "livenessPath");
+        if (this.readinessPath.equals(this.livenessPath)) {
+            throw new IllegalArgumentException("readinessPath and livenessPath must differ");
+        }
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) {
+        HttpRequest request = exchange.request();
+        String path = request.path();
+        boolean isReadiness = readinessPath.equals(path);
+        boolean isLiveness = livenessPath.equals(path);
+
+        if (!isReadiness && !isLiveness) {
+            exchange.respond(HttpResponse.noBody(HttpStatus.NOT_FOUND, request.version()));
+            return;
+        }
+
+        if (request.method() != HttpMethod.GET) {
+            exchange.respond(HttpResponse.noBody(HttpStatus.METHOD_NOT_ALLOWED, request.version(),
+                    List.of(new HttpHeader("Allow", HttpMethod.GET.name()))));
+            return;
+        }
+
+        ProbeSnapshot snapshot = isReadiness ? probe.readiness() : probe.liveness();
+        HttpStatus status = snapshot.healthy() ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;
+        exchange.respond(HttpResponse.noBody(status, request.version(),
+                List.of(new HttpHeader(STATUS_HEADER, snapshot.status()))));
+    }
+
+    private static String validatePath(String path, String parameterName) {
+        Objects.requireNonNull(path, parameterName);
+        if (path.isBlank()) {
+            throw new IllegalArgumentException(parameterName + " must not be blank");
+        }
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException(parameterName + " must start with '/'");
+        }
+        return path;
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/CommunityHealthEndpointTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/CommunityHealthEndpointTckTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.health;
+
+import eu.exeris.kernel.spi.bootstrap.HealthProbe;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.tck.contract.health.AbstractHealthEndpointTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Community: HealthEndpointHandler TCK")
+class CommunityHealthEndpointTckTest extends AbstractHealthEndpointTck {
+
+    @Override
+    protected HttpHandler newHandler(HealthProbe probe) {
+        return new HealthEndpointHandler(probe);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.health;
+
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
+import eu.exeris.kernel.spi.bootstrap.HealthProbe;
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpTypedResponse;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test pinning the end-to-end flow:
+ * {@link KernelHealthMonitor} (Core, implements {@link HealthProbe})
+ * → {@link HealthEndpointHandler} (Community)
+ * → operator-visible response.
+ *
+ * <p>The {@link AbstractHealthEndpointTck} subclass already covers the handler
+ * contract with a stub probe; this test verifies that the real Core monitor
+ * surfaces the right state through the handler.
+ */
+@DisplayName("HealthEndpointHandler + KernelHealthMonitor integration")
+class HealthEndpointHandlerKernelMonitorIntegrationTest {
+
+    private static final String READINESS = HealthEndpointHandler.DEFAULT_READINESS_PATH;
+    private static final String LIVENESS = HealthEndpointHandler.DEFAULT_LIVENESS_PATH;
+
+    @Test
+    @DisplayName("Full bootstrap: pre-START 503; after START + RUNNING 200")
+    void surfacesReadinessThroughBootstrapTransitions() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("memory", true);
+        HealthEndpointHandler handler = new HealthEndpointHandler(monitor);
+
+        RecordingExchange before = invoke(handler, READINESS);
+        assertThat(before.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(before.header(HealthEndpointHandler.STATUS_HEADER)).hasValue("STARTING");
+
+        monitor.markKernelState(KernelHealthMonitor.KernelState.INITIALIZED);
+        monitor.markKernelState(KernelHealthMonitor.KernelState.STARTED);
+        monitor.markSubsystemState("memory", KernelHealthMonitor.SubsystemState.RUNNING);
+
+        RecordingExchange after = invoke(handler, READINESS);
+        assertThat(after.status()).isEqualTo(HttpStatus.OK);
+        assertThat(after.header(HealthEndpointHandler.STATUS_HEADER)).hasValue("READY");
+    }
+
+    @Test
+    @DisplayName("Liveness reports DOWN after kernel marked FAILED")
+    void livenessSurfacesFailedKernel() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.markKernelState(KernelHealthMonitor.KernelState.INITIALIZED);
+        HealthEndpointHandler handler = new HealthEndpointHandler(monitor);
+
+        assertThat(invoke(handler, LIVENESS).status()).isEqualTo(HttpStatus.OK);
+
+        monitor.markKernelState(KernelHealthMonitor.KernelState.FAILED);
+
+        RecordingExchange afterFailure = invoke(handler, LIVENESS);
+        assertThat(afterFailure.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(afterFailure.header(HealthEndpointHandler.STATUS_HEADER)).hasValue("DOWN");
+    }
+
+    private static RecordingExchange invoke(HttpHandler handler, String path) {
+        HttpRequest request = HttpRequest.noBody(HttpMethod.GET, path, HttpVersion.HTTP_1_1, List.of());
+        RecordingExchange exchange = new RecordingExchange(request);
+        handler.handle(exchange);
+        return exchange;
+    }
+
+    private static final class RecordingExchange implements HttpExchange {
+        private final HttpRequest request;
+        private HttpResponse response;
+
+        RecordingExchange(HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public void respond(HttpResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public void respond(HttpTypedResponse response) {
+            throw new UnsupportedOperationException();
+        }
+
+        HttpStatus status() {
+            assertThat(response).isNotNull();
+            return response.status();
+        }
+
+        Optional<String> header(String name) {
+            assertThat(response).isNotNull();
+            for (HttpHeader header : response.headers()) {
+                if (header.nameEqualsIgnoreCase(name)) {
+                    return Optional.of(header.value());
+                }
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
@@ -8,6 +8,8 @@
  */
 package eu.exeris.kernel.core.bootstrap.health;
 
+import eu.exeris.kernel.spi.bootstrap.HealthProbe;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,11 +18,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Core bootstrap health registry for K8s-like readiness/liveness probes.
  *
+ * <p>Implements the read-only {@link HealthProbe} SPI contract so that HTTP
+ * handlers and out-of-band reporters can consume probe state without coupling
+ * to this Core class.
+ *
  * <p>This class intentionally exposes state only through immutable snapshots.
  * It can be queried concurrently from probe threads while bootstrap transitions
  * subsystem states.
  */
-public final class KernelHealthMonitor {
+public final class KernelHealthMonitor implements HealthProbe {
 
     private static final String STATUS_STARTING = "STARTING";
     private static final String STATUS_READY = "READY";
@@ -69,6 +75,7 @@ public final class KernelHealthMonitor {
     }
 
     /** Readiness: UP only when kernel is started and every required subsystem is RUNNING. */
+    @Override
     public ProbeSnapshot readiness() {
         if (kernelFailed.get()) {
             return new ProbeSnapshot(STATUS_FAILED, false);
@@ -89,6 +96,7 @@ public final class KernelHealthMonitor {
     }
 
     /** Liveness: UP after kernel init, DOWN only when kernel entered failed state. */
+    @Override
     public ProbeSnapshot liveness() {
         if (kernelFailed.get()) {
             return new ProbeSnapshot(STATUS_DOWN, false);
@@ -104,9 +112,6 @@ public final class KernelHealthMonitor {
         STARTED,
         SHUTTING_DOWN,
         FAILED
-    }
-
-    public record ProbeSnapshot(String status, boolean healthy) {
     }
 
     private record SubsystemHealth(boolean requiredForReadiness, SubsystemState state) {

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/HealthProbe.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/HealthProbe.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.bootstrap;
+
+/**
+ * Read-only contract for kernel readiness and liveness probes.
+ *
+ * <h2>Why an SPI interface</h2>
+ * <p>HTTP health endpoints, sidecar reporters, and Enterprise observability adapters
+ * all need to consume the kernel's readiness/liveness state without coupling to the
+ * Core orchestration class that owns the state. {@code HealthProbe} provides the
+ * minimal read-only surface; the Core orchestrator's monitor implements it.
+ *
+ * <h2>Probe semantics (Kubernetes-aligned)</h2>
+ * <ul>
+ *   <li><b>Liveness</b> answers <em>"is the kernel alive — should the container keep running?"</em>
+ *       — {@code healthy=false} signals the runtime should be replaced.</li>
+ *   <li><b>Readiness</b> answers <em>"should traffic be routed to this instance?"</em>
+ *       — {@code healthy=false} signals the load balancer should drain this instance
+ *       (e.g., during startup, shutdown, or while a required subsystem is degraded).</li>
+ * </ul>
+ *
+ * <h2>The Wall</h2>
+ * <p>This interface carries no Core types and no transport types — a probe consumer
+ * may run inside a sidecar process, an out-of-band metric exporter, or an HTTP
+ * handler with equal ease.
+ *
+ * @since 0.7.0
+ */
+public interface HealthProbe {
+
+    /**
+     * Returns the current readiness probe snapshot.
+     *
+     * @return non-null snapshot
+     */
+    ProbeSnapshot readiness();
+
+    /**
+     * Returns the current liveness probe snapshot.
+     *
+     * @return non-null snapshot
+     */
+    ProbeSnapshot liveness();
+
+    /**
+     * Immutable point-in-time snapshot of a probe outcome.
+     *
+     * <p>Carries a textual {@code status} suitable for human diagnostics
+     * (e.g., {@code "READY"}, {@code "STARTING"}, {@code "FAILED"}, {@code "UP"},
+     * {@code "DOWN"}) and a machine-checkable {@code healthy} flag that maps
+     * directly to HTTP {@code 200} / {@code 503} responses.
+     *
+     * @param status  textual status; never {@code null}
+     * @param healthy {@code true} if the probe is currently passing
+     */
+    record ProbeSnapshot(String status, boolean healthy) {
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/health/AbstractHealthEndpointTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/health/AbstractHealthEndpointTck.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.health;
+
+import eu.exeris.kernel.spi.bootstrap.HealthProbe;
+import eu.exeris.kernel.spi.bootstrap.HealthProbe.ProbeSnapshot;
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpTypedResponse;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TCK: Abstract base for health-endpoint handler bindings.
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@code GET <readinessPath>} returns {@code 200 OK} when readiness is healthy
+ *       and {@code 503 Service Unavailable} otherwise.</li>
+ *   <li>{@code GET <livenessPath>} returns {@code 200 OK} when liveness is healthy
+ *       and {@code 503 Service Unavailable} otherwise.</li>
+ *   <li>Non-matching path → {@code 404 Not Found}.</li>
+ *   <li>Non-{@code GET} method on a probe path → {@code 405 Method Not Allowed}
+ *       with {@code Allow: GET} header.</li>
+ *   <li>Status header is mirrored from the underlying probe snapshot's textual status.</li>
+ * </ul>
+ *
+ * <h2>How to use</h2>
+ * <pre>{@code
+ * class CommunityHealthEndpointTckTest extends AbstractHealthEndpointTck {
+ *     @Override
+ *     protected HttpHandler newHandler(HealthProbe probe) {
+ *         return new HealthEndpointHandler(probe);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>The abstract drives state transitions through a stub {@link HealthProbe}; bindings
+ * supply only the handler factory.
+ *
+ * @since 0.7.0
+ */
+public abstract class AbstractHealthEndpointTck {
+
+    /** Default readiness path used by the abstract. Bindings using a custom path must override. */
+    protected static final String READINESS_PATH = "/healthz/readiness";
+
+    /** Default liveness path used by the abstract. Bindings using a custom path must override. */
+    protected static final String LIVENESS_PATH = "/healthz/liveness";
+
+    /** Header name carrying the textual status (mirrored from the probe snapshot). */
+    protected static final String STATUS_HEADER = "X-Exeris-Health";
+
+    /**
+     * Produces a fresh handler bound to the given probe. Bindings construct their
+     * concrete handler and return it.
+     *
+     * @param probe non-null probe to drive
+     * @return non-null handler under test
+     */
+    protected abstract HttpHandler newHandler(HealthProbe probe);
+
+    @Test
+    @DisplayName("Readiness 200 when probe is healthy; status header mirrors snapshot")
+    void readinessReturnsOkWhenProbeIsHealthy() {
+        StubHealthProbe probe = StubHealthProbe.healthy();
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe), get(READINESS_PATH));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.OK);
+        assertThat(exchange.headerValue(STATUS_HEADER)).hasValue("READY");
+    }
+
+    @Test
+    @DisplayName("Readiness 503 when probe reports not healthy")
+    void readinessReturnsServiceUnavailableWhenProbeIsUnhealthy() {
+        StubHealthProbe probe = new StubHealthProbe(
+                new ProbeSnapshot("STARTING", false),
+                new ProbeSnapshot("UP", true));
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe), get(READINESS_PATH));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(exchange.headerValue(STATUS_HEADER)).hasValue("STARTING");
+    }
+
+    @Test
+    @DisplayName("Liveness 200 when probe is healthy")
+    void livenessReturnsOkWhenProbeIsHealthy() {
+        StubHealthProbe probe = StubHealthProbe.healthy();
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe), get(LIVENESS_PATH));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.OK);
+        assertThat(exchange.headerValue(STATUS_HEADER)).hasValue("UP");
+    }
+
+    @Test
+    @DisplayName("Liveness 503 when probe reports DOWN")
+    void livenessReturnsServiceUnavailableWhenProbeIsUnhealthy() {
+        StubHealthProbe probe = new StubHealthProbe(
+                new ProbeSnapshot("READY", true),
+                new ProbeSnapshot("DOWN", false));
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe), get(LIVENESS_PATH));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(exchange.headerValue(STATUS_HEADER)).hasValue("DOWN");
+    }
+
+    @Test
+    @DisplayName("Degraded path: liveness 200 / readiness 503 surfaced independently")
+    void degradedSurfacesLivenessUpAndReadinessDown() {
+        StubHealthProbe probe = new StubHealthProbe(
+                new ProbeSnapshot("STARTING", false),
+                new ProbeSnapshot("UP", true));
+
+        HttpHandler handler = newHandler(probe);
+
+        RecordingHttpExchange readiness = invoke(handler, get(READINESS_PATH));
+        RecordingHttpExchange liveness = invoke(handler, get(LIVENESS_PATH));
+
+        assertThat(readiness.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(liveness.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("Both probes 503 when probe is fully unhealthy (FAILED kernel)")
+    void bothProbesReturnUnavailableOnFailedKernel() {
+        StubHealthProbe probe = new StubHealthProbe(
+                new ProbeSnapshot("FAILED", false),
+                new ProbeSnapshot("DOWN", false));
+
+        HttpHandler handler = newHandler(probe);
+
+        RecordingHttpExchange readiness = invoke(handler, get(READINESS_PATH));
+        RecordingHttpExchange liveness = invoke(handler, get(LIVENESS_PATH));
+
+        assertThat(readiness.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(readiness.headerValue(STATUS_HEADER)).hasValue("FAILED");
+        assertThat(liveness.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(liveness.headerValue(STATUS_HEADER)).hasValue("DOWN");
+    }
+
+    @Test
+    @DisplayName("Non-matching path returns 404 without invoking the probe")
+    void unknownPathReturnsNotFound() {
+        StubHealthProbe probe = StubHealthProbe.healthy();
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe), get("/api/users"));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(probe.readinessCalls).isZero();
+        assertThat(probe.livenessCalls).isZero();
+    }
+
+    @Test
+    @DisplayName("Non-GET method on probe path returns 405 with Allow: GET header")
+    void postOnProbePathReturnsMethodNotAllowed() {
+        StubHealthProbe probe = StubHealthProbe.healthy();
+
+        RecordingHttpExchange exchange = invoke(newHandler(probe),
+                HttpRequest.noBody(HttpMethod.POST, READINESS_PATH, HttpVersion.HTTP_1_1, List.of()));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(exchange.headerValue("Allow")).hasValue("GET");
+        assertThat(probe.readinessCalls).isZero();
+    }
+
+    private static HttpRequest get(String path) {
+        return HttpRequest.noBody(HttpMethod.GET, path, HttpVersion.HTTP_1_1, List.of());
+    }
+
+    private static RecordingHttpExchange invoke(HttpHandler handler, HttpRequest request) {
+        RecordingHttpExchange exchange = new RecordingHttpExchange(request);
+        handler.handle(exchange);
+        return exchange;
+    }
+
+    /**
+     * Simple {@link HealthProbe} stub the abstract drives directly. Counts probe calls
+     * so contract tests can assert the handler short-circuits non-matching paths.
+     */
+    protected static final class StubHealthProbe implements HealthProbe {
+
+        private final ProbeSnapshot readinessSnapshot;
+        private final ProbeSnapshot livenessSnapshot;
+        private int readinessCalls;
+        private int livenessCalls;
+
+        StubHealthProbe(ProbeSnapshot readiness, ProbeSnapshot liveness) {
+            this.readinessSnapshot = readiness;
+            this.livenessSnapshot = liveness;
+        }
+
+        static StubHealthProbe healthy() {
+            return new StubHealthProbe(
+                    new ProbeSnapshot("READY", true),
+                    new ProbeSnapshot("UP", true));
+        }
+
+        @Override
+        public ProbeSnapshot readiness() {
+            readinessCalls++;
+            return readinessSnapshot;
+        }
+
+        @Override
+        public ProbeSnapshot liveness() {
+            livenessCalls++;
+            return livenessSnapshot;
+        }
+    }
+
+    /**
+     * Minimal {@link HttpExchange} that records the response written by the handler.
+     * Self-contained so that bindings need not provide a wire-level recorder for this TCK.
+     */
+    protected static final class RecordingHttpExchange implements HttpExchange {
+
+        private final HttpRequest request;
+        private HttpResponse response;
+
+        RecordingHttpExchange(HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public void respond(HttpResponse response) {
+            if (this.response != null) {
+                throw new IllegalStateException("respond() already called");
+            }
+            this.response = response;
+        }
+
+        @Override
+        public void respond(HttpTypedResponse response) {
+            throw new UnsupportedOperationException("Health TCK uses bodyless responses only");
+        }
+
+        HttpStatus status() {
+            assertThat(response).as("handler must call respond()").isNotNull();
+            return response.status();
+        }
+
+        Optional<String> headerValue(String name) {
+            assertThat(response).as("handler must call respond()").isNotNull();
+            for (HttpHeader header : response.headers()) {
+                if (header.nameEqualsIgnoreCase(name)) {
+                    return Optional.of(header.value());
+                }
+            }
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Sprint 7 deliverable #3** (Bootstrap / HTTP: Embedded Health
Endpoint) — Kubernetes-friendly readiness/liveness probe surface backed by the
existing \`KernelHealthMonitor\`.

The Sprint 7 split so far: 7a = disclosure mode (#95, merged), **7b = health
endpoint** (this PR), 7c/7d still open (telemetry async dispatcher, metrics
export).

## Architecture

| Layer | Change |
|:--|:--|
| **SPI** | New \`eu.exeris.kernel.spi.bootstrap.HealthProbe\` interface (read-only) with nested \`ProbeSnapshot\` record. |
| **Core** | \`KernelHealthMonitor\` now implements \`HealthProbe\`. Its previous nested \`ProbeSnapshot\` record is removed in favour of the SPI type — no external consumers of the inner type existed. |
| **Community** | New \`HealthEndpointHandler\` (\`HttpHandler\`) surfaces probe state over HTTP. |

## Endpoint contract

| Probe | Default path | Healthy | Not healthy |
|:--|:--|:--|:--|
| **Readiness** | \`/healthz/readiness\` | \`200 OK\` | \`503 Service Unavailable\` |
| **Liveness** | \`/healthz/liveness\` | \`200 OK\` | \`503 Service Unavailable\` |

- Status text from the probe snapshot (\`READY\` / \`STARTING\` / \`UP\` / \`DOWN\` /
  \`FAILED\`) mirrored into \`X-Exeris-Health\` response header.
- Non-matching paths → \`404 Not Found\` (probe not invoked).
- Non-\`GET\` methods on a probe path → \`405 Method Not Allowed\` with
  \`Allow: GET\`.
- Bodyless responses — K8s probes evaluate the status code only.
- Custom paths available via \`new HealthEndpointHandler(probe, readinessPath, livenessPath)\`.

## Tests

- **\`AbstractHealthEndpointTck\`** (TCK module) — 8 contract tests with a stub
  \`HealthProbe\`: ready/not-ready, liveness up/down, degraded path, failed
  kernel, unknown path 404, non-GET 405. The stub also verifies the handler
  short-circuits non-matching paths without invoking the probe.
- **\`CommunityHealthEndpointTckTest\`** — binding-agnostic Community binding.
- **\`HealthEndpointHandlerKernelMonitorIntegrationTest\`** — end-to-end pin
  with the real \`KernelHealthMonitor\`: bootstrap transitions (pre-START 503
  → STARTED+RUNNING 200) and FAILED-state liveness switch (UP → DOWN).

## Docs

- **\`docs/subsystems/bootstrap.md\`** — Kubernetes Health Probes section
  rewritten to reflect the implemented handler. Wiring example + K8s manifest
  snippet + TCK obligation list included. Auto-bound dedicated health port
  remains called out as TRL-4 target. Also corrected the
  \"Health state is tracked by KernelHealthMonitor (Core), not an SPI type\"
  line.
- **\`docs/subsystems/http.md\`** — \`AbstractHealthEndpointTck\` added to TCK
  list; new *Operational Endpoints* section linking back to bootstrap.md.

## Quality gate

\`\`\`
mvn -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify -DskipITs
→ all modules SUCCESS, 0 PMD/Checkstyle violations
→ 10 new health tests green
\`\`\`

## Test plan

- [x] \`AbstractHealthEndpointTck\` — 8 contract tests across all probe states.
- [x] \`CommunityHealthEndpointTckTest\` — Community binding green.
- [x] \`HealthEndpointHandlerKernelMonitorIntegrationTest\` — end-to-end with real monitor.
- [x] Full \`mvn verify\` on SPI + TCK + Core + Community: 0 regressions.

## Out of scope (follow-up)

- **Auto-bound health server on a dedicated port** (\`exeris.bootstrap.healthPort\`,
  default 9090). Current revision requires operators to register the handler
  with the application HTTP engine and probe the data-plane port. TRL-4 target.
- **Response body shaping** — bodyless because K8s probes evaluate status code
  only and \`X-Exeris-Health\` carries the textual status. A small JSON body
  could be added when typed-response encoding is wired in v0.7+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)