### PR TITLE
v0.7 Sprint 8b-ii: @RequiresRole runtime decision (ADR-014 §5–§6)

### DIFF
--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -2,8 +2,8 @@
 
 **Physical Layout:**
 
-- SPI: `eu.exeris.kernel.spi.security.*` (PrincipalContext, StorageContext, SecurityProvider, AuthenticationResult, ImmutablePrincipal, ImmutableStorageContext, KernelIsolationClaims, credentials/KernelPasswordEncoder, credentials/PasswordEncoderConfig, **`@RequiresRole` + `RoleMatch` + `KernelRoles`** since 0.7.0)
-  > **Note:** the `@RequiresRole` SPI annotation surface ships in 0.7.0 (Sprint 8a). The APT processor that generates `RoleCheckRegistry` and the runtime admission integration ship in Sprint 8b.
+- SPI: `eu.exeris.kernel.spi.security.*` (PrincipalContext, StorageContext, SecurityProvider, AuthenticationResult, ImmutablePrincipal, ImmutableStorageContext, KernelIsolationClaims, credentials/KernelPasswordEncoder, credentials/PasswordEncoderConfig, **`@RequiresRole` + `RoleMatch` + `KernelRoles` + `RoleRegistry` + `PrincipalContext.roleMask()`** since 0.7.0)
+  > **Note:** the SPI surface for compile-time RBAC ships in 0.7.0 — annotation + role-bit catalogue (Sprint 8a), `RoleRegistry` interface + `roleMask()` carrier (Sprint 8b-ii). The APT processor in `exeris-kernel-build-config` ships in Sprint 8b-i; the Core `RoleCheckEnforcer` runtime decision helper ships in Sprint 8b-ii. Wiring the generated registry into a `LazyConstant` bootstrap loader and auto-binding the enforcer into the transport admission path remain operator concerns until the auto-bind landing.
 - Community: `eu.exeris.kernel.community.security.*` (`CommunitySecurityProvider`, `Argon2idPasswordEncoder`, `CommunityJwksValidator`)
 - Core: `eu.exeris.kernel.core.security.*` (Token Extractors, ScopedValue Orchestration)
 
@@ -49,7 +49,7 @@ zero-leak, hyper-density concurrency with immutable identity at every layer. It 
 
 1. Define the `PrincipalContext` interface. Roles are open-form string constants, not a closed enum.
 2. Provide the `KernelProviders.PRINCIPAL_CONTEXT` and `KernelProviders.STORAGE_CONTEXT` ScopedValue slots.
-3. Expose the `@RequiresRole` annotation type, the `RoleMatch` enum, and the canonical `KernelRoles` system-role bit mapping for declarative RBAC (since 0.7.0). The annotation is `@Retention(SOURCE)` — consumed at compile time only by the APT processor (planned for Sprint 8b).
+3. Expose the `@RequiresRole` annotation type, the `RoleMatch` enum, the canonical `KernelRoles` system-role bit mapping (Sprint 8a), the read-only `RoleRegistry` runtime contract and the `PrincipalContext.roleMask()` carrier (Sprint 8b-ii) for declarative RBAC. The annotation is `@Retention(SOURCE)` — consumed at compile time only by the APT processor.
 
 **What Security Core DOES:**
 
@@ -190,13 +190,21 @@ token lifetime. The following contract governs token lifecycle in the Kernel:
 
 ## `@RequiresRole` Processing — No Reflection on Hot Path
 
