### PR TITLE
v0.7 Sprint 8a: @RequiresRole SPI annotation surface (ADR-014 §3)

### DIFF
--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -2,8 +2,8 @@
 
 **Physical Layout:**
 
-- SPI: `eu.exeris.kernel.spi.security.*` (PrincipalContext, StorageContext, SecurityProvider, AuthenticationResult, ImmutablePrincipal, ImmutableStorageContext, KernelIsolationClaims, credentials/KernelPasswordEncoder, credentials/PasswordEncoderConfig)
-  > **Note:** `@RequiresRole` is planned only.
+- SPI: `eu.exeris.kernel.spi.security.*` (PrincipalContext, StorageContext, SecurityProvider, AuthenticationResult, ImmutablePrincipal, ImmutableStorageContext, KernelIsolationClaims, credentials/KernelPasswordEncoder, credentials/PasswordEncoderConfig, **`@RequiresRole` + `RoleMatch` + `KernelRoles`** since 0.7.0)
+  > **Note:** the `@RequiresRole` SPI annotation surface ships in 0.7.0 (Sprint 8a). The APT processor that generates `RoleCheckRegistry` and the runtime admission integration ship in Sprint 8b.
 - Community: `eu.exeris.kernel.community.security.*` (`CommunitySecurityProvider`, `Argon2idPasswordEncoder`, `CommunityJwksValidator`)
 - Core: `eu.exeris.kernel.core.security.*` (Token Extractors, ScopedValue Orchestration)
 
@@ -49,7 +49,7 @@ zero-leak, hyper-density concurrency with immutable identity at every layer. It 
 
 1. Define the `PrincipalContext` interface. Roles are open-form string constants, not a closed enum.
 2. Provide the `KernelProviders.PRINCIPAL_CONTEXT` and `KernelProviders.STORAGE_CONTEXT` ScopedValue slots.
-3. Expose `@RequiresRole` annotations for declarative RBAC (planned only — not yet implemented).
+3. Expose the `@RequiresRole` annotation type, the `RoleMatch` enum, and the canonical `KernelRoles` system-role bit mapping for declarative RBAC (since 0.7.0). The annotation is `@Retention(SOURCE)` — consumed at compile time only by the APT processor (planned for Sprint 8b).
 
 **What Security Core DOES:**
 
@@ -189,24 +189,43 @@ token lifetime. The following contract governs token lifecycle in the Kernel:
 
 ## `@RequiresRole` Processing — No Reflection on Hot Path
 
-> **Status: Planned — not yet implemented in this repo.** The `@RequiresRole` annotation and the
-> `RoleCheckRegistry` APT-generated class do not exist in the current SPI or `exeris-kernel-build-config`.
-> The description below is the target design. Do not reference these types until the corresponding
-> SPI/APT implementation lands.
+> **Status (0.7.0):** SPI annotation surface (`@RequiresRole`, `RoleMatch`, `KernelRoles`) is implemented
+> as of Sprint 8a. The APT processor in `exeris-kernel-build-config`, the generated `RoleCheckRegistry`,
+> the `LazyConstant` loader, the `principal.roleMask()` carrier, and the runtime admission hook ship in
+> Sprint 8b. Until then, `@RequiresRole` annotations are valid declarations but no enforcement is wired —
+> use `CitadelGuard.requireRole(...)` for runtime checks.
 
-`@RequiresRole` annotations are **NOT processed via runtime reflection**. The target mechanism is:
+### SPI surface (since 0.7.0)
+
+```java
+@RequiresRole({"ROLE_ADMIN"})                                  // any admin → permitted
+@RequiresRole({"ROLE_ADMIN", "ROLE_OPERATOR"})                 // admin OR operator
+@RequiresRole(value = {"ROLE_ADMIN", "ROLE_AUDITOR"}, match = RoleMatch.ALL)
+                                                               // both required
+```
+
+Live in `eu.exeris.kernel.spi.security`. The annotation is `@Retention(SOURCE)` — consumed at compile
+time only — so reflection at runtime can never observe it. `KernelRoles` reserves bits `[0, 8)` for
+the kernel-owned system roles (`ROLE_SYSTEM`, `ROLE_ADMIN`, `ROLE_OPERATOR`, `ROLE_USER`); application
+roles are assigned bits `[8, 64)` by the APT processor at build time. ADR-014 covers the binding
+contract end-to-end.
+
+### Target mechanism (Sprint 8b)
+
+`@RequiresRole` annotations are **NOT processed via runtime reflection**. The mechanism is:
 
 1. **Compile-time annotation processor (APT):** An annotation processor in `exeris-kernel-build-config`
    generates a static `RoleCheckRegistry` class at compile time. For each annotated method, a `long` bitmask
    encoding the required roles is emitted into the registry.
