### PR TITLE
v0.7 Sprint 8d: QA-008 CypherHelper decomposition + QA-009 partial

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherHelper.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherHelper.java
@@ -8,7 +8,6 @@
  */
 package eu.exeris.kernel.community.graph;
 
-import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.exceptions.graph.GraphQueryException;
 import eu.exeris.kernel.spi.graph.model.GraphEdgeDescriptor;
 import eu.exeris.kernel.spi.graph.model.GraphTraversal;
@@ -16,197 +15,97 @@ import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
-import org.neo4j.driver.Value;
 
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
-// Backend adapter intentionally mirrors the GraphSession surface for the Cypher dialect.
-// GodClass: adapter must implement the complete CommunityGraphBackend interface — all Cypher
-// read/write operations share one session boundary; extraction would break transactional cohesion.
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.CyclomaticComplexity", "PMD.GodClass"})
-final class CommunityGraphCypherHelper implements CommunityGraphBackend {
+/**
+ * Cypher backend orchestrator (QA-008). Owns the Neo4j session/transaction lifecycle and
+ * dispatches every {@link CommunityGraphBackend} call to a {@link CommunityGraphCypherReader}
+ * (read-only) or a {@link CommunityGraphCypherWriter} (mutations). The reader and writer
+ * share this orchestrator as their {@link CypherExecutor}, so transactional cohesion is
+ * preserved across reads and writes against a single session.
+ *
+ * @since 0.7.0
+ */
+// CommunityGraphBackend is wide; orchestrator implements every method via delegation
+// to Reader/Writer or via direct transaction-lifecycle handling, so the per-method
+// branching is uniformly small (highest method CC = 5) but accumulates across the
+// 13-method backend surface.
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.CyclomaticComplexity"})
+final class CommunityGraphCypherHelper implements CommunityGraphBackend, CypherExecutor {
+
     private static final String PMD_AVOID_CATCHING_GENERIC_EXCEPTION = "PMD.AvoidCatchingGenericException";
     private static final String CYPHER_BACKEND_QUERY_TYPE = "CYPHER_BACKEND";
-    private static final String CYPHER_IDENTIFIER_QUERY_TYPE = "CYPHER_IDENTIFIER";
-    private static final String CYPHER_EXECUTION_DETAIL = "Failed to execute Cypher operation";
-    private static final String ROOT_NODE_QUERY_TYPE = "ROOT_NODE";
-    private static final String PARAM_SOURCE_ID = "sourceId";
-    private static final String PARAM_TARGET_ID = "targetId";
-    private static final String PARAM_PROPERTIES = "properties";
-    private static final Pattern CYPHER_IDENTIFIER_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
 
-    private final CommunityGraphDialect dialect;
     private final CommunityNeo4jClient neo4jClient;
+    private final CommunityGraphCypherReader reader;
+    private final CommunityGraphCypherWriter writer;
     private Session cypherSession;
     private Transaction cypherTransaction;
 
     /* default */ CommunityGraphCypherHelper(CommunityGraphDialect dialect, CommunityNeo4jClient neo4jClient) {
-        this.dialect = Objects.requireNonNull(dialect, "dialect must not be null");
+        Objects.requireNonNull(dialect, "dialect must not be null");
         this.neo4jClient = neo4jClient;
+        this.reader = new CommunityGraphCypherReader(dialect, this);
+        this.writer = new CommunityGraphCypherWriter(this);
     }
 
+    // ─── CommunityGraphBackend — read delegation ─────────────────────────────────
+
     @Override
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
     public List<UUID> traverseBreadthFirst(GraphTraversal traversal) {
-        String query = dialect.buildMultiHopQuery(traversal.edgeDescriptor(), 1, traversal.maxDepth());
-        Map<String, Object> params = Map.of(PARAM_SOURCE_ID, traversal.startNodeId().toString());
-        try {
-            return executeCypherRead(query, params, result -> {
-                List<UUID> ids = new ArrayList<>();
-                while (result.hasNext()) {
-                    ids.add(asUuid(result.next().get("id"), "BFS"));
-                }
-                return ids;
-            });
-        } catch (RuntimeException cause) {
-            throw new GraphQueryException("BFS", CYPHER_EXECUTION_DETAIL, cause);
-        }
+        return reader.traverseBreadthFirst(traversal);
     }
 
     @Override
     public LoanedBuffer streamBfsJson(GraphTraversal traversal) {
-        List<UUID> bfs = traverseBreadthFirst(traversal);
-        byte[] jsonBytes = CommunityGraphBufferOps.toUuidJsonArray(bfs);
-        LoanedBuffer buffer = KernelProviders.allocator().allocateNetwork(jsonBytes.length);
-        MemorySegment.copy(jsonBytes, 0, buffer.segment(), ValueLayout.JAVA_BYTE, 0, jsonBytes.length);
-        buffer.setSize(jsonBytes.length);
-        return buffer;
+        return reader.streamBfsJson(traversal);
     }
+
+    @Override
+    public UUID getRootNode() {
+        return reader.getRootNode();
+    }
+
+    @Override
+    public void loadAdjacency(GraphEdgeDescriptor edge, CommunityPathFinder.Builder builder) {
+        reader.loadAdjacency(edge, builder);
+    }
+
+    // ─── CommunityGraphBackend — write delegation ────────────────────────────────
 
     @Override
     public void createEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId,
                     double weight, String properties) {
-        String sourceLabel = requireIdentifier(edge.sourceNode());
-        String relationType = requireIdentifier(edge.edgeType());
-        String targetLabel = requireIdentifier(edge.targetNode());
-        String query = """
-                MERGE (source:%s {id: $sourceId})
-                MERGE (target:%s {id: $targetId})
-                CREATE (source)-[r:%s]->(target)
-                SET r.weight = $weight,
-                    r.%s = $%s
-                """.formatted(sourceLabel, targetLabel, relationType,
-                PARAM_PROPERTIES, PARAM_PROPERTIES);
-        executeCypherWrite(query, edgeParameters(sourceId, targetId, weight, properties));
+        writer.createEdge(edge, sourceId, targetId, weight, properties);
     }
 
     @Override
     public void upsertEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId,
                     double weight, String properties) {
-        String sourceLabel = requireIdentifier(edge.sourceNode());
-        String relationType = requireIdentifier(edge.edgeType());
-        String targetLabel = requireIdentifier(edge.targetNode());
-        String query = """
-                MERGE (source:%s {id: $sourceId})
-                MERGE (target:%s {id: $targetId})
-                MERGE (source)-[r:%s]->(target)
-                SET r.weight = $weight,
-                    r.%s = $%s
-                """.formatted(sourceLabel, targetLabel, relationType,
-                PARAM_PROPERTIES, PARAM_PROPERTIES);
-        executeCypherWrite(query, edgeParameters(sourceId, targetId, weight, properties));
+        writer.upsertEdge(edge, sourceId, targetId, weight, properties);
     }
 
     @Override
     public void deleteEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId) {
-        String sourceLabel = requireIdentifier(edge.sourceNode());
-        String relationType = requireIdentifier(edge.edgeType());
-        String targetLabel = requireIdentifier(edge.targetNode());
-        String query = """
-                MATCH (source:%s {id: $sourceId})-[r:%s]->(target:%s {id: $targetId})
-                DELETE r
-                """.formatted(sourceLabel, relationType, targetLabel);
-        executeCypherWrite(query, Map.of(
-                PARAM_SOURCE_ID, sourceId.toString(),
-                PARAM_TARGET_ID, targetId.toString()
-        ));
+        writer.deleteEdge(edge, sourceId, targetId);
     }
 
     @Override
     public void upsertNode(String label, UUID nodeId, LoanedBuffer properties) {
-        String nodeLabel = requireIdentifier(label);
-        String query = """
-                MERGE (n:%s {id: $nodeId})
-                SET n.%s = $%s
-                """.formatted(nodeLabel, PARAM_PROPERTIES, PARAM_PROPERTIES);
-        executeCypherWrite(query, Map.of(
-                "nodeId", nodeId.toString(),
-            PARAM_PROPERTIES, CommunityGraphBufferOps.decodeProperties(properties)
-        ));
+        writer.upsertNode(label, nodeId, properties);
     }
 
     @Override
     public void deleteNode(String label, UUID nodeId) {
-        String nodeLabel = requireIdentifier(label);
-        String query = """
-                MATCH (n:%s {id: $nodeId})
-                DETACH DELETE n
-                """.formatted(nodeLabel);
-        executeCypherWrite(query, Map.of("nodeId", nodeId.toString()));
+        writer.deleteNode(label, nodeId);
     }
 