-> **Status (0.7.0):** SPI annotation surface (`@RequiresRole`, `RoleMatch`, `KernelRoles`) is implemented
-> as of Sprint 8a. The APT processor (`eu.exeris.kernel.buildconfig.security.RequiresRoleProcessor`)
-> ships in Sprint 8b-i and emits `eu.exeris.kernel.security.generated.RoleCheckRegistry` at compile time.
-> The `LazyConstant<RoleCheckRegistry>` loader, the `principal.roleMask()` carrier, the runtime admission
-> hook, and the `AbstractRequiresRoleTck` ship in Sprint 8b-ii. Until then, `@RequiresRole` annotations
-> emit a generated registry but no runtime check consumes it — use `CitadelGuard.requireRole(...)` for
-> runtime checks.
+> **Status (0.7.0):**
+>
+> - SPI annotation surface (`@RequiresRole`, `RoleMatch`, `KernelRoles`) — Sprint 8a.
+> - APT processor (`eu.exeris.kernel.buildconfig.security.RequiresRoleProcessor`) emitting
+>   `eu.exeris.kernel.security.generated.RoleCheckRegistry` — Sprint 8b-i.
+> - SPI runtime carriers (`RoleRegistry` interface, `PrincipalContext.roleMask()` default) and
+>   the Core `RoleCheckEnforcer` decision helper plus `AbstractRequiresRoleTck` —
+>   Sprint 8b-ii.
+> - Operator-side wiring (load the generated registry through a `LazyConstant`, populate
+>   `principal.roleMask()` at authentication time via `registry.roleNameToBit(...)`, and call
+>   `RoleCheckEnforcer.check(methodId, principal, registry)` from the transport admission path)
+>   remains explicit until the auto-bind landing.
+>
+> Dynamic role decisions continue to use `CitadelGuard.requireRole(...)` — both paths emit
+> `EX-SEC-2003` so operators see uniform telemetry.
 
 ### SPI surface (since 0.7.0)
 
@@ -234,12 +242,34 @@ contract end-to-end.
 3. **No `Class.getAnnotation()` on hot path:** Zero reflection calls occur after JVM startup. The APT-generated
    registry is loaded once via `LazyConstant.of(...)` at first access.
 
