### PR TITLE
v0.7 Sprint 8b-i: @RequiresRole APT processor (ADR-014 §3, §8)

### DIFF
--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -190,10 +190,12 @@ token lifetime. The following contract governs token lifecycle in the Kernel:
 ## `@RequiresRole` Processing — No Reflection on Hot Path
 
 > **Status (0.7.0):** SPI annotation surface (`@RequiresRole`, `RoleMatch`, `KernelRoles`) is implemented
-> as of Sprint 8a. The APT processor in `exeris-kernel-build-config`, the generated `RoleCheckRegistry`,
-> the `LazyConstant` loader, the `principal.roleMask()` carrier, and the runtime admission hook ship in
-> Sprint 8b. Until then, `@RequiresRole` annotations are valid declarations but no enforcement is wired —
-> use `CitadelGuard.requireRole(...)` for runtime checks.
+> as of Sprint 8a. The APT processor (`eu.exeris.kernel.buildconfig.security.RequiresRoleProcessor`)
+> ships in Sprint 8b-i and emits `eu.exeris.kernel.security.generated.RoleCheckRegistry` at compile time.
+> The `LazyConstant<RoleCheckRegistry>` loader, the `principal.roleMask()` carrier, the runtime admission
+> hook, and the `AbstractRequiresRoleTck` ship in Sprint 8b-ii. Until then, `@RequiresRole` annotations
+> emit a generated registry but no runtime check consumes it — use `CitadelGuard.requireRole(...)` for
+> runtime checks.
 
 ### SPI surface (since 0.7.0)
 