-    @Override
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
-    public UUID getRootNode() {
-        String query = "MATCH (n:ROOT) RETURN n.id AS id LIMIT 1";
-        try {
-            return executeCypherRead(query, Map.of(), result -> {
-                if (!result.hasNext()) {
-                    throw new GraphQueryException(ROOT_NODE_QUERY_TYPE, "Root node not found");
-                }
-                return asUuid(result.next().get("id"), ROOT_NODE_QUERY_TYPE);
-            });
-        } catch (GraphQueryException cause) {
-            throw cause;
-        } catch (RuntimeException cause) {
-            throw new GraphQueryException(ROOT_NODE_QUERY_TYPE, CYPHER_EXECUTION_DETAIL, cause);
-        }
-    }
-
-    @Override
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
-    public void loadAdjacency(GraphEdgeDescriptor edge, CommunityPathFinder.Builder builder) {
-        String sourceLabel = requireIdentifier(edge.sourceNode());
-        String relationType = requireIdentifier(edge.edgeType());
-        String targetLabel = requireIdentifier(edge.targetNode());
-        String query = """
-                MATCH (source:%s)-[r:%s]->(target:%s)
-                RETURN source.id AS source_id,
-                       target.id AS target_id,
-                       coalesce(r.weight, 1.0) AS weight,
-                       r.%s AS %s
-                """.formatted(sourceLabel, relationType, targetLabel,
-                PARAM_PROPERTIES, PARAM_PROPERTIES);
-
-        try {
-            executeCypherRead(query, Map.of(), result -> {
-                while (result.hasNext()) {
-                    org.neo4j.driver.Record row = result.next();
-                    UUID sourceId = asUuid(row.get("source_id"), edge.edgeType());
-                    UUID targetId = asUuid(row.get("target_id"), edge.edgeType());
-                    double weight = row.get("weight").asDouble(1.0);
-                    String properties = toPropertyString(row.get(PARAM_PROPERTIES));
-                    builder.addEdge(sourceId, targetId, weight, properties);
-                    if (edge.bidirectional() || edge.direction() == GraphEdgeDescriptor.Direction.BOTH) {
-                        builder.addEdge(targetId, sourceId, weight, properties);
-                    }
-                }
-                return null;
-            });
-        } catch (RuntimeException cause) {
-            throw new GraphQueryException(edge.edgeType(),
-                    "Failed to load adjacency for shortest path", cause);
-        }
-    }
+    // ─── CommunityGraphBackend — transaction lifecycle ───────────────────────────
 
     @Override
     @SuppressWarnings({PMD_AVOID_CATCHING_GENERIC_EXCEPTION, "PMD.NullAssignment"})