-2. **Runtime lookup:** At admission time, the transport layer performs a single `int` bitmask AND operation
+2. **Runtime lookup:** At admission time, the transport layer performs a single `long` bitmask AND operation
    between the principal's role bitmask (extracted from the JWT at parse time) and the required role bitmask
    from the registry. This is O(1) and allocation-free.
 3. **No `Class.getAnnotation()` on hot path:** Zero reflection calls occur after JVM startup. The APT-generated
    registry is loaded once via `LazyConstant.of(...)` at first access.
 
 ```
-Hot-path check: (principal.roleMask() & registry.requiredMask(methodId)) != 0
+Hot-path check (RoleMatch.ANY): (principal.roleMask() & registry.requiredMask(methodId)) != 0L
+Hot-path check (RoleMatch.ALL): (principal.roleMask() & registry.requiredMask(methodId)) == registry.requiredMask(methodId)
 ```
 
 If this check fails, `EX-SEC-2003` is thrown before any business logic executes.

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelRoles.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelRoles.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+/**
+ * Canonical kernel-owned role-name → bit-position mapping for the small set of
+ * system roles every Exeris deployment understands.
+ *
+ * <h2>Why a fixed mapping</h2>
+ * <p>Per ADR-014 §3 the kernel's {@code @RequiresRole} pipeline is built around a
+ * single primitive bitmask AND/EQ on the hot path. System roles get reserved low
+ * bits so that the runtime check never has to consult an indirection table for
+ * the most common authorization primitives ({@code ROLE_ADMIN}, etc.).
+ * Application-defined roles are assigned remaining bits at build time by the APT
+ * processor and recorded in the generated {@code RoleCheckRegistry}.
+ *
+ * <h2>Bit budget</h2>
+ * <p>The runtime check uses a {@code long} mask (64 bits). System roles occupy
+ * bits {@code [0..7]} (8 reserved slots, today 4 used) leaving 56 bits for
+ * application roles. ADR-014 §10 (Consequences) covers shard expansion if a
+ * deployment ever exceeds 64 roles.
+ *
+ * @see RequiresRole
+ * @see <a href="../../../../../../docs/adr/ADR-014%20RequiresRole%20Compile-Time%20RBAC%20Generation.md">ADR-014</a>
+ * @since 0.7.0
+ */
+public final class KernelRoles {
+
+    // -----------------------------------------------------------------------
+    // System role bit positions (reserved range: [0, SYSTEM_ROLE_BIT_LIMIT))
+    // -----------------------------------------------------------------------
+
+    /** Internal kernel components (bootstrap, scheduler, recovery). Bit 0. */
+    public static final int BIT_SYSTEM = 0;
+
+    /** Operator with full administrative authority. Bit 1. */
+    public static final int BIT_ADMIN = 1;
+
+    /** Operator with read-mostly observability + maintenance authority. Bit 2. */
+    public static final int BIT_OPERATOR = 2;
+
+    /** Authenticated user with default tenant-scoped access. Bit 3. */
+    public static final int BIT_USER = 3;
+
+    /**
+     * Exclusive upper bound of the system-role bit range. Application-defined
+     * roles assigned by the APT processor MUST start at this index or higher.
+     */
+    public static final int SYSTEM_ROLE_BIT_LIMIT = 8;
+
+    // -----------------------------------------------------------------------
+    // Canonical role-name constants — these strings appear in @RequiresRole
+    // -----------------------------------------------------------------------
+
+    /** @see #BIT_SYSTEM */
+    public static final String ROLE_SYSTEM = "ROLE_SYSTEM";
+
+    /** @see #BIT_ADMIN */
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    /** @see #BIT_OPERATOR */
+    public static final String ROLE_OPERATOR = "ROLE_OPERATOR";
+
+    /** @see #BIT_USER */
+    public static final String ROLE_USER = "ROLE_USER";
+
+    private KernelRoles() {
+        // Constants holder — not instantiable.
+    }
+
+    /**
+     * Returns the canonical bit position for a system role, or {@code -1} if the
+     * given name is not one of the system roles defined here.
+     *
+     * <p>This method is intended for the APT processor's compile-time bit
+     * resolution. Runtime decision paths MUST use the precomputed bitmask in the
+     * generated {@code RoleCheckRegistry}, not this lookup.
+     *
+     * @param roleName non-null role name
+     * @return bit position {@code [0, SYSTEM_ROLE_BIT_LIMIT)} or {@code -1}
+     */
+    public static int systemRoleBit(String roleName) {
+        return switch (roleName) {
+            case ROLE_SYSTEM -> BIT_SYSTEM;
+            case ROLE_ADMIN -> BIT_ADMIN;
+            case ROLE_OPERATOR -> BIT_OPERATOR;
+            case ROLE_USER -> BIT_USER;
+            case null, default -> -1;
+        };
+    }
+
+    /**
+     * Returns the canonical bitmask for a single system role. Convenience wrapper
+     * over {@link #systemRoleBit(String)}.
+     *
+     * @param roleName non-null role name
+     * @return bitmask with one bit set, or {@code 0L} if the role is unknown
+     */
+    public static long systemRoleMask(String roleName) {
+        int bit = systemRoleBit(roleName);
+        return bit < 0 ? 0L : 1L << bit;
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RequiresRole.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RequiresRole.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Compile-time RBAC declaration: the annotated method or type entry point requires
+ * the caller's principal to hold the listed role(s).
+ *
+ * <h2>Why {@link RetentionPolicy#SOURCE}</h2>
+ * <p>Per ADR-014 §3 the annotation is consumed exclusively at compile time by the
+ * APT processor that ships in {@code exeris-kernel-build-config}. The processor
+ * produces a generated {@code RoleCheckRegistry} with primitive-only static fields
+ * and an O(1) lookup per method-id; no runtime reflection ever inspects this
+ * annotation. {@code SOURCE} retention guarantees the annotation never reaches the
+ * class file and therefore cannot leak onto a hot path through {@code Class
+ * .getAnnotation()} misuse.
+ *
+ * <h2>Match semantics</h2>
+ * <p>{@link #match()} controls how the declared roles are combined into a single
+ * bitmask check at runtime:
+ *
+ * <pre>{@code
+ * @RequiresRole({"ROLE_ADMIN"})                       // any admin → permitted
+ * @RequiresRole({"ROLE_ADMIN", "ROLE_OPERATOR"})      // admin OR operator
+ * @RequiresRole(value = {"ROLE_ADMIN", "ROLE_AUDITOR"}, match = RoleMatch.ALL)
+ *                                                     // both required
+ * }</pre>
+ *
+ * <h2>Coexistence with {@code CitadelGuard}</h2>
+ * <p>{@code CitadelGuard.requireRole(String)} remains the runtime fallback for
+ * dynamic role decisions (the required role is computed from request data).
+ * Static {@code @RequiresRole} checks short-circuit before {@code CitadelGuard}
+ * is consulted; both produce {@code EX-SEC-2003} on denial so operators see
+ * uniform telemetry.
+ *
+ * <h2>Build-time validation</h2>
+ * <p>The APT processor MUST fail compilation when {@link #value()} contains a
+ * role name that is not present in the canonical {@link KernelRoles} table or in
+ * the application-defined role mapping resolved at build time. Build failures
+ * are preferred over runtime warnings — this is a security contract, not a
+ * style preference.
+ *
+ * @see KernelRoles
+ * @see RoleMatch
+ * @see <a href="../../../../../../docs/adr/ADR-014%20RequiresRole%20Compile-Time%20RBAC%20Generation.md">ADR-014</a>
+ * @since 0.7.0
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface RequiresRole {
+
+    /**
+     * Required role names. Must be non-empty. Each entry must resolve to a bit
+     * assignment known to the APT processor — either a {@link KernelRoles} system
+     * role or an application-declared role.
+     *
+     * @return required role names; never empty
+     */
+    String[] value();
+
+    /**
+     * How {@link #value()} entries are combined when more than one role is listed.
+     * Defaults to {@link RoleMatch#ANY} so single-role declarations carry no
+     * surprise ({@code @RequiresRole("ROLE_ADMIN")} is equivalent to ANY-of).
+     *
+     * @return match strategy; default {@link RoleMatch#ANY}
+     */
+    RoleMatch match() default RoleMatch.ANY;
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RoleMatch.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RoleMatch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+/**
+ * Match semantics for {@link RequiresRole} declarations.
+ *
+ * <p>Per ADR-014 §3, the generated runtime check translates to a single primitive
+ * operation:
+ *
+ * <ul>
+ *   <li>{@link #ANY} — {@code (principal.roleMask() & required) != 0L}</li>
+ *   <li>{@link #ALL} — {@code (principal.roleMask() & required) == required}</li>
+ * </ul>
+ *
+ * <p>No allocation, no reflection, no string interning at decision time.
+ *
+ * @since 0.7.0
+ */
+public enum RoleMatch {
+
+    /** Principal must hold at least one of the declared roles. */
+    ANY,
+
+    /** Principal must hold every declared role. */
+    ALL
+}

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/security/KernelRolesTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/security/KernelRolesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("KernelRoles — canonical system-role bit mapping (ADR-014)")
+class KernelRolesTest {
+
+    @Test
+    @DisplayName("Reserved system-role bits are unique and within [0, SYSTEM_ROLE_BIT_LIMIT)")
+    void systemBitsAreUniqueAndWithinReservedRange() {
+        int[] bits = {
+                KernelRoles.BIT_SYSTEM,
+                KernelRoles.BIT_ADMIN,
+                KernelRoles.BIT_OPERATOR,
+                KernelRoles.BIT_USER
+        };
+        for (int bit : bits) {
+            assertThat(bit)
+                    .as("system role bit must be within the reserved range")
+                    .isBetween(0, KernelRoles.SYSTEM_ROLE_BIT_LIMIT - 1);
+        }
+        assertThat(bits).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("SYSTEM_ROLE_BIT_LIMIT leaves head-room for application-defined roles in a long mask")
+    void reservedRangeFitsInLongMask() {
+        assertThat(KernelRoles.SYSTEM_ROLE_BIT_LIMIT)
+                .as("system reservation must leave the majority of a long mask for application roles")
+                .isLessThan(Long.SIZE);
+    }
+
+    @Test
+    @DisplayName("systemRoleBit() resolves canonical names; unknown names return -1")
+    void resolvesCanonicalNames() {
+        assertThat(KernelRoles.systemRoleBit(KernelRoles.ROLE_SYSTEM)).isEqualTo(KernelRoles.BIT_SYSTEM);
+        assertThat(KernelRoles.systemRoleBit(KernelRoles.ROLE_ADMIN)).isEqualTo(KernelRoles.BIT_ADMIN);
+        assertThat(KernelRoles.systemRoleBit(KernelRoles.ROLE_OPERATOR)).isEqualTo(KernelRoles.BIT_OPERATOR);
+        assertThat(KernelRoles.systemRoleBit(KernelRoles.ROLE_USER)).isEqualTo(KernelRoles.BIT_USER);
+        assertThat(KernelRoles.systemRoleBit("ROLE_GHOST")).isEqualTo(-1);
+        assertThat(KernelRoles.systemRoleBit(null)).isEqualTo(-1);
+    }
+
+    @Test
+    @DisplayName("systemRoleMask() returns a single-bit mask matching systemRoleBit()")
+    void maskMatchesBit() {
+        assertThat(KernelRoles.systemRoleMask(KernelRoles.ROLE_ADMIN))
+                .isEqualTo(1L << KernelRoles.BIT_ADMIN);
+        assertThat(KernelRoles.systemRoleMask("ROLE_GHOST")).isZero();
+        assertThat(Long.bitCount(KernelRoles.systemRoleMask(KernelRoles.ROLE_USER))).isOne();
+    }
+
+    @Test
+    @DisplayName("Role-name constants are stable strings (no accidental refactors)")
+    void roleNameConstantsAreStable() {
+        assertThat(KernelRoles.ROLE_SYSTEM).isEqualTo("ROLE_SYSTEM");
+        assertThat(KernelRoles.ROLE_ADMIN).isEqualTo("ROLE_ADMIN");
+        assertThat(KernelRoles.ROLE_OPERATOR).isEqualTo("ROLE_OPERATOR");
+        assertThat(KernelRoles.ROLE_USER).isEqualTo("ROLE_USER");
+    }
+}

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/security/RequiresRoleTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/security/RequiresRoleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("@RequiresRole — SPI annotation contract (ADR-014)")
+class RequiresRoleTest {
+
+    @Test
+    @DisplayName("Retention is SOURCE — annotation never reaches the class file")
+    void retentionIsSource() {
+        Retention retention = RequiresRole.class.getAnnotation(Retention.class);
+        assertThat(retention)
+                .as("@RequiresRole MUST declare @Retention(SOURCE) per ADR-014 §3")
+                .isNotNull();
+        assertThat(retention.value())
+                .as("Reflection at runtime MUST never observe @RequiresRole — that would "
+                        + "violate the No-Waste-Compute hot-path contract")
+                .isEqualTo(RetentionPolicy.SOURCE);
+    }
+
+    @Test
+    @DisplayName("Targets are METHOD and TYPE only")
+    void targetsAreMethodAndType() {
+        Target target = RequiresRole.class.getAnnotation(Target.class);
+        assertThat(target).isNotNull();
+        assertThat(target.value())
+                .containsExactlyInAnyOrder(ElementType.METHOD, ElementType.TYPE);
+    }
+
+    @Test
+    @DisplayName("Default match strategy is RoleMatch.ANY")
+    void defaultMatchIsAny() throws NoSuchMethodException {
+        Object defaultValue = RequiresRole.class.getMethod("match").getDefaultValue();
+        assertThat(defaultValue).isEqualTo(RoleMatch.ANY);
+    }
+
+    @Test
+    @DisplayName("RoleMatch carries exactly ANY and ALL — no surprises for the APT processor")
+    void roleMatchEnumShape() {
+        assertThat(RoleMatch.values())
+                .containsExactly(RoleMatch.ANY, RoleMatch.ALL);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the SPI surface for compile-time RBAC per **ADR-014 §3** (already
ACCEPTED in Sprint 1, dated 2026-04-30). This is groundwork for Sprint 8b — the
APT processor, generated \`RoleCheckRegistry\`, \`principal.roleMask()\`, and
runtime admission integration ship next.

The Sprint 8 split: **8a = SPI groundwork (this PR)**, 8b = APT + runtime,
8c = SQ-005..011 batch, 8d = QA-008/009, 8e = Hot-path collections review,
8f = release readiness.

## Added (\`exeris-kernel-spi/.../security\`)

- **\`RoleMatch\`** enum: \`ANY\` (bitmask AND != 0) and \`ALL\` (bitmask AND ==
  required).
- **\`@RequiresRole\`** annotation:
  - \`@Retention(SOURCE)\` — never reaches the class file; runtime reflection
    can never observe it. Per ADR-014 §3 the APT processor is the sole consumer.
  - \`@Target({METHOD, TYPE})\`.
  - \`String[] value()\`, \`RoleMatch match() default ANY\`.
- **\`KernelRoles\`** — canonical kernel-owned role-name → bit-position mapping.
  Reserves bits \`[0, 8)\` for system roles (\`ROLE_SYSTEM\`=0, \`ROLE_ADMIN\`=1,
  \`ROLE_OPERATOR\`=2, \`ROLE_USER\`=3). Application roles will occupy bits
  \`[8, 64)\` via the APT processor in 8b. \`systemRoleBit()\` /
  \`systemRoleMask()\` resolvers are intended for the build-time processor;
  runtime decision paths use the precomputed bitmask in the generated registry.

## Usage

\`\`\`java
@RequiresRole({"ROLE_ADMIN"})                                  // any admin → permitted
@RequiresRole({"ROLE_ADMIN", "ROLE_OPERATOR"})                 // admin OR operator
@RequiresRole(value = {"ROLE_ADMIN", "ROLE_AUDITOR"}, match = RoleMatch.ALL)
                                                               // both required
\`\`\`

## Tests

- **\`RequiresRoleTest\`** (4 cases): retention is \`SOURCE\`; targets are
  \`METHOD\`+\`TYPE\` only; default match is \`ANY\`; \`RoleMatch\` enum carries
  exactly \`ANY\`+\`ALL\`.
- **\`KernelRolesTest\`** (5 cases): bit positions unique within the reserved
  range; reserved range fits in a long mask with head-room; canonical name →
  bit resolution; mask matches bit; role-name string constants stable.

## Docs

- \`docs/subsystems/security.md\`:
  - Physical Layout SPI line lists the new types and notes the 0.7.0 landing
    of the annotation surface.
  - *What Security SPI DOES* item #3 updated from *planned only* to
    *implemented (annotation surface only); APT in 8b*.
  - *@RequiresRole Processing* section status block updated; new
    *SPI surface (since 0.7.0)* subsection with usage examples and bit-range
    note. Hot-path check formula extended to cover both \`ANY\` and \`ALL\`
    branches.

## Quality gate

\`\`\`
mvn -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify -DskipITs
→ all modules SUCCESS, 0 PMD/Checkstyle violations
→ 9 new SPI tests green
\`\`\`

## Test plan

- [x] 4 \`RequiresRoleTest\` cases.
- [x] 5 \`KernelRolesTest\` cases.
- [x] No regressions in existing security/SPI tests.
- [x] Full \`mvn verify\` on SPI + TCK + Core + Community: 0 regressions.

## Out of scope (8b follow-up)

- Annotation processor in \`exeris-kernel-build-config\` that scans
  \`@RequiresRole\`-bearing elements and emits \`RoleCheckRegistry\`.
- \`principal.roleMask(): long\` carrier on \`PrincipalContext\` (or shard array).
- Runtime admission hook + \`LazyConstant<RoleCheckRegistry>\` loader.
- \`AbstractRequiresRoleTck\` + \`RequiresRoleZeroAllocTck\` + Community binding.
- Maven BOM \`annotationProcessorPaths\` default wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)