### PR TITLE
v0.7 Sprint 7d: Prometheus metrics export (Sprint 7 closure)

### DIFF
--- a/docs/subsystems/telemetry.md
+++ b/docs/subsystems/telemetry.md
@@ -337,6 +337,57 @@ When the ring is full, `emit()` discards the incoming event (drop-newest), incre
 
 ---
 
+## Operational metrics export — Prometheus (since 0.7.0)
+
+Operators scraping kernel metrics use the Prometheus pull model. The kernel ships two Community classes:
+
+- **`eu.exeris.kernel.community.metrics.PrometheusMetricsSink`** — `TelemetrySink` that records counter/gauge/latency calls in concurrent maps and produces a Prometheus 0.0.4 text exposition snapshot on demand via `exposeText()`.
+- **`eu.exeris.kernel.community.metrics.PrometheusMetricsHandler`** — `HttpHandler` that serves `GET /metrics` (path configurable) returning the snapshot as the HTTP response body. Path-mismatch → `404`; non-`GET` → `405` with `Allow: GET`. Pair with `HealthEndpointHandler` on the same HTTP engine.
+
+### Why pull, not push
+
+| Aspect | Prometheus pull (chosen) | OTLP push |
+|:--|:--|:--|
+| Client state | None — each scrape is stateless | Long-lived gRPC client + retry buffer |
+| Dependencies | None beyond JDK | `opentelemetry-exporter-otlp` + Protobuf |
+| Failure mode | Scraper observes scrape failure directly | Push retries can mask sustained failure |
+| K8s integration | Pod annotation / `ServiceMonitor` | OpenTelemetry Collector sidecar |
+
+The Community baseline ships pull because it adds zero new runtime dependencies and integrates with standard Kubernetes scraping out of the box. An Enterprise binding may add an OTLP exporter later without modifying this sink.
+
+### Metric mapping
+
+| `TelemetrySink` call | Prometheus type | Exposition shape |
+|:--|:--|:--|
+| `increment(name, delta)` | `counter` | `name <total>` |
+| `gauge(name, value)` | `gauge` | `name <last_value>` |
+| `latency(name, nanoseconds)` | `summary` | `name_count <count>` + `name_sum <sum>` (no quantiles in baseline) |
+
+Latency without quantiles is intentional — streaming quantile sketches add allocation pressure on the hot path. Operators compute averages via PromQL: `rate(name_sum[1m]) / rate(name_count[1m])`. Quantile support is tracked as a 0.8+ enhancement once a low-allocation sketch (e.g., DDSketch) is selected.
+
+### Naming sanitisation
+
+Caller-supplied names are mapped to the Prometheus name regex `[a-zA-Z_:][a-zA-Z0-9_:]*` — characters outside the set are replaced with `_`, and a leading digit/invalid first character is prefixed with `_`. The original name remains the lookup key in the concurrent maps so multiple `increment` calls on the same logical metric continue to accumulate as expected.
+
+### Wiring example
+
+```java
+PrometheusMetricsSink metrics = new PrometheusMetricsSink();
+List<TelemetrySink> sinks = List.of(metrics, new JfrTelemetrySink());
+
+// ... bind sinks via KernelProviders.TELEMETRY_SINKS …
+
+PrometheusMetricsHandler handler = new PrometheusMetricsHandler(metrics, allocator);
+httpServerEngine.setHandler(handler);   // or compose into an application router
+```
+
+### Validation
+
+- `PrometheusMetricsSinkTest` covers counter/gauge/latency exposition, sanitisation, deterministic ordering, concurrent updates (16 VTs × 1000 increments), and `close()` semantics.
+- `PrometheusMetricsHandlerTest` covers routing (200/404/405), Content-Type, Content-Length, and custom paths.
+
+---
+
 ## L0 Crash Observability — Memory-Mapped Crash Buffer (TRL-4 Requirement)
 
 The Glass-Box in-RAM buffer used during L0 (pre-JFR) boot provides **zero durability** on a hard JVM crash.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandler.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.metrics;
