### PR TITLE
v0.7 Sprint 8b-ii: PR #102 review fixup (Javadoc + zero-alloc guard)

### DIFF
--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRequiresRoleZeroAllocTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRequiresRoleZeroAllocTckTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.RoleCheckEnforcer;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import eu.exeris.kernel.tck.contract.AbstractSubsystemZeroAllocTck;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Community zero-allocation guard for the {@code @RequiresRole} accept path
+ * (ADR-014 §5; reviewer finding on PR #102).
+ *
+ * <h2>What this proves</h2>
+ * <p>{@link RoleCheckEnforcer#isAllowed(int, PrincipalContext, RoleRegistry)}
+ * is a pure primitive {@code AND}/{@code EQ} dance over a {@code long} mask
+ * and the registry's primitive lookups. The accept path MUST therefore emit
+ * zero {@code eu.exeris.*} heap allocations across {@code hotPathIterations()}
+ * invocations under JFR observation
+ * ({@code jdk.ObjectAllocationInNewTLAB} +
+ * {@code jdk.ObjectAllocationOutsideTLAB} +
+ * {@code jdk.ObjectAllocationSample}).
+ *
+ * <h2>Hot-path call shape</h2>
+ * <p>The iteration calls the enforcer with a {@code int} literal for the
+ * method id — {@link #METHOD_ID} is a {@code static final int} constant —
+ * which avoids the {@link Integer} autoboxing that {@code BiPredicate.test}
+ * would force. The principal's {@code roleMask()} returns a primitive long
+ * directly from a record field; the stub registry returns primitive longs
+ * and a primitive boolean from constant-time switches.
+ *
+ * <h2>Tier expectation</h2>
+ * <p>{@link #supportsZeroGcHotPath()} returns {@code true}: this is a Core
+ * helper, not an SPI gateway, and the contract is "no allocation, full
+ * stop." Failure of this test means a regression introduced autoboxing,
+ * captured-lambda creation, or an allocating registry path.
+ *
+ * @since 0.7.0
+ */
+@DisplayName("Community: @RequiresRole zero-alloc TCK")
+class CommunityRequiresRoleZeroAllocTckTest extends AbstractSubsystemZeroAllocTck {
+
+    private static final int METHOD_ID = 0;
+    private static final int BIT_ADMIN = 1;
+
+    private RoleRegistry registry;
+    private PrincipalContext principal;
+
+    @Override
+    protected String subsystemName() {
+        return "Security";
+    }
+
+    @Override
+    protected String hotPathDescription() {
+        return "RoleCheckEnforcer.isAllowed(methodId, principal, registry) — accept path";
+    }
+
+    @Override
+    protected boolean supportsZeroGcHotPath() {
+        return true;
+    }
+
+    @Override
+    protected void bootstrapSubsystem() {
+        registry = new ZeroAllocStubRegistry();
+        principal = new MaskedPrincipal(1L << BIT_ADMIN);
+    }
+
+    @Override
+    protected void runSingleIteration() {
+        boolean allowed = RoleCheckEnforcer.isAllowed(METHOD_ID, principal, registry);
+        if (!allowed) {
+            throw new AssertionError("accept path must allow — stub mis-wired");
+        }
+    }
+
+    @Override
+    protected void tearDownSubsystem() {
+        // No resources to release — registry and principal are GC-managed records.
+    }
+
+    /**
+     * Stub registry whose lookups are constant-time and allocation-free:
+     * primitive {@code int} in, primitive {@code long}/{@code boolean} out.
+     */
+    private static final class ZeroAllocStubRegistry implements RoleRegistry {
+
+        private static final long REQUIRED = 1L << BIT_ADMIN;
+
+        @Override
+        public long requiredAny(int methodId) {
+            return REQUIRED;
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            return false;
+        }
+
+        @Override
+        public int methodCount() {
+            return 1;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            return "ROLE_ADMIN".equals(roleName) ? BIT_ADMIN : -1;
+        }
+    }
+
+    /**
+     * Minimal {@link PrincipalContext} carrying a precomputed role mask —
+     * the same shape an authentication layer wires after resolving claim
+     * role names through the registry. Backed by a record so the {@code long}
+     * field is read directly via field access, no boxing, no virtual call
+     * beyond the interface dispatch.
+     */
+    private record MaskedPrincipal(long maskValue) implements PrincipalContext {
+        @Override
+        public UUID principalId() {
+            return new UUID(0L, 0L);
+        }
+
+        @Override
+        public java.util.Optional<UUID> tenantId() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public Set<String> roles() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> scopes() {
+            return Set.of();
+        }
+
+        @Override
+        public long roleMask() {
+            return maskValue;
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRequiresRoleTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRequiresRoleTck.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <pre>{@code
  * class CommunityRequiresRoleTckTest extends AbstractRequiresRoleTck {
  *     @Override
- *     protected BiFunction<Integer, PrincipalContext, Boolean> isAllowed(RoleRegistry registry) {
+ *     protected BiPredicate<Integer, PrincipalContext> isAllowed(RoleRegistry registry) {
  *         return (methodId, principal) -> RoleCheckEnforcer.isAllowed(methodId, principal, registry);
  *     }
  *


### PR DESCRIPTION
## Summary

Post-merge follow-up to #102 — PR #102 was merged before the reviewer feedback push landed, so the two findings ship as a separate small PR.

- **[CONTRACT]** `AbstractRequiresRoleTck` "How to use" snippet declared `BiFunction<Integer, PrincipalContext, Boolean>` while the abstract method actually returns `BiPredicate<Integer, PrincipalContext>`. Aligned the snippet with the real signature so copy-paste compiles.
- **[TCK DEBT]** Delivered the per-binding zero-alloc guard that `AbstractRequiresRoleTck` line 38–40 promises: `CommunityRequiresRoleZeroAllocTckTest` runs `RoleCheckEnforcer.isAllowed(int, principal, registry)` under `jdk.ObjectAllocationInNewTLAB` + `OutsideTLAB` + `Sample` and asserts zero `eu.exeris.*` allocations. Reuses the standard `AbstractSubsystemZeroAllocTck` three-phase protocol; bootstrap creates the stub registry + masked principal before the recording, the hot loop calls the static int-arg overload directly so no `Integer` autoboxing leaks in.

## Test plan

- [x] `mvn -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify` → 1063 tests SUCCESS, 0 PMD/Checkstyle violations
- [x] `CommunityRequiresRoleZeroAllocTckTest` — 1 test, 0.033s, allocation count 0 against `eu.exeris.*` filter
- [x] `CommunityRequiresRoleTckTest` — 7 contract tests still green after Javadoc edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)