@@ -278,6 +177,37 @@ final class CommunityGraphCypherHelper implements CommunityGraphBackend {
         }
     }
 
+    // ─── CypherExecutor — session/transaction-aware run ──────────────────────────
+
+    @Override
+    public <T> T executeRead(String query, Map<String, Object> params, Function<Result, T> readerFn) {
+        if (cypherTransaction != null) {
+            return readerFn.apply(cypherTransaction.run(query, params));
+        }
+        try (Session session = openCypherSession()) {
+            return readerFn.apply(session.run(query, params));
+        }
+    }
+
+    @Override
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    public void executeWrite(String query, Map<String, Object> params) {
+        try {
+            if (cypherTransaction != null) {
+                cypherTransaction.run(query, params).consume();
+                return;
+            }
+            try (Session session = openCypherSession()) {
+                session.run(query, params).consume();
+            }
+        } catch (RuntimeException cause) {
+            throw new GraphQueryException(CYPHER_BACKEND_QUERY_TYPE,
+                    CommunityGraphCypherReader.CYPHER_EXECUTION_DETAIL, cause);
+        }
+    }
+
+    // ─── Internals ───────────────────────────────────────────────────────────────
+
     private Session openCypherSession() {
         return requireNeo4jClient().openSession();
     }
@@ -288,78 +218,6 @@ final class CommunityGraphCypherHelper implements CommunityGraphBackend {
                     "Neo4j client is not configured for Cypher backend");
         }
         return neo4jClient;