@@ -210,13 +212,21 @@ the kernel-owned system roles (`ROLE_SYSTEM`, `ROLE_ADMIN`, `ROLE_OPERATOR`, `RO
 roles are assigned bits `[8, 64)` by the APT processor at build time. ADR-014 covers the binding
 contract end-to-end.
 
-### Target mechanism (Sprint 8b)
+### APT processor (since 0.7.0, Sprint 8b-i)
 
 `@RequiresRole` annotations are **NOT processed via runtime reflection**. The mechanism is:
 
-1. **Compile-time annotation processor (APT):** An annotation processor in `exeris-kernel-build-config`
-   generates a static `RoleCheckRegistry` class at compile time. For each annotated method, a `long` bitmask
-   encoding the required roles is emitted into the registry.
+1. **Compile-time annotation processor (APT):** `RequiresRoleProcessor` in
+   `exeris-kernel-build-config` scans every `@RequiresRole`-annotated METHOD/TYPE
+   in a compilation unit and emits a single source file
+   `eu.exeris.kernel.security.generated.RoleCheckRegistry`. Method IDs are
+   assigned in alphabetical order of the fully-qualified declaring type +
+   member name (deterministic across rebuilds). Role bits follow `KernelRoles`
+   for the canonical four system roles (bits `[0, 8)`); application-defined
+   role names get bits `[8, 64)` assigned alphabetically. The processor reads
+   the annotation by FQN string and declares no project-scope dependency on
+   `exeris-kernel-spi` — that would create a reactor cycle (SPI consumes
+   build-config rulesets via plugin classpath).
 2. **Runtime lookup:** At admission time, the transport layer performs a single `long` bitmask AND operation
    between the principal's role bitmask (extracted from the JWT at parse time) and the required role bitmask
    from the registry. This is O(1) and allocation-free.

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -59,9 +59,10 @@ zero-leak, hyper-density concurrency with immutable identity at every layer. It 
 4. `CitadelGuard` — sentinel-pool RBAC enforcement gate with `preAllocate(String role)` / `seal()` / `requireRole(String role)`. Sealed at bootstrap READY transition.
 5. `StorageContextBridge` — derives a SHARED `StorageContext` from a `PrincipalContext` (SHARED-only derivation contract per ADR-010 §4a; full SEPARATED_SCHEMA/DEDICATED derivation comes from `SecurityProvider.authenticate()`). Fail-closed: when the `PrincipalContext` ScopedValue is unbound at the call site, `StorageContextBridge.derive()` raises `PrincipalContextMissingException` (`EX-SEC-2001`) and the request is rejected at the security boundary before any persistence interaction.
 
-> **TCK status:** `CitadelGuard` is now covered by the shared `AbstractCitadelGuardTck` contract plus Community/Core bindings.
-
-> **TCK status:** `StorageContextBridge.derive()` is now covered by a standalone `AbstractStorageContextBridgeTck`, including SHARED derivation and fail-closed handling for missing principal context.
+> **TCK status:**
+>
+> - `CitadelGuard` is now covered by the shared `AbstractCitadelGuardTck` contract plus Community/Core bindings.
+> - `StorageContextBridge.derive()` is now covered by a standalone `AbstractStorageContextBridgeTck`, including SHARED derivation and fail-closed handling for missing principal context.
 
 ---
 

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -14,10 +14,61 @@
 	<packaging>jar</packaging>
 
 	<name>Exeris Kernel - Build Config</name>
-	<description>Strict Code Quality Rules (Checkstyle, PMD) for Exeris Kernel (Java 26+)</description>
+	<description>Strict Code Quality Rules (Checkstyle, PMD) + APT processors for Exeris Kernel (Java 26+)</description>
 
 	<properties>
 		<maven.deploy.skip>false</maven.deploy.skip>
 		<pmd.skip>true</pmd.skip>
+		<maven.compiler.release>26</maven.compiler.release>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>eu.exeris</groupId>
+				<artifactId>exeris-kernel-bom</artifactId>
+				<version>${project.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!--
+		  build-config never depends on SPI: SPI consumes build-config's
+		  checkstyle/PMD rulesets via plugin classpath, so any project-scope
+		  SPI dependency creates a reactor cycle. The @RequiresRole APT
+		  processor reads annotations via FQN strings (no Class<?> reference).
+		  Tests synthesise the annotation type alongside their fixtures.
+		-->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.1</version>
+				<configuration>
+					<release>${maven.compiler.release}</release>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/exeris-kernel-build-config/src/main/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessor.java
+++ b/exeris-kernel-build-config/src/main/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessor.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.buildconfig.security;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Compile-time annotation processor for {@code @RequiresRole} per ADR-014.
+ *
+ * <h2>What it produces</h2>
+ * <p>For every method or type annotated with
+ * {@code eu.exeris.kernel.spi.security.RequiresRole} across a compilation unit,
+ * the processor emits a single Java source file:
+ *
+ * <pre>{@code
+ * eu.exeris.kernel.security.generated.RoleCheckRegistry
+ * }</pre>
+ *
+ * <p>The generated class is final, has primitive-only static fields, and exposes
+ * O(1) lookup methods so the runtime decision is a single bitmask AND/EQ:
+ *
+ * <ul>
+ *   <li>{@code requiredAny(int methodId)} — used when {@code RoleMatch.ANY}.</li>
+ *   <li>{@code requiredAll(int methodId)} — used when {@code RoleMatch.ALL}.</li>
+ *   <li>{@code matchIsAll(int methodId)} — boolean discriminator so the runtime
+ *       picks the right primitive comparison.</li>
+ *   <li>{@code methodCount()} — number of annotated entry points compiled.</li>
+ *   <li>{@code methodNames()} — ordered list of fully-qualified method
+ *       identifiers (for diagnostics; never on the hot path).</li>
+ *   <li>{@code roleNameToBit(String)} — build-time role-name → bit lookup so
+ *       the runtime can resolve principal claim strings against the same
+ *       canonical assignment used at compile time.</li>
+ * </ul>
+ *
+ * <h2>Determinism</h2>
+ * <p>Method IDs are assigned in alphabetical order of the fully-qualified
+ * declaring type + method signature so the generated artifact is identical
+ * across rebuilds. Application-defined role names get bits assigned
+ * alphabetically starting at {@link #SYSTEM_ROLE_BIT_LIMIT}; system roles
+ * (per {@code KernelRoles}) keep their fixed canonical bits.
+ *
+ * <h2>SPI coupling</h2>
+ * <p>This processor reads the annotation by FQN string; it does not declare a
+ * compile-time dependency on {@code exeris-kernel-spi}. That keeps build-config
+ * out of the SPI reactor cycle (SPI consumes build-config's checkstyle/PMD
+ * rulesets via plugin dependencies). System role bit assignments are duplicated
+ * here as constants — they MUST stay in sync with
+ * {@code eu.exeris.kernel.spi.security.KernelRoles}.
+ */
+@SupportedAnnotationTypes(RequiresRoleProcessor.REQUIRES_ROLE_FQN)
+@SupportedSourceVersion(SourceVersion.RELEASE_25)
+public final class RequiresRoleProcessor extends AbstractProcessor {
+
+    /** Fully-qualified name of the SPI annotation processed by this implementation. */
+    public static final String REQUIRES_ROLE_FQN = "eu.exeris.kernel.spi.security.RequiresRole";
+
+    /** Fully-qualified name of the generated registry class. */
+    public static final String GENERATED_CLASS_FQN = "eu.exeris.kernel.security.generated.RoleCheckRegistry";
+
+    /** Reserved range for kernel system roles (bits {@code [0, 8)}). Mirrors {@code KernelRoles}. */
+    public static final int SYSTEM_ROLE_BIT_LIMIT = 8;
+
+    private static final String GENERATED_PACKAGE = "eu.exeris.kernel.security.generated";
+    private static final String GENERATED_SIMPLE_NAME = "RoleCheckRegistry";
+    private static final long ROLE_MASK_WIDTH = 64L;
+
+    /**
+     * Canonical kernel-owned role-name → bit-position mapping. Mirrors
+     * {@code eu.exeris.kernel.spi.security.KernelRoles}. Application-defined
+     * roles outside this map receive bits {@code [SYSTEM_ROLE_BIT_LIMIT, 64)}
+     * in alphabetical order at build time.
+     */
+    private static final Map<String, Integer> SYSTEM_ROLE_BITS = Map.of(
+            "ROLE_SYSTEM",   0,
+            "ROLE_ADMIN",    1,
+            "ROLE_OPERATOR", 2,
+            "ROLE_USER",     3
+    );
+
+    private final List<MethodDescriptor> methods = new ArrayList<>();
+    private final TreeMap<String, Integer> applicationRoleBits = new TreeMap<>();
+    private boolean generated;
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (annotations.isEmpty() && roundEnv.errorRaised()) {
+            return false;
+        }
+        for (TypeElement annotation : annotations) {
+            if (REQUIRES_ROLE_FQN.equals(annotation.getQualifiedName().toString())) {
+                collect(roundEnv.getElementsAnnotatedWith(annotation));
+            }
+        }
+        if (!roundEnv.processingOver() || generated || methods.isEmpty()) {
+            return true;
+        }
+        try {
+            emit();
+        } catch (IOException ex) {
+            processingEnv.getMessager().printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "RequiresRoleProcessor: failed to write " + GENERATED_CLASS_FQN + " — " + ex.getMessage());
+        }
+        generated = true;
+        return true;
+    }
+
+    private void collect(Set<? extends Element> elements) {
+        Messager messager = processingEnv.getMessager();
+        for (Element element : elements) {
+            ElementKind kind = element.getKind();
+            if (kind != ElementKind.METHOD && kind != ElementKind.CLASS && kind != ElementKind.INTERFACE) {
+                messager.printMessage(Diagnostic.Kind.WARNING,
+                        "@RequiresRole on unsupported element kind " + kind + " — ignored", element);
+                continue;
+            }
+            AnnotationMirror mirror = findMirror(element);
+            if (mirror == null) {
+                continue;
+            }
+            List<String> roles = readStringArray(mirror, "value");
+            if (roles.isEmpty()) {
+                messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@RequiresRole.value() must declare at least one role", element);
+                continue;
+            }
+            boolean matchAll = "ALL".equals(readEnumValue(mirror, "match", "ANY"));
+            String methodKey = methodKey(element);
+            methods.add(new MethodDescriptor(methodKey, List.copyOf(roles), matchAll));
+            for (String role : roles) {
+                if (!SYSTEM_ROLE_BITS.containsKey(role)) {
+                    applicationRoleBits.computeIfAbsent(role, _ -> -1);
+                }
+            }
+        }
+    }
+
+    private static AnnotationMirror findMirror(Element element) {
+        for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
+            if (REQUIRES_ROLE_FQN.equals(mirror.getAnnotationType().toString())) {
+                return mirror;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> readStringArray(AnnotationMirror mirror, String name) {
+        AnnotationValue value = findValue(mirror, name);
+        if (value == null) {
+            return List.of();
+        }
+        @SuppressWarnings("unchecked")
+        List<? extends AnnotationValue> entries = (List<? extends AnnotationValue>) value.getValue();
+        List<String> out = new ArrayList<>(entries.size());
+        for (AnnotationValue entry : entries) {
+            out.add(entry.getValue().toString());
+        }
+        return out;
+    }
+
+    private static String readEnumValue(AnnotationMirror mirror, String name, String fallback) {
+        AnnotationValue value = findValue(mirror, name);
+        if (value == null) {
+            return fallback;
+        }
+        Object raw = value.getValue();
+        if (raw instanceof VariableElement enumConstant) {
+            return enumConstant.getSimpleName().toString();
+        }
+        return raw.toString();
+    }
+
+    private static AnnotationValue findValue(AnnotationMirror mirror, String name) {
+        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry
+                : mirror.getElementValues().entrySet()) {
+            if (entry.getKey().getSimpleName().contentEquals(name)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String methodKey(Element element) {
+        Element parent = element.getEnclosingElement();
+        String prefix = parent == null ? "" : parent + ".";
+        return prefix + element;
+    }
+
+    private void emit() throws IOException {
+        methods.sort((left, right) -> left.methodKey.compareTo(right.methodKey));
+        assignApplicationBits();
+        Filer filer = processingEnv.getFiler();
+        JavaFileObject source = filer.createSourceFile(GENERATED_CLASS_FQN);
+        try (PrintWriter writer = new PrintWriter(source.openWriter())) {
+            writeRegistry(writer);
+        }
+    }
+
+    private void assignApplicationBits() {
+        long nextBit = SYSTEM_ROLE_BIT_LIMIT;
+        for (Map.Entry<String, Integer> entry : applicationRoleBits.entrySet()) {
+            if (nextBit >= ROLE_MASK_WIDTH) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "@RequiresRole role budget exceeded (max " + ROLE_MASK_WIDTH
+                                + " roles per long mask). Offending role: " + entry.getKey());
+                return;
+            }
+            entry.setValue((int) nextBit);
+            nextBit++;
+        }
+    }
+
+    private long bitFor(String role) {
+        Integer system = SYSTEM_ROLE_BITS.get(role);
+        if (system != null) {
+            return 1L << system;
+        }
+        Integer app = applicationRoleBits.get(role);
+        return app == null ? 0L : 1L << app;
+    }
+
+    private long mask(List<String> roles) {
+        long mask = 0L;
+        for (String role : roles) {
+            mask |= bitFor(role);
+        }
+        return mask;
+    }
+
+    private void writeRegistry(PrintWriter writer) {
+        writer.println("// Generated by " + getClass().getName() + " — do not edit.");
+        writer.println("package " + GENERATED_PACKAGE + ";");
+        writer.println();
+        writer.println("public final class " + GENERATED_SIMPLE_NAME + " {");
+        writer.println();
+        writeMethodIdConstants(writer);
+        writer.println();
+        writeMaskArrays(writer);
+        writer.println();
+        writeRoleNameMap(writer);
+        writer.println();
+        writeAccessors(writer);
+        writer.println();
+        writer.println("    private " + GENERATED_SIMPLE_NAME + "() {");
+        writer.println("        // generated registry — not instantiable");
+        writer.println("    }");
+        writer.println("}");
+    }
+
+    private void writeMethodIdConstants(PrintWriter writer) {
+        for (int index = 0; index < methods.size(); index++) {
+            writer.println("    /** " + escapeJavadoc(methods.get(index).methodKey) + " */");
+            writer.println("    public static final int M_" + index + " = " + index + ";");
+        }
+    }
+
+    private void writeMaskArrays(PrintWriter writer) {
+        writer.println("    private static final long[] REQUIRED_ANY = {");
+        for (int index = 0; index < methods.size(); index++) {
+            MethodDescriptor descriptor = methods.get(index);
+            long mask = descriptor.matchAll ? 0L : mask(descriptor.roles);
+            writer.println("        " + maskLiteral(mask) + (index < methods.size() - 1 ? "," : ""));
+        }
+        writer.println("    };");
+        writer.println();
+        writer.println("    private static final long[] REQUIRED_ALL = {");
+        for (int index = 0; index < methods.size(); index++) {
+            MethodDescriptor descriptor = methods.get(index);
+            long mask = descriptor.matchAll ? mask(descriptor.roles) : 0L;
+            writer.println("        " + maskLiteral(mask) + (index < methods.size() - 1 ? "," : ""));
+        }
+        writer.println("    };");
+        writer.println();
+        writer.println("    private static final boolean[] MATCH_IS_ALL = {");
+        for (int index = 0; index < methods.size(); index++) {
+            writer.println("        " + methods.get(index).matchAll
+                    + (index < methods.size() - 1 ? "," : ""));
+        }
+        writer.println("    };");
+        writer.println();
+        writer.println("    private static final String[] METHOD_NAMES = {");
+        for (int index = 0; index < methods.size(); index++) {
+            writer.println("        \"" + escapeString(methods.get(index).methodKey) + "\""
+                    + (index < methods.size() - 1 ? "," : ""));
+        }
+        writer.println("    };");
+    }
+
+    private void writeRoleNameMap(PrintWriter writer) {
+        writer.println("    private static final java.util.Map<String, Integer> ROLE_BITS;");
+        writer.println("    static {");
+        writer.println("        java.util.HashMap<String, Integer> bits = new java.util.HashMap<>();");
+        for (Map.Entry<String, Integer> entry : new TreeMap<>(SYSTEM_ROLE_BITS).entrySet()) {
+            writer.println("        bits.put(\"" + escapeString(entry.getKey()) + "\", "
+                    + entry.getValue() + ");");
+        }
+        for (Map.Entry<String, Integer> entry : applicationRoleBits.entrySet()) {
+            writer.println("        bits.put(\"" + escapeString(entry.getKey()) + "\", "
+                    + entry.getValue() + ");");
+        }
+        writer.println("        ROLE_BITS = java.util.Map.copyOf(bits);");
+        writer.println("    }");
+    }
+
+    private void writeAccessors(PrintWriter writer) {
+        writer.println("    public static int methodCount() { return " + methods.size() + "; }");
+        writer.println("    public static long requiredAny(int methodId) { return REQUIRED_ANY[methodId]; }");
+        writer.println("    public static long requiredAll(int methodId) { return REQUIRED_ALL[methodId]; }");
+        writer.println("    public static boolean matchIsAll(int methodId) { return MATCH_IS_ALL[methodId]; }");
+        writer.println("    public static String methodName(int methodId) { return METHOD_NAMES[methodId]; }");
+        writer.println("    public static java.util.Set<String> roleNames() { return ROLE_BITS.keySet(); }");
+        writer.println("    public static int roleNameToBit(String role) {");
+        writer.println("        Integer bit = ROLE_BITS.get(role);");
+        writer.println("        return bit == null ? -1 : bit;");
+        writer.println("    }");
+    }
+
+    private static String maskLiteral(long mask) {
+        return "0x" + Long.toHexString(mask) + "L";
+    }
+
+    private static String escapeJavadoc(String value) {
+        return value.replace("*/", "* /");
+    }
+
+    private static String escapeString(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /**
+     * Snapshot of one annotated method's binding intent. Mutable list/key are
+     * enclosed by the processor instance — never escapes to caller-visible API.
+     */
+    private record MethodDescriptor(String methodKey, List<String> roles, boolean matchAll) {
+
+        @SuppressWarnings("unused") // ensures LinkedHashMap import is exercised in tests
+        Map<String, Object> debugView() {
+            Map<String, Object> view = new LinkedHashMap<>();
+            view.put("method", methodKey);
+            view.put("roles", roles);
+            view.put("matchAll", matchAll);
+            return view;
+        }
+    }
+}

--- a/exeris-kernel-build-config/src/main/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessor.java
+++ b/exeris-kernel-build-config/src/main/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessor.java
@@ -27,7 +27,6 @@ import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,7 +76,7 @@ import java.util.TreeMap;
  * {@code eu.exeris.kernel.spi.security.KernelRoles}.
  */
 @SupportedAnnotationTypes(RequiresRoleProcessor.REQUIRES_ROLE_FQN)
-@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedSourceVersion(SourceVersion.RELEASE_26)
 public final class RequiresRoleProcessor extends AbstractProcessor {
 
     /** Fully-qualified name of the SPI annotation processed by this implementation. */
@@ -92,6 +91,13 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
     private static final String GENERATED_PACKAGE = "eu.exeris.kernel.security.generated";
     private static final String GENERATED_SIMPLE_NAME = "RoleCheckRegistry";
     private static final long ROLE_MASK_WIDTH = 64L;
+
+    // Repeated literals extracted to keep generated source layout consistent and to
+    // satisfy SonarQube S1192 (duplicated literal warnings).
+    private static final String FOUR_SPACES = "    ";
+    private static final String EIGHT_SPACES = "        ";
+    private static final String CLOSE_BLOCK = FOUR_SPACES + "}";
+    private static final String CLOSE_ARRAY_LITERAL = FOUR_SPACES + "};";
 
     /**
      * Canonical kernel-owned role-name → bit-position mapping. Mirrors
@@ -120,46 +126,50 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
                 collect(roundEnv.getElementsAnnotatedWith(annotation));
             }
         }
-        if (!roundEnv.processingOver() || generated || methods.isEmpty()) {
-            return true;
+        if (roundEnv.processingOver() && !generated && !methods.isEmpty()) {
+            try {
+                emit();
+            } catch (IOException ex) {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "RequiresRoleProcessor: failed to write " + GENERATED_CLASS_FQN
+                                + " — " + ex.getMessage());
+            }
+            generated = true;
         }
-        try {
-            emit();
-        } catch (IOException ex) {
-            processingEnv.getMessager().printMessage(
-                    Diagnostic.Kind.ERROR,
-                    "RequiresRoleProcessor: failed to write " + GENERATED_CLASS_FQN + " — " + ex.getMessage());
-        }
-        generated = true;
         return true;
     }
 
     private void collect(Set<? extends Element> elements) {
-        Messager messager = processingEnv.getMessager();
         for (Element element : elements) {
-            ElementKind kind = element.getKind();
-            if (kind != ElementKind.METHOD && kind != ElementKind.CLASS && kind != ElementKind.INTERFACE) {
-                messager.printMessage(Diagnostic.Kind.WARNING,
-                        "@RequiresRole on unsupported element kind " + kind + " — ignored", element);
-                continue;
-            }
-            AnnotationMirror mirror = findMirror(element);
-            if (mirror == null) {
-                continue;
-            }
-            List<String> roles = readStringArray(mirror, "value");
-            if (roles.isEmpty()) {
-                messager.printMessage(Diagnostic.Kind.ERROR,
-                        "@RequiresRole.value() must declare at least one role", element);
-                continue;
-            }
-            boolean matchAll = "ALL".equals(readEnumValue(mirror, "match", "ANY"));
-            String methodKey = methodKey(element);
-            methods.add(new MethodDescriptor(methodKey, List.copyOf(roles), matchAll));
-            for (String role : roles) {
-                if (!SYSTEM_ROLE_BITS.containsKey(role)) {
-                    applicationRoleBits.computeIfAbsent(role, _ -> -1);
-                }
+            collectOne(element);
+        }
+    }
+
+    private void collectOne(Element element) {
+        Messager messager = processingEnv.getMessager();
+        ElementKind kind = element.getKind();
+        if (kind != ElementKind.METHOD && kind != ElementKind.CLASS && kind != ElementKind.INTERFACE) {
+            messager.printMessage(Diagnostic.Kind.WARNING,
+                    "@RequiresRole on unsupported element kind " + kind + " — ignored", element);
+            return;
+        }
+        AnnotationMirror mirror = findMirror(element);
+        if (mirror == null) {
+            return;
+        }
+        List<String> roles = readStringArray(mirror, "value");
+        if (roles.isEmpty()) {
+            messager.printMessage(Diagnostic.Kind.ERROR,
+                    "@RequiresRole.value() must declare at least one role", element);
+            return;
+        }
+        boolean matchAll = "ALL".equals(readEnumValue(mirror, "match", "ANY"));
+        String methodKey = methodKey(element);
+        methods.add(new MethodDescriptor(methodKey, List.copyOf(roles), matchAll));
+        for (String role : roles) {
+            if (!SYSTEM_ROLE_BITS.containsKey(role)) {
+                applicationRoleBits.putIfAbsent(role, -1);
             }
         }
     }
@@ -182,7 +192,10 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
         List<? extends AnnotationValue> entries = (List<? extends AnnotationValue>) value.getValue();
         List<String> out = new ArrayList<>(entries.size());
         for (AnnotationValue entry : entries) {
-            out.add(entry.getValue().toString());
+            Object raw = entry.getValue();
+            if (raw != null) {
+                out.add(raw.toString());
+            }
         }
         return out;
     }
@@ -193,6 +206,9 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
             return fallback;
         }
         Object raw = value.getValue();
+        if (raw == null) {
+            return fallback;
+        }
         if (raw instanceof VariableElement enumConstant) {
             return enumConstant.getSimpleName().toString();
         }
@@ -264,84 +280,104 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
         writer.println();
         writeMethodIdConstants(writer);
         writer.println();
-        writeMaskArrays(writer);
+        writeAnyMaskArray(writer);
+        writer.println();
+        writeAllMaskArray(writer);
+        writer.println();
+        writeMatchDiscriminatorArray(writer);
+        writer.println();
+        writeMethodNamesArray(writer);
         writer.println();
         writeRoleNameMap(writer);
         writer.println();
         writeAccessors(writer);
         writer.println();
-        writer.println("    private " + GENERATED_SIMPLE_NAME + "() {");
-        writer.println("        // generated registry — not instantiable");
-        writer.println("    }");
+        writer.println(FOUR_SPACES + "private " + GENERATED_SIMPLE_NAME + "() {");
+        writer.println(EIGHT_SPACES + "// generated registry — not instantiable");
+        writer.println(CLOSE_BLOCK);
         writer.println("}");
     }
 
     private void writeMethodIdConstants(PrintWriter writer) {
         for (int index = 0; index < methods.size(); index++) {
-            writer.println("    /** " + escapeJavadoc(methods.get(index).methodKey) + " */");
-            writer.println("    public static final int M_" + index + " = " + index + ";");
+            writer.println(FOUR_SPACES + "/** " + escapeJavadoc(methods.get(index).methodKey) + " */");
+            writer.println(FOUR_SPACES + "public static final int M_" + index + " = " + index + ";");
         }
     }
 
-    private void writeMaskArrays(PrintWriter writer) {
-        writer.println("    private static final long[] REQUIRED_ANY = {");
+    private void writeAnyMaskArray(PrintWriter writer) {
+        writer.println(FOUR_SPACES + "private static final long[] REQUIRED_ANY = {");
         for (int index = 0; index < methods.size(); index++) {
             MethodDescriptor descriptor = methods.get(index);
-            long mask = descriptor.matchAll ? 0L : mask(descriptor.roles);
-            writer.println("        " + maskLiteral(mask) + (index < methods.size() - 1 ? "," : ""));
+            long maskValue = descriptor.matchAll ? 0L : mask(descriptor.roles);
+            writer.println(EIGHT_SPACES + maskLiteral(maskValue) + entrySeparator(index));
         }
-        writer.println("    };");
-        writer.println();
-        writer.println("    private static final long[] REQUIRED_ALL = {");
+        writer.println(CLOSE_ARRAY_LITERAL);
+    }
+
+    private void writeAllMaskArray(PrintWriter writer) {
+        writer.println(FOUR_SPACES + "private static final long[] REQUIRED_ALL = {");
         for (int index = 0; index < methods.size(); index++) {
             MethodDescriptor descriptor = methods.get(index);
-            long mask = descriptor.matchAll ? mask(descriptor.roles) : 0L;
-            writer.println("        " + maskLiteral(mask) + (index < methods.size() - 1 ? "," : ""));
+            long maskValue = descriptor.matchAll ? mask(descriptor.roles) : 0L;
+            writer.println(EIGHT_SPACES + maskLiteral(maskValue) + entrySeparator(index));
         }
-        writer.println("    };");
-        writer.println();
-        writer.println("    private static final boolean[] MATCH_IS_ALL = {");
+        writer.println(CLOSE_ARRAY_LITERAL);
+    }
+
+    private void writeMatchDiscriminatorArray(PrintWriter writer) {
+        writer.println(FOUR_SPACES + "private static final boolean[] MATCH_IS_ALL = {");
         for (int index = 0; index < methods.size(); index++) {
-            writer.println("        " + methods.get(index).matchAll
-                    + (index < methods.size() - 1 ? "," : ""));
+            writer.println(EIGHT_SPACES + methods.get(index).matchAll + entrySeparator(index));
         }
-        writer.println("    };");
-        writer.println();
-        writer.println("    private static final String[] METHOD_NAMES = {");
+        writer.println(CLOSE_ARRAY_LITERAL);
+    }
+
+    private void writeMethodNamesArray(PrintWriter writer) {
+        writer.println(FOUR_SPACES + "private static final String[] METHOD_NAMES = {");
         for (int index = 0; index < methods.size(); index++) {
-            writer.println("        \"" + escapeString(methods.get(index).methodKey) + "\""
-                    + (index < methods.size() - 1 ? "," : ""));
+            writer.println(EIGHT_SPACES + "\"" + escapeString(methods.get(index).methodKey) + "\""
+                    + entrySeparator(index));
         }
-        writer.println("    };");
+        writer.println(CLOSE_ARRAY_LITERAL);
+    }
+
+    private String entrySeparator(int index) {
+        return index < methods.size() - 1 ? "," : "";
     }
 
     private void writeRoleNameMap(PrintWriter writer) {
-        writer.println("    private static final java.util.Map<String, Integer> ROLE_BITS;");
-        writer.println("    static {");
-        writer.println("        java.util.HashMap<String, Integer> bits = new java.util.HashMap<>();");
+        writer.println(FOUR_SPACES + "private static final java.util.Map<String, Integer> ROLE_BITS;");
+        writer.println(FOUR_SPACES + "static {");
+        writer.println(EIGHT_SPACES + "java.util.HashMap<String, Integer> bits = new java.util.HashMap<>();");
         for (Map.Entry<String, Integer> entry : new TreeMap<>(SYSTEM_ROLE_BITS).entrySet()) {
-            writer.println("        bits.put(\"" + escapeString(entry.getKey()) + "\", "
+            writer.println(EIGHT_SPACES + "bits.put(\"" + escapeString(entry.getKey()) + "\", "
                     + entry.getValue() + ");");
         }
         for (Map.Entry<String, Integer> entry : applicationRoleBits.entrySet()) {
-            writer.println("        bits.put(\"" + escapeString(entry.getKey()) + "\", "
+            writer.println(EIGHT_SPACES + "bits.put(\"" + escapeString(entry.getKey()) + "\", "
                     + entry.getValue() + ");");
         }
-        writer.println("        ROLE_BITS = java.util.Map.copyOf(bits);");
-        writer.println("    }");
+        writer.println(EIGHT_SPACES + "ROLE_BITS = java.util.Map.copyOf(bits);");
+        writer.println(CLOSE_BLOCK);
     }
 
     private void writeAccessors(PrintWriter writer) {
-        writer.println("    public static int methodCount() { return " + methods.size() + "; }");
-        writer.println("    public static long requiredAny(int methodId) { return REQUIRED_ANY[methodId]; }");
-        writer.println("    public static long requiredAll(int methodId) { return REQUIRED_ALL[methodId]; }");
-        writer.println("    public static boolean matchIsAll(int methodId) { return MATCH_IS_ALL[methodId]; }");
-        writer.println("    public static String methodName(int methodId) { return METHOD_NAMES[methodId]; }");
-        writer.println("    public static java.util.Set<String> roleNames() { return ROLE_BITS.keySet(); }");
-        writer.println("    public static int roleNameToBit(String role) {");
-        writer.println("        Integer bit = ROLE_BITS.get(role);");
-        writer.println("        return bit == null ? -1 : bit;");
-        writer.println("    }");
+        writer.println(FOUR_SPACES + "public static int methodCount() { return " + methods.size() + "; }");
+        writer.println(FOUR_SPACES + "public static long requiredAny(int methodId) "
+                + "{ return REQUIRED_ANY[methodId]; }");
+        writer.println(FOUR_SPACES + "public static long requiredAll(int methodId) "
+                + "{ return REQUIRED_ALL[methodId]; }");
+        writer.println(FOUR_SPACES + "public static boolean matchIsAll(int methodId) "
+                + "{ return MATCH_IS_ALL[methodId]; }");
+        writer.println(FOUR_SPACES + "public static String methodName(int methodId) "
+                + "{ return METHOD_NAMES[methodId]; }");
+        writer.println(FOUR_SPACES + "public static java.util.Set<String> roleNames() "
+                + "{ return ROLE_BITS.keySet(); }");
+        writer.println(FOUR_SPACES + "public static int roleNameToBit(String role) {");
+        writer.println(EIGHT_SPACES + "Integer bit = ROLE_BITS.get(role);");
+        writer.println(EIGHT_SPACES + "return bit == null ? -1 : bit;");
+        writer.println(CLOSE_BLOCK);
     }
 
     private static String maskLiteral(long mask) {
@@ -356,19 +392,6 @@ public final class RequiresRoleProcessor extends AbstractProcessor {
         return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
-    /**
-     * Snapshot of one annotated method's binding intent. Mutable list/key are
-     * enclosed by the processor instance — never escapes to caller-visible API.
-     */
-    private record MethodDescriptor(String methodKey, List<String> roles, boolean matchAll) {
-
-        @SuppressWarnings("unused") // ensures LinkedHashMap import is exercised in tests
-        Map<String, Object> debugView() {
-            Map<String, Object> view = new LinkedHashMap<>();
-            view.put("method", methodKey);
-            view.put("roles", roles);
-            view.put("matchAll", matchAll);
-            return view;
-        }
-    }
+    /** Snapshot of one annotated method's binding intent. */
+    private record MethodDescriptor(String methodKey, List<String> roles, boolean matchAll) { }
 }

--- a/exeris-kernel-build-config/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/exeris-kernel-build-config/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+eu.exeris.kernel.buildconfig.security.RequiresRoleProcessor

--- a/exeris-kernel-build-config/src/test/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessorTest.java
+++ b/exeris-kernel-build-config/src/test/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessorTest.java
@@ -157,12 +157,8 @@ class RequiresRoleProcessorTest {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertThat(compiler).as("system Java compiler must be available").isNotNull();
 
-        StandardJavaFileManager fileManager =
-                compiler.getStandardFileManager(null, null, java.nio.charset.StandardCharsets.UTF_8);
         Path classes = workDir.resolve("classes");
         Files.createDirectories(classes);
-        fileManager.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classes.toFile()));
-        fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, List.of(workDir.toFile()));
 
         List<JavaFileObject> units = sources.stream()
                 .map(InMemorySource::new)
@@ -170,17 +166,22 @@ class RequiresRoleProcessorTest {
                 .toList();
 
         StringBuilder diagnostics = new StringBuilder();
-        boolean ok = compiler.getTask(
-                null,
-                fileManager,
-                diagnostic -> diagnostics.append(diagnostic.getKind())
-                        .append(": ").append(diagnostic.getMessage(null)).append('\n'),
-                List.of("-proc:full", "--release", "26"),
-                null,
-                units
-        ).call();
+        boolean ok;
+        try (StandardJavaFileManager fileManager =
+                     compiler.getStandardFileManager(null, null, java.nio.charset.StandardCharsets.UTF_8)) {
+            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classes.toFile()));
+            fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, List.of(workDir.toFile()));
 
-        fileManager.close();
+            ok = compiler.getTask(
+                    null,
+                    fileManager,
+                    diagnostic -> diagnostics.append(diagnostic.getKind())
+                            .append(": ").append(diagnostic.getMessage(null)).append('\n'),
+                    List.of("-proc:full", "--release", "26"),
+                    null,
+                    units
+            ).call();
+        }
         return new ProcessorRun(ok, diagnostics.toString());
     }
 
@@ -200,11 +201,13 @@ class RequiresRoleProcessorTest {
             return content;
         }
 
+        private static final String URI_SEPARATOR = "/";
+
         private static String extractName(String source) {
             // Pull "package foo.bar; ... class|interface|@interface|enum Name" → foo/bar/Name
             String pkg = lineMatching(source, "package ");
             String pkgPath = pkg == null ? "" : pkg.substring("package ".length(), pkg.indexOf(';'))
-                    .trim().replace('.', '/') + "/";
+                    .trim().replace(".", URI_SEPARATOR) + URI_SEPARATOR;
             String typeLine = Stream.of("public class ", "class ", "interface ",
                             "public interface ", "public @interface ", "@interface ",
                             "public enum ", "enum ")

--- a/exeris-kernel-build-config/src/test/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessorTest.java
+++ b/exeris-kernel-build-config/src/test/java/eu/exeris/kernel/buildconfig/security/RequiresRoleProcessorTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.buildconfig.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compiles a small fixture source tree with the {@link RequiresRoleProcessor} on
+ * the annotation processor path and asserts the generated
+ * {@code RoleCheckRegistry} source carries the expected method-id, mask, and
+ * role-bit assignments.
+ *
+ * <p>The synthetic {@code RequiresRole} + {@code RoleMatch} sources live alongside
+ * the fixture so the test does not need a project-scope dependency on
+ * {@code exeris-kernel-spi} (that would create a reactor cycle —
+ * see {@code build-config/pom.xml}).
+ */
+@DisplayName("RequiresRoleProcessor")
+class RequiresRoleProcessorTest {
+
+    private static final String REQUIRES_ROLE_SOURCE = """
+            package eu.exeris.kernel.spi.security;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            @Retention(RetentionPolicy.SOURCE)
+            @Target({ElementType.METHOD, ElementType.TYPE})
+            public @interface RequiresRole {
+                String[] value();
+                RoleMatch match() default RoleMatch.ANY;
+            }
+            """;
+
+    private static final String ROLE_MATCH_SOURCE = """
+            package eu.exeris.kernel.spi.security;
+            public enum RoleMatch { ANY, ALL }
+            """;
+
+    @Test
+    @DisplayName("Generates RoleCheckRegistry with deterministic method IDs and ANY/ALL masks")
+    void generatesRegistry(@TempDir Path workDir) throws IOException {
+        String fixture = """
+                package fixtures;
+                import eu.exeris.kernel.spi.security.RequiresRole;
+                import eu.exeris.kernel.spi.security.RoleMatch;
+                public class AdminApi {
+                    @RequiresRole({"ROLE_ADMIN"})
+                    public void purgeCache() {}
+
+                    @RequiresRole(value = {"ROLE_ADMIN", "ROLE_AUDITOR"}, match = RoleMatch.ALL)
+                    public void replayLog() {}
+
+                    @RequiresRole({"ROLE_OPERATOR", "tenant.metrics.read"})
+                    public void readMetrics() {}
+                }
+                """;
+
+        compileWithProcessor(workDir, List.of(REQUIRES_ROLE_SOURCE, ROLE_MATCH_SOURCE, fixture));
+
+        Path registry = workDir.resolve(
+                "eu/exeris/kernel/security/generated/RoleCheckRegistry.java");
+        assertThat(registry).exists();
+        String content = Files.readString(registry);
+
+        // Method IDs are alphabetical by enclosing type + member, so:
+        //   M_0 = AdminApi.purgeCache(), M_1 = AdminApi.readMetrics(), M_2 = AdminApi.replayLog()
+        assertThat(content)
+                .contains("public static final int M_0 = 0;")
+                .contains("public static final int M_1 = 1;")
+                .contains("public static final int M_2 = 2;")
+                .contains("purgeCache()")
+                .contains("replayLog()")
+                .contains("readMetrics()");
+
+        // Bit assignments:
+        //   ROLE_ADMIN = bit 1 (system) → 0x2L
+        //   ROLE_OPERATOR = bit 2 (system) → 0x4L
+        //   tenant.metrics.read = bit 8 (first app role)  → 0x100L
+        //   ROLE_AUDITOR = bit 9 (second app role alphabetically after tenant.metrics.read?)
+        //     alphabetical sort over app roles: "ROLE_AUDITOR" < "tenant.metrics.read"
+        //     so ROLE_AUDITOR = bit 8, tenant.metrics.read = bit 9.
+        assertThat(content)
+                .contains("bits.put(\"ROLE_ADMIN\", 1)")
+                .contains("bits.put(\"ROLE_OPERATOR\", 2)")
+                .contains("bits.put(\"ROLE_AUDITOR\", 8)")
+                .contains("bits.put(\"tenant.metrics.read\", 9)");
+
+        // ANY mask for purgeCache (M_0) = ROLE_ADMIN bit 1 → 0x2L
+        // ALL mask for replayLog (M_2) = ROLE_ADMIN | ROLE_AUDITOR = 0x2L | 0x100L = 0x102L
+        // ANY mask for readMetrics (M_1) = ROLE_OPERATOR | tenant.metrics.read = 0x4L | 0x200L = 0x204L
+        assertThat(content)
+                .contains("MATCH_IS_ALL = {")
+                .contains("MATCH_IS_ALL")
+                .contains("0x2L")     // purgeCache ANY mask
+                .contains("0x204L")   // readMetrics ANY mask
+                .contains("0x102L");  // replayLog ALL mask
+    }
+
+    @Test
+    @DisplayName("Empty value() raises a compile error")
+    void emptyValueIsCompileError(@TempDir Path workDir) throws IOException {
+        String fixture = """
+                package fixtures;
+                import eu.exeris.kernel.spi.security.RequiresRole;
+                public class BadApi {
+                    @RequiresRole({})
+                    public void noRoles() {}
+                }
+                """;
+        ProcessorRun run = compileWithProcessor(workDir,
+                List.of(REQUIRES_ROLE_SOURCE, ROLE_MATCH_SOURCE, fixture));
+
+        assertThat(run.diagnostics)
+                .as("the processor must report an error for empty @RequiresRole.value()")
+                .contains("@RequiresRole.value() must declare at least one role");
+    }
+
+    @Test
+    @DisplayName("No @RequiresRole declarations produces no registry file")
+    void noAnnotationsProducesNoRegistry(@TempDir Path workDir) throws IOException {
+        String fixture = """
+                package fixtures;
+                public class Plain { public void hi() {} }
+                """;
+        compileWithProcessor(workDir, List.of(REQUIRES_ROLE_SOURCE, ROLE_MATCH_SOURCE, fixture));
+
+        Path registry = workDir.resolve(
+                "eu/exeris/kernel/security/generated/RoleCheckRegistry.java");
+        assertThat(registry).doesNotExist();
+    }
+
+    private static ProcessorRun compileWithProcessor(Path workDir, List<String> sources) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).as("system Java compiler must be available").isNotNull();
+
+        StandardJavaFileManager fileManager =
+                compiler.getStandardFileManager(null, null, java.nio.charset.StandardCharsets.UTF_8);
+        Path classes = workDir.resolve("classes");
+        Files.createDirectories(classes);
+        fileManager.setLocation(StandardLocation.CLASS_OUTPUT, List.of(classes.toFile()));
+        fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, List.of(workDir.toFile()));
+
+        List<JavaFileObject> units = sources.stream()
+                .map(InMemorySource::new)
+                .map(JavaFileObject.class::cast)
+                .toList();
+
+        StringBuilder diagnostics = new StringBuilder();
+        boolean ok = compiler.getTask(
+                null,
+                fileManager,
+                diagnostic -> diagnostics.append(diagnostic.getKind())
+                        .append(": ").append(diagnostic.getMessage(null)).append('\n'),
+                List.of("-proc:full", "--release", "26"),
+                null,
+                units
+        ).call();
+
+        fileManager.close();
+        return new ProcessorRun(ok, diagnostics.toString());
+    }
+
+    private record ProcessorRun(boolean ok, String diagnostics) { }
+
+    private static final class InMemorySource extends SimpleJavaFileObject {
+
+        private final String content;
+
+        InMemorySource(String content) {
+            super(URI.create("memory:///" + extractName(content) + ".java"), Kind.SOURCE);
+            this.content = content;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return content;
+        }
+
+        private static String extractName(String source) {
+            // Pull "package foo.bar; ... class|interface|@interface|enum Name" → foo/bar/Name
+            String pkg = lineMatching(source, "package ");
+            String pkgPath = pkg == null ? "" : pkg.substring("package ".length(), pkg.indexOf(';'))
+                    .trim().replace('.', '/') + "/";
+            String typeLine = Stream.of("public class ", "class ", "interface ",
+                            "public interface ", "public @interface ", "@interface ",
+                            "public enum ", "enum ")
+                    .map(prefix -> matchAfter(source, prefix))
+                    .filter(java.util.Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "fixture source missing top-level type declaration"));
+            return pkgPath + typeLine;
+        }
+
+        private static String matchAfter(String source, String prefix) {
+            int idx = source.indexOf(prefix);
+            if (idx < 0) {
+                return null;
+            }
+            int start = idx + prefix.length();
+            int end = start;
+            while (end < source.length()) {
+                char current = source.charAt(end);
+                if (Character.isJavaIdentifierPart(current)) {
+                    end++;
+                } else {
+                    break;
+                }
+            }
+            return source.substring(start, end);
+        }
+
+        private static String lineMatching(String source, String prefix) {
+            for (String line : source.split("\\R")) {
+                String trimmed = line.strip();
+                if (trimmed.startsWith(prefix)) {
+                    return trimmed;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the build-time annotation processor per **ADR-014 §3, §8**.
Sprint 8b is sliced: **8b-i = APT processor + tests (this PR)**, 8b-ii =
runtime admission hook + \`AbstractRequiresRoleTck\` + Community binding
(next PR).

Sprint 8 progress: 8a = SPI annotation surface (#99, merged),
**8b-i = APT processor (this PR)**, 8b-ii / 8c / 8d / 8e / 8f remaining.

## Reactor cycle constraint

\`build-config\` provides \`checkstyle.xml\` + \`pmd-ruleset.xml\` to every
other module via plugin classpath, which means a project-scope dependency
on SPI from build-config creates a Maven reactor cycle:
\`build-config → SPI → parent → build-config\`. The processor sidesteps
this by reading the annotation by FQN string
(\`eu.exeris.kernel.spi.security.RequiresRole\`) and not declaring any
project dependency on SPI types. System role bit assignments are
duplicated in the processor as constants — they MUST stay in sync with
\`KernelRoles\` (small invariant guarded by the existing \`KernelRolesTest\`).

## Generated artifact

For every \`@RequiresRole\`-annotated METHOD/TYPE in a compilation unit
the processor emits a single source file
\`eu.exeris.kernel.security.generated.RoleCheckRegistry\` containing only
primitive static fields:

| Field | Purpose |
|:--|:--|
| \`M_<n>\` | method id constants (alphabetical by FQN+member) |
| \`REQUIRED_ANY[]\` | per-method bitmask for \`RoleMatch.ANY\` checks |
| \`REQUIRED_ALL[]\` | per-method bitmask for \`RoleMatch.ALL\` checks |
| \`MATCH_IS_ALL[]\` | boolean discriminator picking ANY vs ALL at runtime |
| \`METHOD_NAMES[]\` | ordered FQN strings (diagnostics only, off hot path) |
| \`ROLE_BITS\` | \`Map<String,Integer>\` resolving role names to bit slots |

Determinism: method IDs are alphabetical by enclosing-type + member name;
application role names get bits \`[8, 64)\` alphabetically. System roles
keep their canonical \`KernelRoles\` bits \`[0, 8)\`.

## Tests (3 cases)

The processor tests use \`ToolProvider.getSystemJavaCompiler()\` and
synthesise the \`@RequiresRole\` + \`RoleMatch\` sources alongside fixtures
so the test suite needs no project-scope SPI dependency.

- **\`generatesRegistry\`** — compiles a fixture with \`ANY\` + \`ALL\` +
  a mix of system/application roles; asserts method-id alphabetical
  ordering (\`purgeCache\`, \`readMetrics\`, \`replayLog\`), bit assignments
  (\`ROLE_ADMIN=1\`, \`ROLE_OPERATOR=2\`, \`ROLE_AUDITOR=8\`,
  \`tenant.metrics.read=9\`), and resulting masks (\`ANY 0x2L / 0x204L\`,
  \`ALL 0x102L\`).
- **\`emptyValueIsCompileError\`** — \`@RequiresRole({})\` raises a clear
  processor error per ADR §6 (build-time errors over runtime warnings).
- **\`noAnnotationsProducesNoRegistry\`** — clean fixture leaves the
  registry source absent (processor is a no-op when nothing to bind).

## Docs

- \`docs/subsystems/security.md\` — status block updated: APT shipped in
  8b-i; runtime admission + \`LazyConstant\` loader + \`roleMask()\` carrier
  + \`AbstractRequiresRoleTck\` remain explicitly Sprint 8b-ii. The
  *@RequiresRole Processing* section now describes the processor's
  determinism rules and the no-SPI-dep design constraint.

## Quality gate

\`\`\`
mvn -pl exeris-kernel-build-config,exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify -DskipITs
→ all modules SUCCESS
→ 0 PMD/Checkstyle violations
→ 3 new processor tests green
\`\`\`

## Test plan

- [x] 3 \`RequiresRoleProcessorTest\` cases (deterministic registry, error
      diagnostic, no-op when no annotations).
- [x] No regressions in existing tests.
- [x] Full \`mvn verify\` on build-config + SPI + TCK + Core + Community.

## Out of scope (8b-ii)

- \`principal.roleMask(): long\` carrier on \`PrincipalContext\` +
  \`ImmutablePrincipal\`.
- \`RoleCheckEnforcer\` (Core) doing the bitmask AND/EQ on the hot path.
- \`LazyConstant<RoleCheckRegistry>\` loader binding the generated class.
- \`AbstractRequiresRoleTck\` + \`RequiresRoleZeroAllocTck\` + Community
  binding.
- Wiring the processor into kernel modules' \`annotationProcessorPaths\`
  so in-tree \`@RequiresRole\` declarations actually generate the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)