-```
-Hot-path check (RoleMatch.ANY): (principal.roleMask() & registry.requiredMask(methodId)) != 0L
-Hot-path check (RoleMatch.ALL): (principal.roleMask() & registry.requiredMask(methodId)) == registry.requiredMask(methodId)
+```text
+Hot-path check (RoleMatch.ANY): (principal.roleMask() & registry.requiredAny(methodId)) != 0L
+Hot-path check (RoleMatch.ALL): (principal.roleMask() & registry.requiredAll(methodId)) == registry.requiredAll(methodId)
 ```
 
 If this check fails, `EX-SEC-2003` is thrown before any business logic executes.
+
+### Runtime decision (since 0.7.0, Sprint 8b-ii)
+
+`eu.exeris.kernel.core.security.RoleCheckEnforcer` is the canonical Core helper that
+performs the per-request RBAC decision. Both call sites are allocation-free on the
+accept path:
+
+```java
+// 1. Predicate form — useful for guard expressions
+boolean ok = RoleCheckEnforcer.isAllowed(methodId, principal, registry);
+
+// 2. Throwing form — used at admission boundaries (HTTP, command handlers, ...)
+RoleCheckEnforcer.check(methodId, principal, registry);
+// raises InsufficientPrivilegesException (EX-SEC-2003) on deny
+```
+
+`registry` is any `RoleRegistry` implementation — typically the generated
+`RoleCheckRegistry` adapted into the SPI interface, or any operator-supplied source.
+`principal.roleMask()` is the precomputed long that the authentication layer wires
+by translating the principal's claim role names through `registry.roleNameToBit(...)`.
+The TCK contract is pinned by `AbstractRequiresRoleTck`; the Community binding is
+`CommunityRequiresRoleTckTest` in `exeris-kernel-community`.
 
 ---
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRequiresRoleTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRequiresRoleTckTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.RoleCheckEnforcer;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import eu.exeris.kernel.tck.contract.security.AbstractRequiresRoleTck;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+
+@DisplayName("Community: @RequiresRole runtime TCK")
+class CommunityRequiresRoleTckTest extends AbstractRequiresRoleTck {
+
+    @Override
+    protected BiPredicate<Integer, PrincipalContext> isAllowed(RoleRegistry registry) {
+        return (methodId, principal) -> RoleCheckEnforcer.isAllowed(methodId, principal, registry);
+    }
+
+    @Override
+    protected BiConsumer<Integer, PrincipalContext> check(RoleRegistry registry) {
+        return (methodId, principal) -> RoleCheckEnforcer.check(methodId, principal, registry);
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RoleCheckEnforcer.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RoleCheckEnforcer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security;
+
+import eu.exeris.kernel.spi.exceptions.security.InsufficientPrivilegesException;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+
+/**
+ * Runtime decision helper for {@code @RequiresRole}-annotated entry points.
+ *
+ * <p>Per ADR-014 §5 the authorization decision is a single primitive
+ * AND/EQ between the principal's pre-computed {@code long} mask and the
+ * registry-supplied required mask:
+ *
+ * <pre>{@code
+ * RoleMatch.ANY  →  (principal.roleMask() & registry.requiredAny(methodId)) != 0L
+ * RoleMatch.ALL  →  (principal.roleMask() & registry.requiredAll(methodId)) == registry.requiredAll(methodId)
+ * }</pre>
+ *
+ * <p>The accept path is allocation-free. The deny path raises
+ * {@link InsufficientPrivilegesException} ({@code EX-SEC-2003}) with a
+ * synthetic role label so operators see the same telemetry shape as the
+ * existing dynamic {@code CitadelGuard.requireRole(...)} fallback.
+ *
+ * <h2>Wiring</h2>
+ * <p>The intended call sites are HTTP/transport admission interceptors that
+ * map a request entry point to a stable {@code methodId} (typically the
+ * compile-time constant emitted by the {@code RequiresRoleProcessor}). The
+ * registry instance is constructor-injected by the operator's bootstrap;
+ * tests inject a {@link RoleRegistry} stub.
+ *
+ * @since 0.7.0
+ */
+public final class RoleCheckEnforcer {
+
+    private RoleCheckEnforcer() {
+        // Static helper — not instantiable.
+    }
+
+    /**
+     * Returns {@code true} when the principal's mask satisfies the
+     * registry-declared requirement for {@code methodId}. Allocation-free.
+     *
+     * @param methodId  compile-time method id
+     * @param principal non-null principal context
+     * @param registry  non-null role registry
+     * @return {@code true} when the request is permitted
+     */
+    public static boolean isAllowed(int methodId, PrincipalContext principal, RoleRegistry registry) {
+        long principalMask = principal.roleMask();
+        if (registry.matchIsAll(methodId)) {
+            long required = registry.requiredAll(methodId);
+            return (principalMask & required) == required;
+        }
+        return (principalMask & registry.requiredAny(methodId)) != 0L;
+    }
+
+    /**
+     * Enforces the registered requirement; raises {@link InsufficientPrivilegesException}
+     * on deny.
+     *
+     * @param methodId  compile-time method id
+     * @param principal non-null principal context
+     * @param registry  non-null role registry
+     * @throws InsufficientPrivilegesException when the principal lacks the required role(s)
+     */
+    public static void check(int methodId, PrincipalContext principal, RoleRegistry registry) {
+        if (!isAllowed(methodId, principal, registry)) {
+            throw new InsufficientPrivilegesException(
+                    "@RequiresRole[methodId=" + methodId + "]");
+        }
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/PrincipalContext.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/PrincipalContext.java
@@ -208,6 +208,29 @@ public interface PrincipalContext {
         return owned.contains(role1) || owned.contains(role2) || owned.contains(role3);
     }
 
+    /**
+     * Pre-computed role bitmask aligned with the build-time role-bit assignment
+     * captured in the generated {@code RoleCheckRegistry} (see ADR-014 §3, §5).
+     *
+     * <p>The bitmask is the runtime carrier behind {@code @RequiresRole} checks
+     * — a {@code RoleCheckEnforcer} performs a single primitive AND/EQ between
+     * this value and the per-method required mask. Implementations populate the
+     * mask at authentication time by translating the principal's role names
+     * through {@code roleNameToBit(...)} on the registry.
+     *
+     * <p>Default returns {@code 0L} so existing principal implementations remain
+     * source-compatible. A {@code 0L} mask makes every {@code @RequiresRole}
+     * check on a non-empty required mask deny, which is the correct fail-closed
+     * default.
+     *
+     * @return packed role bitmask; {@code 0L} when the principal has no
+     *         registry-resolved roles
+     * @since 0.7.0
+     */
+    default long roleMask() {
+        return 0L;
+    }
+
     // =====================================================================
     // Scopes — "What can this token do?"
     // =====================================================================

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RoleRegistry.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/RoleRegistry.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.security;
+
+/**
+ * Read-only SPI contract over a build-time role-check registry per ADR-014 §3.
+ *
+ * <h2>Why an interface</h2>
+ * <p>The canonical implementation is the generated
+ * {@code eu.exeris.kernel.security.generated.RoleCheckRegistry} class produced
+ * by the {@code RequiresRoleProcessor}. That class is intentionally final with
+ * static accessors so its hot-path lookups inline. This interface adapts those
+ * static accessors into an injectable contract that {@code RoleCheckEnforcer},
+ * test harnesses, and operator-supplied registry sources can all share.
+ *
+ * <h2>Hot-path discipline</h2>
+ * <p>Implementations MUST satisfy:
+ * <ul>
+ *   <li>{@link #requiredAny(int)} / {@link #requiredAll(int)} — O(1), allocation-free.</li>
+ *   <li>{@link #matchIsAll(int)} — O(1), allocation-free.</li>
+ *   <li>{@link #methodCount()} — O(1).</li>
+ *   <li>{@link #roleNameToBit(String)} — O(1) average; called at authentication
+ *       time, never on the per-request hot path.</li>
+ * </ul>
+ *
+ * @since 0.7.0
+ */
+public interface RoleRegistry {
+
+    /**
+     * Returns the {@code RoleMatch.ANY}-shaped required bitmask for the given
+     * method id, or {@code 0L} if the method is annotated with
+     * {@code RoleMatch.ALL}.
+     *
+     * @param methodId compile-time method id from the generated registry
+     * @return required {@code ANY} mask
+     */
+    long requiredAny(int methodId);
+
+    /**
+     * Returns the {@code RoleMatch.ALL}-shaped required bitmask for the given
+     * method id, or {@code 0L} if the method is annotated with
+     * {@code RoleMatch.ANY}.
+     *
+     * @param methodId compile-time method id from the generated registry
+     * @return required {@code ALL} mask
+     */
+    long requiredAll(int methodId);
+
+    /**
+     * @param methodId compile-time method id from the generated registry
+     * @return {@code true} when the method declared {@code RoleMatch.ALL}
+     */
+    boolean matchIsAll(int methodId);
+
+    /**
+     * @return number of {@code @RequiresRole}-annotated entry points compiled
+     *         into the registry
+     */
+    int methodCount();
+
+    /**
+     * Resolves a role name to its compile-time bit position. Returns {@code -1}
+     * when the role is unknown so callers fail closed.
+     *
+     * @param roleName non-null role name
+     * @return bit position {@code [0, 64)} or {@code -1}
+     */
+    int roleNameToBit(String roleName);
+
+    /**
+     * Convenience: returns a single-bit mask for {@code roleName} or {@code 0L}
+     * when the role is unknown to this registry.
+     *
+     * @param roleName non-null role name
+     * @return single-bit mask, or {@code 0L}
+     */
+    default long roleNameToMask(String roleName) {
+        int bit = roleNameToBit(roleName);
+        return bit < 0 ? 0L : 1L << bit;
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRequiresRoleTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRequiresRoleTck.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.security;
+
+import eu.exeris.kernel.spi.exceptions.KernelErrorCodes;
+import eu.exeris.kernel.spi.exceptions.security.InsufficientPrivilegesException;
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: runtime contract for {@code @RequiresRole} enforcement (ADR-014 §5–§6).
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@code RoleMatch.ANY} accepts when the principal mask intersects the
+ *       required mask, otherwise raises {@code EX-SEC-2003}.</li>
+ *   <li>{@code RoleMatch.ALL} accepts only when the principal mask covers
+ *       every bit in the required mask.</li>
+ *   <li>A principal with the default {@code roleMask() = 0L} is denied for
+ *       any non-empty required mask (fail-closed default).</li>
+ *   <li>Denial raises {@link InsufficientPrivilegesException} with
+ *       {@code errorCode = EX-SEC-2003}.</li>
+ *   <li>Accept path performs no allocation beyond what the registry
+ *       implementation does for its lookup methods (verified separately by
+ *       a per-binding zero-alloc test).</li>
+ * </ul>
+ *
+ * <h2>How to use</h2>
+ * <pre>{@code
+ * class CommunityRequiresRoleTckTest extends AbstractRequiresRoleTck {
+ *     @Override
+ *     protected BiFunction<Integer, PrincipalContext, Boolean> isAllowed(RoleRegistry registry) {
+ *         return (methodId, principal) -> RoleCheckEnforcer.isAllowed(methodId, principal, registry);
+ *     }
+ *
+ *     @Override
+ *     protected BiConsumer<Integer, PrincipalContext> check(RoleRegistry registry) {
+ *         return (methodId, principal) -> RoleCheckEnforcer.check(methodId, principal, registry);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>The abstract drives the enforcer with a stub {@link RoleRegistry}; bindings
+ * supply the enforcer factory.
+ *
+ * @since 0.7.0
+ */
+public abstract class AbstractRequiresRoleTck {
+
+    /** Method id used for ANY-match scenarios. */
+    protected static final int METHOD_ANY = 0;
+
+    /** Method id used for ALL-match scenarios. */
+    protected static final int METHOD_ALL = 1;
+
+    /** Bit position assigned to {@code ROLE_ADMIN} in the stub registry. */
+    protected static final int BIT_ADMIN = 1;
+
+    /** Bit position assigned to {@code ROLE_AUDITOR} in the stub registry. */
+    protected static final int BIT_AUDITOR = 8;
+
+    /**
+     * Returns a function that delegates to the binding's allocation-free
+     * decision routine.
+     *
+     * @param registry registry supplied by the abstract; binding must read it
+     * @return non-null predicate {@code (methodId, principal) → allowed}
+     */
+    protected abstract java.util.function.BiPredicate<Integer, PrincipalContext> isAllowed(RoleRegistry registry);
+
+    /**
+     * Returns a consumer that delegates to the binding's deny-path enforcer.
+     * On deny the consumer MUST throw {@link InsufficientPrivilegesException}.
+     *
+     * @param registry registry supplied by the abstract; binding must read it
+     * @return non-null consumer {@code (methodId, principal) → void}
+     */
+    protected abstract java.util.function.BiConsumer<Integer, PrincipalContext> check(RoleRegistry registry);
+
+    @Test
+    @DisplayName("ANY-match accepts a principal whose mask intersects the required set")
+    void anyMatchAccepts() {
+        RoleRegistry registry = new StubRegistry();
+        PrincipalContext principal = principalWithMask(1L << BIT_ADMIN);
+
+        assertThat(isAllowed(registry).test(METHOD_ANY, principal)).isTrue();
+    }
+
+    @Test
+    @DisplayName("ANY-match denies a principal whose mask is empty")
+    void anyMatchDeniesEmptyMask() {
+        RoleRegistry registry = new StubRegistry();
+        PrincipalContext principal = principalWithMask(0L);
+
+        assertThat(isAllowed(registry).test(METHOD_ANY, principal)).isFalse();
+    }
+
+    @Test
+    @DisplayName("ANY-match denies a principal whose mask hits other bits only")
+    void anyMatchDeniesUnrelatedMask() {
+        RoleRegistry registry = new StubRegistry();
+        // bit 9 is not part of the ANY required mask {ADMIN(1), AUDITOR(8)}.
+        PrincipalContext principal = principalWithMask(1L << 9);
+
+        assertThat(isAllowed(registry).test(METHOD_ANY, principal)).isFalse();
+    }
+
+    @Test
+    @DisplayName("ALL-match accepts only when every required bit is set")
+    void allMatchRequiresEveryBit() {
+        RoleRegistry registry = new StubRegistry();
+        PrincipalContext bothRoles = principalWithMask((1L << BIT_ADMIN) | (1L << BIT_AUDITOR));
+        PrincipalContext adminOnly = principalWithMask(1L << BIT_ADMIN);
+
+        assertThat(isAllowed(registry).test(METHOD_ALL, bothRoles)).isTrue();
+        assertThat(isAllowed(registry).test(METHOD_ALL, adminOnly)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Default principal (roleMask() returns 0L) fails closed")
+    void defaultPrincipalFailsClosed() {
+        RoleRegistry registry = new StubRegistry();
+        PrincipalContext defaultPrincipal = ImmutablePrincipal.system(
+                UUID.randomUUID(),
+                Set.of("ROLE_ADMIN")); // role names present but no roleMask override
+
+        assertThat(defaultPrincipal.roleMask())
+                .as("ImmutablePrincipal must keep the SPI default of 0L until callers explicitly populate it")
+                .isZero();
+        assertThat(isAllowed(registry).test(METHOD_ANY, defaultPrincipal)).isFalse();
+        assertThatThrownBy(() -> check(registry).accept(METHOD_ANY, defaultPrincipal))
+                .isInstanceOf(InsufficientPrivilegesException.class)
+                .extracting(thrown -> ((InsufficientPrivilegesException) thrown).errorCode())
+                .isEqualTo(KernelErrorCodes.EX_SEC_2003);
+    }
+
+    @Test
+    @DisplayName("check() raises EX-SEC-2003 on deny and returns silently on accept")
+    void checkRaisesOnDenyAndReturnsSilentlyOnAccept() {
+        RoleRegistry registry = new StubRegistry();
+        PrincipalContext admin = principalWithMask(1L << BIT_ADMIN);
+
+        check(registry).accept(METHOD_ANY, admin);   // accept — must not throw
+
+        assertThatThrownBy(() -> check(registry).accept(METHOD_ALL, admin))
+                .isInstanceOf(InsufficientPrivilegesException.class)
+                .satisfies(thrown -> assertThat(((InsufficientPrivilegesException) thrown).errorCode())
+                        .isEqualTo(KernelErrorCodes.EX_SEC_2003))
+                .satisfies(thrown -> {
+                    Object[] rawArgs = ((InsufficientPrivilegesException) thrown).rawArgs();
+                    assertThat(rawArgs)
+                            .as("rawArgs[0] must carry the method-id label for telemetry correlation")
+                            .hasSize(1);
+                    assertThat(rawArgs[0])
+                            .asString()
+                            .contains("methodId=" + METHOD_ALL);
+                });
+    }
+
+    @Test
+    @DisplayName("roleNameToBit is consulted when populating the principal mask at auth time")
+    void roleNameToBitResolves() {
+        RoleRegistry registry = new StubRegistry();
+
+        assertThat(registry.roleNameToBit("ROLE_ADMIN")).isEqualTo(BIT_ADMIN);
+        assertThat(registry.roleNameToBit("ROLE_AUDITOR")).isEqualTo(BIT_AUDITOR);
+        assertThat(registry.roleNameToBit("ROLE_GHOST"))
+                .as("unknown roles must surface as -1 so callers can fail closed")
+                .isEqualTo(-1);
+        assertThat(registry.roleNameToMask("ROLE_ADMIN")).isEqualTo(1L << BIT_ADMIN);
+        assertThat(registry.roleNameToMask("ROLE_GHOST")).isZero();
+    }
+
+    private static PrincipalContext principalWithMask(long mask) {
+        return new MaskedPrincipal(mask);
+    }
+
+    /**
+     * Stub registry mirroring the shape that {@code RoleCheckRegistry} would
+     * expose for two methods: {@code METHOD_ANY} requires {@code ANY} of
+     * {@code ROLE_ADMIN(1)} or {@code ROLE_AUDITOR(8)}; {@code METHOD_ALL}
+     * requires {@code ALL} of the same two.
+     */
+    protected static final class StubRegistry implements RoleRegistry {
+
+        private static final long REQUIRED = (1L << BIT_ADMIN) | (1L << BIT_AUDITOR);
+
+        @Override
+        public long requiredAny(int methodId) {
+            return methodId == METHOD_ANY ? REQUIRED : 0L;
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            return methodId == METHOD_ALL ? REQUIRED : 0L;
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            return methodId == METHOD_ALL;
+        }
+
+        @Override
+        public int methodCount() {
+            return 2;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            return switch (roleName) {
+                case "ROLE_ADMIN" -> BIT_ADMIN;
+                case "ROLE_AUDITOR" -> BIT_AUDITOR;
+                case null, default -> -1;
+            };
+        }
+    }
+
+    /**
+     * Minimal {@link PrincipalContext} carrying only a precomputed role mask —
+     * the shape an authentication layer wires after resolving claim role names
+     * through the registry.
+     */
+    private record MaskedPrincipal(long maskValue) implements PrincipalContext {
+        @Override
+        public UUID principalId() {
+            return new UUID(0L, 0L);
+        }
+
+        @Override
+        public java.util.Optional<UUID> tenantId() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public Set<String> roles() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> scopes() {
+            return Set.of();
+        }
+
+        @Override
+        public long roleMask() {
+            return maskValue;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the runtime side of compile-time RBAC per **ADR-014 §5–§6**.
With this PR the \`@RequiresRole\` pipeline is **end-to-end usable**:

- 8a: SPI annotation surface (#99, merged)
- 8b-i: APT processor emitting \`RoleCheckRegistry\` (#100, merged)
- **8b-ii: SPI runtime carriers + Core enforcer + TCK (this PR)**

Sprint 8 progress: 8a/8b-i/**8b-ii** closed; 8c/8d/8e/8f remaining.

## Added (SPI)

- **\`PrincipalContext.roleMask()\`** — default returning \`0L\`.
  Implementations populate the precomputed long mask at authentication time
  by translating claim role names through \`RoleRegistry.roleNameToBit()\`.
  Default \`0L\` keeps existing principal implementations source-compatible
  AND fail-closed against any non-empty required mask.
- **\`RoleRegistry\`** — read-only contract over a build-time role-check
  registry: \`requiredAny\` / \`requiredAll\` / \`matchIsAll\` / \`methodCount\`
  / \`roleNameToBit\` plus a default \`roleNameToMask\` convenience.
  Implementations: the generated \`RoleCheckRegistry\` (adapted), test stubs,
  operator-supplied sources.

## Added (Core)

- **\`RoleCheckEnforcer\`** — static helper performing the bitmask AND/EQ
  per ADR-014 §5:

  \`\`\`java
  // Predicate form — guard expressions
  boolean ok = RoleCheckEnforcer.isAllowed(methodId, principal, registry);

  // Throwing form — admission boundaries
  RoleCheckEnforcer.check(methodId, principal, registry);
  // raises InsufficientPrivilegesException (EX-SEC-2003) on deny
  \`\`\`

  \`isAllowed\` is allocation-free. \`check\` raises with
  \`rawArgs[0] = \"@RequiresRole[methodId=<n>]\"\` so operators see uniform
  \`EX-SEC-2003\` telemetry across both the static and the dynamic
  \`CitadelGuard\` fallback path.

## Added (TCK)

- **\`AbstractRequiresRoleTck\`** — 7 contract tests driven by a stub
  \`RoleRegistry\` exposing two methods (\`METHOD_ANY\` needs ANY of
  bits \`1|8\`; \`METHOD_ALL\` needs ALL):
  1. ANY-match accepts on intersection
  2. ANY-match denies an empty mask
  3. ANY-match denies an unrelated mask
  4. ALL-match requires every bit
  5. Default principal (\`roleMask()=0L\`) fails closed
  6. \`check()\` raises \`EX-SEC-2003\` on deny with method-id rawArgs label
  7. \`roleNameToBit\` / \`roleNameToMask\` resolution + unknown → \`-1\`

  Bindings supply two \`BiPredicate\` / \`BiConsumer\` factories so the
  abstract stays binding-agnostic.

- **\`CommunityRequiresRoleTckTest\`** — binds the abstract against
  \`RoleCheckEnforcer\`.

## Docs

- \`docs/subsystems/security.md\`:
  - Physical Layout SPI line lists \`RoleRegistry\` + \`roleMask()\`
    additions; status block converted to a list reflecting the
    8a/8b-i/8b-ii split.
  - *What Security SPI DOES* item #3 expanded to mention the runtime
    carriers shipped in 8b-ii.
  - *@RequiresRole Processing* section: hot-path check formula
    corrected (\`requiredAny\`/\`requiredAll\` accessors); new
    *Runtime decision* subsection with the predicate vs throwing
    call-site forms and the TCK obligation reference.

## Quality gate

\`\`\`
mvn -pl exeris-kernel-build-config,exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify -DskipITs
→ all modules SUCCESS
→ 0 PMD/Checkstyle violations
→ 7 new TCK tests green via CommunityRequiresRoleTckTest
\`\`\`

## Test plan

- [x] 7 \`AbstractRequiresRoleTck\` cases via Community binding.
- [x] No regressions in existing security tests (CitadelGuard, StorageContextBridge etc.).
- [x] Full \`mvn verify\` on build-config + SPI + TCK + Core + Community.

## Out of scope (operator wiring)

- **\`LazyConstant<RoleCheckRegistry>\` bootstrap loader** binding the
  generated class. Operators who use \`@RequiresRole\` today provide the
  registry via constructor injection; auto-bind is an enhancement tied to
  the transport admission interceptor.
- **Auto-wiring \`RequiresRoleProcessor\`** into kernel modules'
  \`annotationProcessorPaths\`. No in-tree \`@RequiresRole\` declarations
  exist yet, so generation has nothing to scan; wiring is a one-line BOM
  change once the first call site lands.
- **\`ImmutablePrincipal.roleMask()\` integration** (would be a record
  canonical-constructor change). Application layers wire their own
  \`MaskedPrincipal\` as needed; existing \`ADR-010\` / \`ADR-012\`
  \`PrincipalContext\` contract is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)