+
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Community {@link HttpHandler} that serves the Prometheus exposition snapshot
+ * captured by a {@link PrometheusMetricsSink} as the body of a {@code GET /metrics}
+ * response.
+ *
+ * <h2>Routing</h2>
+ * <ul>
+ *   <li>{@code GET <metricsPath>} → {@code 200 OK} with Prometheus exposition body.</li>
+ *   <li>Any other path → {@code 404 Not Found}.</li>
+ *   <li>Non-{@code GET} method on the metrics path → {@code 405 Method Not Allowed}
+ *       with {@code Allow: GET}.</li>
+ * </ul>
+ *
+ * <p>Default path is {@value #DEFAULT_METRICS_PATH}. Pair this handler with the
+ * Community {@code HealthEndpointHandler} on the same HTTP engine to expose both
+ * Kubernetes probes and Prometheus scrape data side by side.
+ *
+ * <h2>Allocation</h2>
+ * <p>The exposition body is materialised as a {@link String}, copied into a
+ * {@link LoanedBuffer} sized to the encoded byte length, then transferred to the
+ * engine via {@link HttpExchange#respond(HttpResponse)}. The engine takes
+ * ownership of the buffer. Allocations occur per request — operators concerned
+ * about scrape overhead should size the {@link MemoryAllocator}'s network slab
+ * pool above their typical exposition size.
+ *
+ * @since 0.7.0
+ */
+@SuppressWarnings({
+    "PMD.CloseResource",                  // body ownership transfers to the engine on respond()
+    "PMD.AvoidCatchingGenericException"   // any failure encoding the body must release the buffer
+})
+public final class PrometheusMetricsHandler implements HttpHandler {
+
+    /** Default URI for Prometheus scrapes. */
+    public static final String DEFAULT_METRICS_PATH = "/metrics";
+
+    private final PrometheusMetricsSink sink;
+    private final MemoryAllocator allocator;
+    private final String metricsPath;
+
+    public PrometheusMetricsHandler(PrometheusMetricsSink sink, MemoryAllocator allocator) {
+        this(sink, allocator, DEFAULT_METRICS_PATH);
+    }
+
+    public PrometheusMetricsHandler(PrometheusMetricsSink sink, MemoryAllocator allocator, String metricsPath) {
+        this.sink = Objects.requireNonNull(sink, "sink");
+        this.allocator = Objects.requireNonNull(allocator, "allocator");
+        Objects.requireNonNull(metricsPath, "metricsPath");
+        if (metricsPath.isBlank()) {
+            throw new IllegalArgumentException("metricsPath must not be blank");
+        }
+        if (!metricsPath.startsWith("/")) {
+            throw new IllegalArgumentException("metricsPath must start with '/'");
+        }
+        this.metricsPath = metricsPath;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) {
+        HttpRequest request = exchange.request();
+        if (!metricsPath.equals(request.path())) {
+            exchange.respond(HttpResponse.noBody(HttpStatus.NOT_FOUND, request.version()));
+            return;
+        }
+        if (request.method() != HttpMethod.GET) {
+            exchange.respond(HttpResponse.noBody(HttpStatus.METHOD_NOT_ALLOWED, request.version(),
+                    List.of(new HttpHeader("Allow", HttpMethod.GET.name()))));
+            return;
+        }
+
+        byte[] payload = sink.exposeText().getBytes(StandardCharsets.UTF_8);
+        LoanedBuffer body = allocator.allocateNetwork(payload.length);
+        try {
+            MemorySegment segment = body.segment();
+            MemorySegment.copy(payload, 0, segment, java.lang.foreign.ValueLayout.JAVA_BYTE, 0, payload.length);
+            body.setSize(payload.length);
+        } catch (RuntimeException releaseAndRethrow) {
+            body.close();
+            throw releaseAndRethrow;
+        }
+
+        exchange.respond(new HttpResponse(
+                HttpStatus.OK,
+                request.version(),
+                List.of(
+                        new HttpHeader("Content-Type", PrometheusMetricsSink.CONTENT_TYPE),
+                        new HttpHeader("Content-Length", Integer.toString(payload.length))),
+                body));
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandler.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandler.java
@@ -99,17 +99,21 @@ public final class PrometheusMetricsHandler implements HttpHandler {
             MemorySegment segment = body.segment();
             MemorySegment.copy(payload, 0, segment, java.lang.foreign.ValueLayout.JAVA_BYTE, 0, payload.length);
             body.setSize(payload.length);
+            // Ownership of `body` transfers to the engine only on a successful entry into
+            // the write path (HttpExchange.respond contract: "engine takes ownership ...
+            // after the write completes"). If respond() throws — e.g.,
+            // IllegalStateException for a second call — the engine never took ownership,
+            // so the catch below must close the buffer to avoid a leak.
+            exchange.respond(new HttpResponse(
+                    HttpStatus.OK,
+                    request.version(),
+                    List.of(
+                            new HttpHeader("Content-Type", PrometheusMetricsSink.CONTENT_TYPE),
+                            new HttpHeader("Content-Length", Integer.toString(payload.length))),
+                    body));
         } catch (RuntimeException releaseAndRethrow) {
             body.close();
             throw releaseAndRethrow;
         }
-
-        exchange.respond(new HttpResponse(
-                HttpStatus.OK,
-                request.version(),
-                List.of(
-                        new HttpHeader("Content-Type", PrometheusMetricsSink.CONTENT_TYPE),
-                        new HttpHeader("Content-Length", Integer.toString(payload.length))),
-                body));
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsSink.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/metrics/PrometheusMetricsSink.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.metrics;
+
+import eu.exeris.kernel.spi.telemetry.KernelEvent;
+import eu.exeris.kernel.spi.telemetry.TelemetrySink;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Community {@link TelemetrySink} that records counters, gauges and latency samples
+ * in concurrent maps keyed by metric name, and emits the Prometheus 0.0.4 text
+ * exposition format on demand via {@link #exposeText()}.
+ *
+ * <h2>Why Prometheus pull (not OTLP push)</h2>
+ * <p>The kernel ships a metrics sink + an HTTP handler. Operators wire both into
+ * their HTTP server engine; Prometheus scrapes {@code /metrics} with no client-side
+ * connection state to manage. OTLP push would require a long-lived gRPC client,
+ * buffer + retry logic, and a Protobuf dependency — out of scope for the
+ * Community best-effort baseline. Enterprise binding may add an OTLP exporter
+ * later without touching this sink.
+ *
+ * <h2>Metric mapping</h2>
+ * <table border="1">
+ *   <caption>SPI metric → Prometheus type</caption>
+ *   <tr><th>{@link TelemetrySink} call</th><th>Prometheus type</th></tr>
+ *   <tr><td>{@link #increment(String, long)}</td><td>{@code counter}</td></tr>
+ *   <tr><td>{@link #gauge(String, long)}</td><td>{@code gauge}</td></tr>
+ *   <tr><td>{@link #latency(String, long)}</td>
+ *       <td>{@code summary} ({@code _count} + {@code _sum} only — no quantiles in the baseline)</td></tr>
+ * </table>
+ *
+ * <h2>Naming</h2>
+ * <p>Metric names supplied by callers are mapped to the Prometheus name regex
+ * {@code [a-zA-Z_:][a-zA-Z0-9_:]*}: any character outside that set is replaced
+ * with {@code '_'} and a leading digit is prefixed with {@code '_'}. The original
+ * name remains the lookup key in the concurrent maps so multiple {@code increment}
+ * calls accumulate as expected.
+ *
+ * <h2>{@link #emit(KernelEvent)}</h2>
+ * <p>This sink is metric-only — events are intentionally ignored. Pair it with
+ * {@code JfrTelemetrySink} or {@code Slf4jTelemetrySink} when both signals are
+ * needed.
+ *
+ * <h2>Thread safety</h2>
+ * <p>All public methods are safe to call from any number of producer threads.
+ * {@link #exposeText()} produces a snapshot using sequential reads of the
+ * concurrent state — counters/gauges may shift between read and write of
+ * different metrics within a single export, which is the standard Prometheus
+ * exposition contract.
+ *
+ * @since 0.7.0
+ */
+@SuppressWarnings({
+    "PMD.TooManyMethods",                  // sink contract + 3 metric appenders + sanitize + ctors
+    "PMD.LooseCoupling",                   // ConcurrentHashMap chosen for atomic computeIfAbsent semantics
+    "PMD.ConsecutiveAppendsShouldReuse",   // sequence is more readable than chained .append()
+    "PMD.ConsecutiveLiteralAppends",       // same — readability over micro-perf in exposition path
+    "PMD.LawOfDemeter"                     // LatencyAggregate is a private member; depth-2 access is fine
+})
+public final class PrometheusMetricsSink implements TelemetrySink {
+
+    /** Prometheus text exposition format version 0.0.4 — content type for HTTP responses. */
+    public static final String CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+    private static final String SINK_NAME = "ExerisCommunity/PrometheusMetricsSink";
+
+    private final ConcurrentHashMap<String, LongAdder> counters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicLong> gauges = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, LatencyAggregate> latencies = new ConcurrentHashMap<>();
+
+    @Override
+    public void emit(KernelEvent event) {
+        // Metrics-only sink. Events are surfaced by paired event sinks (JFR/SLF4J).
+    }
+
+    @Override
+    public void increment(String name, long delta) {
+        Objects.requireNonNull(name, "name");
+        counters.computeIfAbsent(name, _ -> new LongAdder()).add(delta);
+    }
+
+    @Override
+    public void gauge(String name, long value) {
+        Objects.requireNonNull(name, "name");
+        gauges.computeIfAbsent(name, _ -> new AtomicLong()).set(value);
+    }
+
+    @Override
+    public void latency(String name, long nanoseconds) {
+        Objects.requireNonNull(name, "name");
+        latencies.computeIfAbsent(name, _ -> new LatencyAggregate()).record(nanoseconds);
+    }
+
+    @Override
+    public String sinkName() {
+        return SINK_NAME;
+    }
+
+    @Override
+    public void close() {
+        counters.clear();
+        gauges.clear();
+        latencies.clear();
+    }
+
+    /**
+     * Returns the Prometheus 0.0.4 text exposition snapshot.
+     *
+     * <p>Each metric block contains a {@code # HELP} line, a {@code # TYPE} line,
+     * and one or more sample lines. Names are sorted lexicographically within each
+     * type group so the output is deterministic for snapshot tests.
+     *
+     * @return non-null exposition text; trailing newline included
+     */
+    public String exposeText() {
+        StringBuilder out = new StringBuilder(256);
+        appendCounters(out);
+        appendGauges(out);
+        appendLatencies(out);
+        return out.toString();
+    }
+
+    private void appendCounters(StringBuilder out) {
+        for (Map.Entry<String, LongAdder> entry : sortedSnapshot(counters).entrySet()) {
+            String exported = sanitize(entry.getKey());
+            out.append("# HELP ").append(exported).append(" Counter recorded by ").append(SINK_NAME).append('\n');
+            out.append("# TYPE ").append(exported).append(" counter\n");
+            out.append(exported).append(' ').append(entry.getValue().sum()).append('\n');
+        }
+    }
+
+    private void appendGauges(StringBuilder out) {
+        for (Map.Entry<String, AtomicLong> entry : sortedSnapshot(gauges).entrySet()) {
+            String exported = sanitize(entry.getKey());
+            out.append("# HELP ").append(exported).append(" Gauge recorded by ").append(SINK_NAME).append('\n');
+            out.append("# TYPE ").append(exported).append(" gauge\n");
+            out.append(exported).append(' ').append(entry.getValue().get()).append('\n');
+        }
+    }
+
+    private void appendLatencies(StringBuilder out) {
+        for (Map.Entry<String, LatencyAggregate> entry : sortedSnapshot(latencies).entrySet()) {
+            String exported = sanitize(entry.getKey());
+            LatencyAggregate aggregate = entry.getValue();
+            out.append("# HELP ").append(exported).append(" Latency summary (nanoseconds) recorded by ")
+                    .append(SINK_NAME).append('\n');
+            out.append("# TYPE ").append(exported).append(" summary\n");
+            out.append(exported).append("_count ").append(aggregate.count.sum()).append('\n');
+            out.append(exported).append("_sum ").append(aggregate.sum.sum()).append('\n');
+        }
+    }
+
+    private static <V> TreeMap<String, V> sortedSnapshot(Map<String, V> source) {
+        return new TreeMap<>(source);
+    }
+
+    /**
+     * Maps an arbitrary metric name to the Prometheus name regex
+     * {@code [a-zA-Z_:][a-zA-Z0-9_:]*}.
+     */
+    /* default */ static String sanitize(String name) {
+        StringBuilder builder = new StringBuilder(name.length());
+        for (int index = 0; index < name.length(); index++) {
+            char current = name.charAt(index);
+            boolean firstCharValid = index == 0 && (Character.isLetter(current) || current == '_' || current == ':');
+            boolean otherCharValid = index > 0
+                    && (Character.isLetterOrDigit(current) || current == '_' || current == ':');
+            if (firstCharValid || otherCharValid) {
+                builder.append(current);
+            } else if (index == 0) {
+                // Prefix a leading digit/invalid first char with '_'.
+                builder.append('_').append(current);
+            } else {
+                builder.append('_');
+            }
+        }
+        return builder.length() == 0 ? "_" : builder.toString();
+    }
+
+    private static final class LatencyAggregate {
+        private final LongAdder count = new LongAdder();
+        private final LongAdder sum = new LongAdder();
+
+        /* default */ void record(long nanoseconds) {
+            count.increment();
+            sum.add(nanoseconds);
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.metrics;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpTypedResponse;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PrometheusMetricsHandler")
+class PrometheusMetricsHandlerTest {
+
+    private static MemoryAllocator allocator;
+
+    @BeforeAll
+    static void setUpAllocator() {
+        allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+    }
+
+    @AfterAll
+    static void tearDownAllocator() {
+        allocator.close();
+    }
+
+    @Test
+    @DisplayName("GET /metrics returns 200 with Prometheus body")
+    void metricsScrapeReturnsExposition() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("kernel_bootstrap_total", 1L);
+        sink.gauge("kernel_heap_bytes", 4096L);
+        PrometheusMetricsHandler handler = new PrometheusMetricsHandler(sink, allocator);
+
+        RecordingExchange exchange = invoke(handler, request(HttpMethod.GET, "/metrics"));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.OK);
+        assertThat(exchange.header("Content-Type")).hasValue(PrometheusMetricsSink.CONTENT_TYPE);
+        assertThat(exchange.body())
+                .contains("kernel_bootstrap_total 1")
+                .contains("kernel_heap_bytes 4096");
+        assertThat(exchange.header("Content-Length"))
+                .hasValueSatisfying(value ->
+                        assertThat(Integer.parseInt(value)).isEqualTo(exchange.body().length()));
+    }
+
+    @Test
+    @DisplayName("Non-matching path returns 404")
+    void unknownPathReturnsNotFound() {
+        PrometheusMetricsHandler handler = new PrometheusMetricsHandler(new PrometheusMetricsSink(), allocator);
+        RecordingExchange exchange = invoke(handler, request(HttpMethod.GET, "/foo"));
+        assertThat(exchange.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("POST /metrics returns 405 with Allow: GET")
+    void postReturnsMethodNotAllowed() {
+        PrometheusMetricsHandler handler = new PrometheusMetricsHandler(new PrometheusMetricsSink(), allocator);
+        RecordingExchange exchange = invoke(handler, request(HttpMethod.POST, "/metrics"));
+
+        assertThat(exchange.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(exchange.header("Allow")).hasValue("GET");
+    }
+
+    @Test
+    @DisplayName("Custom path is honoured; default path then returns 404")
+    void customPathIsHonoured() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("k", 1L);
+        PrometheusMetricsHandler handler = new PrometheusMetricsHandler(sink, allocator, "/observability/metrics");
+
+        RecordingExchange custom = invoke(handler, request(HttpMethod.GET, "/observability/metrics"));
+        RecordingExchange defaultPath = invoke(handler, request(HttpMethod.GET, "/metrics"));
+
+        assertThat(custom.status()).isEqualTo(HttpStatus.OK);
+        assertThat(custom.body()).contains("k 1");
+        assertThat(defaultPath.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null/blank/relative paths")
+    void constructorValidation() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        assertThatThrownBy(() -> new PrometheusMetricsHandler(null, allocator))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new PrometheusMetricsHandler(sink, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new PrometheusMetricsHandler(sink, allocator, ""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PrometheusMetricsHandler(sink, allocator, "metrics"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static HttpRequest request(HttpMethod method, String path) {
+        return HttpRequest.noBody(method, path, HttpVersion.HTTP_1_1, List.of());
+    }
+
+    private static RecordingExchange invoke(PrometheusMetricsHandler handler, HttpRequest request) {
+        RecordingExchange exchange = new RecordingExchange(request);
+        handler.handle(exchange);
+        return exchange;
+    }
+
+    private static final class RecordingExchange implements HttpExchange {
+        private final HttpRequest request;
+        private HttpResponse response;
+        private String capturedBody;
+
+        RecordingExchange(HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public void respond(HttpResponse response) {
+            this.response = response;
+            if (response.body() != null) {
+                int size = (int) response.body().size();
+                byte[] bytes = new byte[size];
+                MemorySegment.copy(response.body().segment(), ValueLayout.JAVA_BYTE, 0, bytes, 0, size);
+                this.capturedBody = new String(bytes, StandardCharsets.UTF_8);
+                response.body().close();
+            } else {
+                this.capturedBody = "";
+            }
+        }
+
+        @Override
+        public void respond(HttpTypedResponse response) {
+            throw new UnsupportedOperationException();
+        }
+
+        HttpStatus status() {
+            assertThat(response).isNotNull();
+            return response.status();
+        }
+
+        String body() {
+            assertThat(response).isNotNull();
+            return capturedBody;
+        }
+
+        Optional<String> header(String name) {
+            assertThat(response).isNotNull();
+            for (HttpHeader header : response.headers()) {
+                if (header.nameEqualsIgnoreCase(name)) {
+                    return Optional.of(header.value());
+                }
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
@@ -17,6 +17,7 @@ import eu.exeris.kernel.spi.http.HttpResponse;
 import eu.exeris.kernel.spi.http.HttpStatus;
 import eu.exeris.kernel.spi.http.HttpTypedResponse;
 import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
 import org.junit.jupiter.api.AfterAll;
@@ -102,6 +103,29 @@ class PrometheusMetricsHandlerTest {
     }
 
     @Test
+    @DisplayName("PR #98 review: body buffer is released when respond() throws (no leak)")
+    void respondThrowsClosesBody() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("k", 1L);
+        PrometheusMetricsHandler handler = new PrometheusMetricsHandler(sink, allocator);
+
+        ThrowingRespondExchange exchange = new ThrowingRespondExchange(
+                request(HttpMethod.GET, "/metrics"));
+
+        assertThatThrownBy(() -> handler.handle(exchange))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("simulated downstream failure");
+
+        assertThat(exchange.capturedBody)
+                .as("handler must have offered the body to respond()")
+                .isNotNull();
+        assertThat(exchange.capturedBody.refCount())
+                .as("body refCount must be 0 after respond() throws — caller still owns it "
+                        + "so the catch in handle() is responsible for releasing it")
+                .isZero();
+    }
+
+    @Test
     @DisplayName("Constructor rejects null/blank/relative paths")
     void constructorValidation() {
         PrometheusMetricsSink sink = new PrometheusMetricsSink();
@@ -176,6 +200,36 @@ class PrometheusMetricsHandlerTest {
                 }
             }
             return Optional.empty();
+        }
+    }
+
+    /**
+     * Exchange whose {@code respond(HttpResponse)} throws after capturing the body, modeling
+     * the SPI contract where the engine never took ownership: the caller (handler) must
+     * release the buffer in its catch block.
+     */
+    private static final class ThrowingRespondExchange implements HttpExchange {
+        private final HttpRequest request;
+        private LoanedBuffer capturedBody;
+
+        ThrowingRespondExchange(HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public void respond(HttpResponse response) {
+            this.capturedBody = response.body();
+            throw new IllegalStateException("simulated downstream failure");
+        }
+
+        @Override
+        public void respond(HttpTypedResponse response) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsSinkTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsSinkTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.metrics;
+
+import eu.exeris.kernel.spi.telemetry.KernelEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.StructuredTaskScope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PrometheusMetricsSink")
+class PrometheusMetricsSinkTest {
+
+    @Test
+    @DisplayName("Counter exposition: HELP + TYPE + value")
+    void counterExposesValue() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("kernel_bootstrap_total", 1L);
+        sink.increment("kernel_bootstrap_total", 2L);
+
+        String exposition = sink.exposeText();
+
+        assertThat(exposition)
+                .contains("# TYPE kernel_bootstrap_total counter")
+                .contains("kernel_bootstrap_total 3");
+    }
+
+    @Test
+    @DisplayName("Gauge exposition: last writer wins")
+    void gaugeReflectsLastWrite() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.gauge("kernel_heap_bytes", 1024L);
+        sink.gauge("kernel_heap_bytes", 4096L);
+
+        String exposition = sink.exposeText();
+
+        assertThat(exposition)
+                .contains("# TYPE kernel_heap_bytes gauge")
+                .contains("kernel_heap_bytes 4096")
+                .doesNotContain("kernel_heap_bytes 1024");
+    }
+
+    @Test
+    @DisplayName("Latency exposition: summary with _count and _sum (no quantiles in baseline)")
+    void latencyExposesSummary() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.latency("flush_nanos", 1_000L);
+        sink.latency("flush_nanos", 2_000L);
+        sink.latency("flush_nanos", 3_000L);
+
+        String exposition = sink.exposeText();
+
+        assertThat(exposition)
+                .contains("# TYPE flush_nanos summary")
+                .contains("flush_nanos_count 3")
+                .contains("flush_nanos_sum 6000");
+    }
+
+    @Test
+    @DisplayName("Output is sorted lexicographically within each metric type")
+    void outputIsDeterministic() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("zeta", 1L);
+        sink.increment("alpha", 1L);
+        sink.gauge("delta", 7L);
+        sink.gauge("beta", 3L);
+
+        String exposition = sink.exposeText();
+        int alphaIndex = exposition.indexOf("\nalpha ");
+        int zetaIndex = exposition.indexOf("\nzeta ");
+        int betaIndex = exposition.indexOf("\nbeta ");
+        int deltaIndex = exposition.indexOf("\ndelta ");
+
+        assertThat(alphaIndex).as("alpha sample line is present").isPositive();
+        assertThat(zetaIndex).isPositive();
+        assertThat(betaIndex).isPositive();
+        assertThat(deltaIndex).isPositive();
+        assertThat(alphaIndex).as("alpha < zeta within counters").isLessThan(zetaIndex);
+        assertThat(betaIndex).as("beta < delta within gauges").isLessThan(deltaIndex);
+    }
+
+    @Test
+    @DisplayName("Names with invalid characters are sanitized to the Prometheus regex")
+    void invalidNameCharactersAreSanitized() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("kernel.bootstrap.total", 5L);
+        sink.gauge("9starts-with-digit", 1L);
+        sink.gauge("with space", 2L);
+
+        String exposition = sink.exposeText();
+
+        assertThat(exposition)
+                .contains("kernel_bootstrap_total 5")
+                .contains("_9starts_with_digit 1")
+                .contains("with_space 2");
+    }
+
+    @Test
+    @DisplayName("emit(KernelEvent) is intentionally a no-op")
+    void emitDoesNotInterfereWithMetrics() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.emit(KernelEvent.info("EX-METRIC-001", "PromTest"));
+        sink.increment("metric", 1L);
+
+        String exposition = sink.exposeText();
+        assertThat(exposition)
+                .contains("metric 1")
+                .doesNotContain("EX-METRIC-001");
+    }
+
+    @Test
+    @DisplayName("Concurrent updates produce a consistent total")
+    void concurrentIncrementsAccumulateCorrectly() throws InterruptedException {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        int threads = 16;
+        int perThread = 1_000;
+
+        try (var scope = StructuredTaskScope.open(StructuredTaskScope.Joiner.<Void>awaitAllSuccessfulOrThrow())) {
+            for (int t = 0; t < threads; t++) {
+                scope.fork(() -> {
+                    for (int j = 0; j < perThread; j++) {
+                        sink.increment("hot", 1L);
+                    }
+                    return null;
+                });
+            }
+            scope.join();
+        }
+
+        assertThat(sink.exposeText()).contains("hot " + (long) threads * perThread);
+    }
+
+    @Test
+    @DisplayName("close() clears recorded state")
+    void closeClearsState() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        sink.increment("a", 1L);
+        sink.gauge("b", 2L);
+        sink.latency("c", 3L);
+
+        sink.close();
+
+        assertThat(sink.exposeText()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Null metric name is rejected")
+    void nullNameRejected() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        assertThatThrownBy(() -> sink.increment(null, 1L)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> sink.gauge(null, 1L)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> sink.latency(null, 1L)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("Sink name is canonical for diagnostics")
+    void sinkNameIsCanonical() {
+        PrometheusMetricsSink sink = new PrometheusMetricsSink();
+        assertThat(sink.sinkName()).isEqualTo("ExerisCommunity/PrometheusMetricsSink");
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Sprint 7 deliverable #2** — operational metrics export baseline —
and **closes Sprint 7** end-to-end.

The Sprint 7 split:
- 7a = disclosure mode (#95, merged)
- 7b = health endpoint (#96, merged)
- 7c = async telemetry dispatcher (#97, merged)
- **7d = Prometheus export (this PR)**

## Decision: Prometheus pull (over OTLP push)

| Aspect | Prometheus pull (chosen) | OTLP push |
|:--|:--|:--|
| Client state | None — each scrape is stateless | Long-lived gRPC client + retry buffer |
| Dependencies | None beyond JDK | \`opentelemetry-exporter-otlp\` + Protobuf |
| Failure mode | Scraper observes scrape failure directly | Push retries can mask sustained failure |
| K8s integration | Pod annotation / \`ServiceMonitor\` | OpenTelemetry Collector sidecar |

Pull adds zero new runtime dependencies. An Enterprise binding may add an OTLP
exporter later without modifying the sink — it stores raw counter/gauge/latency
state.

## Architecture

- **\`PrometheusMetricsSink\`** (\`TelemetrySink\`): records counters
  (\`LongAdder\`), gauges (\`AtomicLong\`), and latencies (\`LongAdder\` count + sum)
  in concurrent maps. \`exposeText()\` produces a deterministic Prometheus 0.0.4
  text exposition snapshot (lex-sorted within each metric type). Names are
  sanitised to the Prometheus regex; the original name remains the lookup key so
  accumulation works as expected. \`emit(KernelEvent)\` is a no-op — pair with
  \`JfrTelemetrySink\`/\`Slf4jTelemetrySink\` for events.
- **\`PrometheusMetricsHandler\`** (\`HttpHandler\`): serves \`GET /metrics\`
  with the exposition body. Path-mismatch → \`404\`; non-\`GET\` → \`405\` with
  \`Allow: GET\`. Custom path via overload. Body is allocated through an
  injected \`MemoryAllocator\` and ownership transfers to the engine on
  \`respond()\`.

## Metric mapping

| \`TelemetrySink\` call | Prometheus type | Exposition shape |
|:--|:--|:--|
| \`increment(name, delta)\` | \`counter\` | \`name <total>\` |
| \`gauge(name, value)\` | \`gauge\` | \`name <last_value>\` |
| \`latency(name, ns)\` | \`summary\` | \`name_count <count>\` + \`name_sum <sum>\` (no quantiles in baseline) |

## Tests

- **\`PrometheusMetricsSinkTest\`** (10 cases): counter/gauge/latency exposition,
  deterministic ordering, name sanitisation, \`emit\` no-op, concurrent updates
  (16 VTs × 1000 increments), close clears state, null-name rejection.
- **\`PrometheusMetricsHandlerTest\`** (5 cases): \`GET /metrics\` 200 + body +
  Content-Type/Length, unknown path 404, POST 405 with \`Allow\`, custom path
  honoured + default returns 404, constructor validation. Uses the real
  \`CommunityMemoryProvider\` allocator so \`LoanedBuffer\` ownership flow is
  exercised end-to-end.

## Docs

- \`docs/subsystems/telemetry.md\` — new *Operational metrics export — Prometheus
  (since 0.7.0)* section with pull-vs-push rationale table, metric mapping
  table, naming sanitisation rule, wiring example, validation summary.

## Quality gate

\`\`\`
mvn -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify -DskipITs
→ all modules SUCCESS
→ 0 PMD/Checkstyle violations
→ 15 new metrics tests green
\`\`\`

## Test plan

- [x] 10 \`PrometheusMetricsSinkTest\` cases.
- [x] 5 \`PrometheusMetricsHandlerTest\` cases.
- [x] No regressions in existing telemetry/HTTP tests.
- [x] Full \`mvn verify\` on SPI + TCK + Core + Community: 0 regressions.

## Out of scope (follow-up)

- **Quantile sketches** for latency histograms — current summary type only
  exposes \`_count\` and \`_sum\`. Operators compute averages via PromQL
  (\`rate(name_sum[1m]) / rate(name_count[1m])\`). 0.8+ enhancement once a
  low-allocation sketch (e.g., DDSketch) is selected.
- **OTLP exporter binding** — Enterprise scope, no impact on this sink.
- **Counter/gauge metric labels (tags).** Baseline is unlabeled; a label-aware
  variant can be added without breaking the sink contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)