-    }
-
-    private <T> T executeCypherRead(String query, Map<String, Object> params, Function<Result, T> reader) {
-        if (cypherTransaction != null) {
-            return reader.apply(cypherTransaction.run(query, params));
-        }
-        try (Session session = openCypherSession()) {
-            return reader.apply(session.run(query, params));
-        }
-    }
-
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
-    private void executeCypherWrite(String query, Map<String, Object> params) {
-        try {
-            if (cypherTransaction != null) {
-                cypherTransaction.run(query, params).consume();
-                return;
-            }
-            try (Session session = openCypherSession()) {
-                session.run(query, params).consume();
-            }
-        } catch (RuntimeException cause) {
-            throw new GraphQueryException(CYPHER_BACKEND_QUERY_TYPE, CYPHER_EXECUTION_DETAIL, cause);
-        }
-    }
-
-    private static Map<String, Object> edgeParameters(UUID sourceId, UUID targetId,
-                                                      double weight, String properties) {
-        Map<String, Object> params = new HashMap<>();
-        params.put(PARAM_SOURCE_ID, sourceId.toString());
-        params.put(PARAM_TARGET_ID, targetId.toString());
-        params.put("weight", weight);
-        params.put(PARAM_PROPERTIES, properties != null ? properties : "{}");
-        return params;
-    }
-
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
-    private static String toPropertyString(Value value) {
-        if (value == null || value.isNull()) {
-            return "{}";
-        }
-        try {
-            return value.asString();
-        } catch (RuntimeException _) {
-            return value.toString();
-        }
-    }
-
-    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
-    private static UUID asUuid(Value value, String queryType) {
-        if (value == null || value.isNull()) {
-            throw new GraphQueryException(queryType, "Cypher query returned null UUID");
-        }
-        String raw;
-        try {
-            raw = value.asString();
-        } catch (RuntimeException _) {
-            raw = String.valueOf(value.asObject());
-        }
-        try {
-            return UUID.fromString(raw);
-        } catch (IllegalArgumentException cause) {
-            throw new GraphQueryException(queryType, "Cypher query returned invalid UUID", cause);
-        }
-    }
-
-    private static String requireIdentifier(String identifier) {
-        if (identifier == null || !CYPHER_IDENTIFIER_PATTERN.matcher(identifier).matches()) {
-            throw new GraphQueryException(CYPHER_IDENTIFIER_QUERY_TYPE,
-                    "Invalid Cypher identifier: expected [A-Za-z][A-Za-z0-9_]*");
-        }
-        return identifier;
     }
 
     @SuppressWarnings("PMD.NullAssignment")

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherReader.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherReader.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.exceptions.graph.GraphQueryException;
+import eu.exeris.kernel.spi.graph.model.GraphEdgeDescriptor;
+import eu.exeris.kernel.spi.graph.model.GraphTraversal;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import org.neo4j.driver.Value;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Read-only side of the Cypher backend (QA-008 decomposition). Encapsulates BFS,
+ * shortest-path adjacency loading, and root-node discovery; mutations live in
+ * {@link CommunityGraphCypherWriter}. Lifecycle and session state are owned by the
+ * caller via {@link CypherExecutor}.
+ *
+ * @since 0.7.0
+ */
+final class CommunityGraphCypherReader {
+
+    /* default */ static final String CYPHER_EXECUTION_DETAIL = "Failed to execute Cypher operation";
+    /* default */ static final String ROOT_NODE_QUERY_TYPE = "ROOT_NODE";
+    /* default */ static final String PARAM_SOURCE_ID = "sourceId";
+    /* default */ static final String PARAM_PROPERTIES = "properties";
+
+    private static final String PMD_AVOID_CATCHING_GENERIC_EXCEPTION = "PMD.AvoidCatchingGenericException";
+
+    private final CommunityGraphDialect dialect;
+    private final CypherExecutor executor;
+
+    /* default */ CommunityGraphCypherReader(CommunityGraphDialect dialect, CypherExecutor executor) {
+        this.dialect = dialect;
+        this.executor = executor;
+    }
+
+    // Neo4j driver raises RuntimeException; map to GraphQueryException
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    /* default */ List<UUID> traverseBreadthFirst(GraphTraversal traversal) {
+        String query = dialect.buildMultiHopQuery(traversal.edgeDescriptor(), 1, traversal.maxDepth());
+        Map<String, Object> params = Map.of(PARAM_SOURCE_ID, traversal.startNodeId().toString());
+        try {
+            return executor.executeRead(query, params, result -> {
+                List<UUID> ids = new ArrayList<>();
+                while (result.hasNext()) {
+                    ids.add(asUuid(result.next().get("id"), "BFS"));
+                }
+                return ids;
+            });
+        } catch (RuntimeException cause) {
+            throw new GraphQueryException("BFS", CYPHER_EXECUTION_DETAIL, cause);
+        }
+    }
+
+    /* default */ LoanedBuffer streamBfsJson(GraphTraversal traversal) {
+        List<UUID> bfs = traverseBreadthFirst(traversal);
+        byte[] jsonBytes = CommunityGraphBufferOps.toUuidJsonArray(bfs);
+        LoanedBuffer buffer = KernelProviders.allocator().allocateNetwork(jsonBytes.length);
+        MemorySegment.copy(jsonBytes, 0, buffer.segment(), ValueLayout.JAVA_BYTE, 0, jsonBytes.length);
+        buffer.setSize(jsonBytes.length);
+        return buffer;
+    }
+
+    // Neo4j driver raises RuntimeException; map to GraphQueryException
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    /* default */ UUID getRootNode() {
+        String query = "MATCH (n:ROOT) RETURN n.id AS id LIMIT 1";
+        try {
+            return executor.executeRead(query, Map.of(), result -> {
+                if (!result.hasNext()) {
+                    throw new GraphQueryException(ROOT_NODE_QUERY_TYPE, "Root node not found");
+                }
+                return asUuid(result.next().get("id"), ROOT_NODE_QUERY_TYPE);
+            });
+        } catch (GraphQueryException cause) {
+            throw cause;
+        } catch (RuntimeException cause) {
+            throw new GraphQueryException(ROOT_NODE_QUERY_TYPE, CYPHER_EXECUTION_DETAIL, cause);
+        }
+    }
+
+    // Neo4j driver raises RuntimeException; map to GraphQueryException
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    /* default */ void loadAdjacency(GraphEdgeDescriptor edge, CommunityPathFinder.Builder builder) {
+        String sourceLabel = CypherIdentifiers.requireIdentifier(edge.sourceNode());
+        String relationType = CypherIdentifiers.requireIdentifier(edge.edgeType());
+        String targetLabel = CypherIdentifiers.requireIdentifier(edge.targetNode());
+        String query = """
+                MATCH (source:%s)-[r:%s]->(target:%s)
+                RETURN source.id AS source_id,
+                       target.id AS target_id,
+                       coalesce(r.weight, 1.0) AS weight,
+                       r.%s AS %s
+                """.formatted(sourceLabel, relationType, targetLabel,
+                PARAM_PROPERTIES, PARAM_PROPERTIES);
+
+        try {
+            executor.executeRead(query, Map.of(), result -> {
+                while (result.hasNext()) {
+                    org.neo4j.driver.Record row = result.next();
+                    UUID sourceId = asUuid(row.get("source_id"), edge.edgeType());
+                    UUID targetId = asUuid(row.get("target_id"), edge.edgeType());
+                    double weight = row.get("weight").asDouble(1.0);
+                    String properties = toPropertyString(row.get(PARAM_PROPERTIES));
+                    builder.addEdge(sourceId, targetId, weight, properties);
+                    if (edge.bidirectional() || edge.direction() == GraphEdgeDescriptor.Direction.BOTH) {
+                        builder.addEdge(targetId, sourceId, weight, properties);
+                    }
+                }
+                return null;
+            });
+        } catch (RuntimeException cause) {
+            throw new GraphQueryException(edge.edgeType(),
+                    "Failed to load adjacency for shortest path", cause);
+        }
+    }
+
+    // Neo4j driver raises RuntimeException; fall back to toString on serialization failure
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    /* default */ static String toPropertyString(Value value) {
+        if (value == null || value.isNull()) {
+            return "{}";
+        }
+        try {
+            return value.asString();
+        } catch (RuntimeException _) {
+            return value.toString();
+        }
+    }
+
+    // Neo4j driver raises RuntimeException; fall back to asObject on type mismatch
+    @SuppressWarnings(PMD_AVOID_CATCHING_GENERIC_EXCEPTION)
+    /* default */ static UUID asUuid(Value value, String queryType) {
+        if (value == null || value.isNull()) {
+            throw new GraphQueryException(queryType, "Cypher query returned null UUID");
+        }
+        String raw;
+        try {
+            raw = value.asString();
+        } catch (RuntimeException _) {
+            raw = String.valueOf(value.asObject());
+        }
+        try {
+            return UUID.fromString(raw);
+        } catch (IllegalArgumentException cause) {
+            throw new GraphQueryException(queryType, "Cypher query returned invalid UUID", cause);
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherWriter.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CommunityGraphCypherWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import eu.exeris.kernel.spi.graph.model.GraphEdgeDescriptor;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Mutating side of the Cypher backend (QA-008 decomposition). Encapsulates edge and node
+ * upserts/deletes; reads live in {@link CommunityGraphCypherReader}. Lifecycle and
+ * session state are owned by the caller via {@link CypherExecutor}.
+ *
+ * @since 0.7.0
+ */
+final class CommunityGraphCypherWriter {
+
+    private static final String PARAM_SOURCE_ID = "sourceId";
+    private static final String PARAM_TARGET_ID = "targetId";
+    private static final String PARAM_PROPERTIES = "properties";
+
+    private final CypherExecutor executor;
+
+    /* default */ CommunityGraphCypherWriter(CypherExecutor executor) {
+        this.executor = executor;
+    }
+
+    /* default */ void createEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId,
+                    double weight, String properties) {
+        String sourceLabel = CypherIdentifiers.requireIdentifier(edge.sourceNode());
+        String relationType = CypherIdentifiers.requireIdentifier(edge.edgeType());
+        String targetLabel = CypherIdentifiers.requireIdentifier(edge.targetNode());
+        String query = """
+                MERGE (source:%s {id: $sourceId})
+                MERGE (target:%s {id: $targetId})
+                CREATE (source)-[r:%s]->(target)
+                SET r.weight = $weight,
+                    r.%s = $%s
+                """.formatted(sourceLabel, targetLabel, relationType,
+                PARAM_PROPERTIES, PARAM_PROPERTIES);
+        executor.executeWrite(query, edgeParameters(sourceId, targetId, weight, properties));
+    }
+
+    /* default */ void upsertEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId,
+                    double weight, String properties) {
+        String sourceLabel = CypherIdentifiers.requireIdentifier(edge.sourceNode());
+        String relationType = CypherIdentifiers.requireIdentifier(edge.edgeType());
+        String targetLabel = CypherIdentifiers.requireIdentifier(edge.targetNode());
+        String query = """
+                MERGE (source:%s {id: $sourceId})
+                MERGE (target:%s {id: $targetId})
+                MERGE (source)-[r:%s]->(target)
+                SET r.weight = $weight,
+                    r.%s = $%s
+                """.formatted(sourceLabel, targetLabel, relationType,
+                PARAM_PROPERTIES, PARAM_PROPERTIES);
+        executor.executeWrite(query, edgeParameters(sourceId, targetId, weight, properties));
+    }
+
+    /* default */ void deleteEdge(GraphEdgeDescriptor edge, UUID sourceId, UUID targetId) {
+        String sourceLabel = CypherIdentifiers.requireIdentifier(edge.sourceNode());
+        String relationType = CypherIdentifiers.requireIdentifier(edge.edgeType());
+        String targetLabel = CypherIdentifiers.requireIdentifier(edge.targetNode());
+        String query = """
+                MATCH (source:%s {id: $sourceId})-[r:%s]->(target:%s {id: $targetId})
+                DELETE r
+                """.formatted(sourceLabel, relationType, targetLabel);
+        executor.executeWrite(query, Map.of(
+                PARAM_SOURCE_ID, sourceId.toString(),
+                PARAM_TARGET_ID, targetId.toString()
+        ));
+    }
+
+    /* default */ void upsertNode(String label, UUID nodeId, LoanedBuffer properties) {
+        String nodeLabel = CypherIdentifiers.requireIdentifier(label);
+        String query = """
+                MERGE (n:%s {id: $nodeId})
+                SET n.%s = $%s
+                """.formatted(nodeLabel, PARAM_PROPERTIES, PARAM_PROPERTIES);
+        executor.executeWrite(query, Map.of(
+                "nodeId", nodeId.toString(),
+                PARAM_PROPERTIES, CommunityGraphBufferOps.decodeProperties(properties)
+        ));
+    }
+
+    /* default */ void deleteNode(String label, UUID nodeId) {
+        String nodeLabel = CypherIdentifiers.requireIdentifier(label);
+        String query = """
+                MATCH (n:%s {id: $nodeId})
+                DETACH DELETE n
+                """.formatted(nodeLabel);
+        executor.executeWrite(query, Map.of("nodeId", nodeId.toString()));
+    }
+
+    private static Map<String, Object> edgeParameters(UUID sourceId, UUID targetId,
+                                                      double weight, String properties) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(PARAM_SOURCE_ID, sourceId.toString());
+        params.put(PARAM_TARGET_ID, targetId.toString());
+        params.put("weight", weight);
+        params.put(PARAM_PROPERTIES, properties != null ? properties : "{}");
+        return params;
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CypherExecutor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CypherExecutor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import org.neo4j.driver.Result;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Session/transaction-aware Cypher execution surface shared by
+ * {@link CommunityGraphCypherReader} and {@link CommunityGraphCypherWriter}.
+ *
+ * <p>The implementation owns the session and transaction state; readers and writers carry no
+ * lifecycle of their own. This preserves transactional cohesion across read+write
+ * operations against a single backend session — extraction is structural only, not a
+ * boundary widening.
+ *
+ * @since 0.7.0
+ */
+interface CypherExecutor {
+
+    /**
+     * Runs {@code query} as a read; if a transaction is active, runs inside it, otherwise
+     * opens a session-scoped read.
+     *
+     * @param <T>    reader return type
+     * @param query  Cypher text
+     * @param params named parameter bindings
+     * @param reader function that consumes the {@link Result}
+     * @return the value computed by {@code reader}
+     */
+    <T> T executeRead(String query, Map<String, Object> params, Function<Result, T> reader);
+
+    /**
+     * Runs {@code query} as a write; if a transaction is active, runs inside it, otherwise
+     * opens a session-scoped write and consumes the result.
+     *
+     * @param query  Cypher text
+     * @param params named parameter bindings
+     */
+    void executeWrite(String query, Map<String, Object> params);
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CypherIdentifiers.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/graph/CypherIdentifiers.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import eu.exeris.kernel.spi.exceptions.graph.GraphQueryException;
+
+import java.util.regex.Pattern;
+
+/**
+ * Identifier validation shared by {@link CommunityGraphCypherReader} and
+ * {@link CommunityGraphCypherWriter} (QA-008 decomposition). Cypher does not allow
+ * parameter substitution for labels and relation types, so every label/type that we
+ * splice into a query string must match {@code [A-Za-z][A-Za-z0-9_]*} — the rule both
+ * Neo4j and Cypher admit for valid identifiers.
+ *
+ * @since 0.7.0
+ */
+final class CypherIdentifiers {
+
+    /* default */ static final String QUERY_TYPE = "CYPHER_IDENTIFIER";
+
+    private static final Pattern PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+
+    private CypherIdentifiers() { /* static utility — not instantiable */ }
+
+    /**
+     * Validates that {@code identifier} is a safe Cypher label/type token.
+     *
+     * @param identifier candidate string
+     * @return {@code identifier} unchanged when valid
+     * @throws GraphQueryException when {@code identifier} is null or contains characters
+     *                             other than ASCII letters, digits, or underscores
+     */
+    /* default */ static String requireIdentifier(String identifier) {
+        if (identifier == null || !PATTERN.matcher(identifier).matches()) {
+            throw new GraphQueryException(QUERY_TYPE,
+                    "Invalid Cypher identifier: expected [A-Za-z][A-Za-z0-9_]*");
+        }
+        return identifier;
+    }
+}


### PR DESCRIPTION
## Summary

**QA-008** — Structural decomposition of \`CommunityGraphCypherHelper\` (384 lines, \`PMD.GodClass\` suppressed). Split into:

| Class | Role |
|---|---|
| \`CypherExecutor\` (interface) | Session/transaction-aware run surface shared by Reader and Writer |
| \`CommunityGraphCypherReader\` | Read-only ops: \`traverseBreadthFirst\`, \`streamBfsJson\`, \`getRootNode\`, \`loadAdjacency\` |
| \`CommunityGraphCypherWriter\` | Mutating ops: \`createEdge\`, \`upsertEdge\`, \`deleteEdge\`, \`upsertNode\`, \`deleteNode\` |
| \`CypherIdentifiers\` | Shared label/relation-type validation |
| \`CommunityGraphCypherHelper\` (orchestrator) | Owns Neo4j session + transaction; implements \`CypherExecutor\`; delegates every \`CommunityGraphBackend\` method |

Transactional cohesion preserved: reader and writer carry no lifecycle of their own; both call back into the orchestrator's executor surface which threads every operation through the active transaction when one is open.

\`PMD.GodClass\` suppression retired (repo-wide GodClass count 10 → 9). \`TooManyMethods\` + \`CyclomaticComplexity\` remain on the orchestrator with a justification comment — it implements every backend method by delegation, so per-method branching is uniformly small (highest method CC = 5) but accumulates across the 13-method backend surface.

**QA-009 partial** — Aspirational ≤100 main-source PMD suppression target requires structural decomposition of the 9 remaining \`PMD.GodClass\`-suppressed classes:

\`CommunityPersistenceEngine\`, \`CommunityHttpRequestProcessor\`, \`Slf4jTelemetrySink\`, \`NativeTcpCarrier\`, \`OutboxOrchestrator\`, \`CommunityHttpClientEngine\`, \`NativeTcpStream\`, \`JdbcFlowSnapshotStore\`, \`CommunityHttp2SessionProcessor\`, \`SubsystemOrchestrator\`.

Each is a 1-PR-sized task on the order of QA-008. Re-triaged to v0.8 batch (\`QA-010..018\`) per sprint exit criteria ("QA-008/009 i SQ-005..011 zamknięte albo explicitly re-triaged do v0.8").

## Test plan

- [x] \`mvn -pl exeris-kernel-spi,exeris-kernel-tck,exeris-kernel-core,exeris-kernel-community -am verify\` → BUILD SUCCESS, 1063 tests, 0 PMD/Checkstyle violations
- [x] All graph TCK tests green after decomposition (no behaviour change)
- [x] Helper still implements \`CommunityGraphBackend\` end-to-end via delegation; no public surface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)