### PR TITLE
Bot-finding cleanup: null-guards, isDigits, S1172 contract suppressions

### DIFF
--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/metrics/PrometheusMetricsHandlerTest.java
@@ -65,8 +65,10 @@ class PrometheusMetricsHandlerTest {
                 .contains("kernel_bootstrap_total 1")
                 .contains("kernel_heap_bytes 4096");
         assertThat(exchange.header("Content-Length"))
-                .hasValueSatisfying(value ->
-                        assertThat(Integer.parseInt(value)).isEqualTo(exchange.body().length()));
+                .hasValueSatisfying(value -> {
+                    assertThat(value).isNotNull().as("Content-Length must be a digit string").matches("\\d+");
+                    assertThat(Integer.parseInt(value)).isEqualTo(exchange.body().length());
+                });
     }
 
     @Test

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventBackpressureTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/events/AbstractEventBackpressureTck.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -140,11 +141,15 @@ public abstract class AbstractEventBackpressureTck {
                 .as("Persistent publish past queueCapacity=%d MUST raise EX-EVENT-6002 within "
                         + QUEUE_CAPACITY + "+1 attempts", QUEUE_CAPACITY)
                 .isNotNull();
-        assertThat(overflow.errorCode())
+        // requireNonNull is redundant after the AssertJ isNotNull() above — both fail the test on
+        // null — but it gives static analyzers (CodeQL, code-quality bot) the explicit non-null
+        // proof they need to stop warning on overflow.errorCode() / overflow.rawArgs() below.
+        EventBusException nonNullOverflow = Objects.requireNonNull(overflow);
+        assertThat(nonNullOverflow.errorCode())
                 .as("errorCode MUST be %s", KernelErrorCodes.EX_EVENT_6002)
                 .isEqualTo(KernelErrorCodes.EX_EVENT_6002);
 
-        Object[] rawArgs = overflow.rawArgs();
+        Object[] rawArgs = nonNullOverflow.rawArgs();
         assertThat(rawArgs)
                 .as("rawArgs MUST follow the [String eventType, long queueDepth, long queueCapacity] layout")
                 .hasSize(3);

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractDistributedFlowSnapshotStoreTck.java
@@ -70,12 +70,27 @@ public abstract class AbstractDistributedFlowSnapshotStoreTck {
     /**
      * Returns a brand-new store instance sharing the same underlying database as
      * {@code current}. Used to simulate a kernel restart while the data persists.
+     *
+     * <p><b>Contract parameter.</b> The abstract base does not consume {@code current} —
+     * concrete implementations such as {@code CommunityJdbcFlowSnapshotStoreTckTest} use it to
+     * extract the shared {@code DataSource} (or container handle) from the previous store so the
+     * "reopened" store reads from the same database. Static analyzers flag this as an unused
+     * parameter; the suppression below is intentional.
      */
+    @SuppressWarnings("java:S1172")
     protected abstract FlowSnapshotStore reopenStore(FlowSnapshotStore current);
 
-    /** Optional: implementations may override to release resources (close pool, etc.). */
+    /**
+     * Optional: implementations may override to release resources (close pool, etc.).
+     *
+     * <p><b>Contract parameter.</b> The default no-op does not consume {@code current};
+     * implementations that own a connection pool, container, or any external resource use it to
+     * close that resource between TCK runs. Static analyzers flag this as an unused parameter
+     * on the default body — the suppression below is intentional.
+     */
+    @SuppressWarnings("java:S1172")
     protected void disposeStore(FlowSnapshotStore current) {
-        // no-op by default
+        // no-op by default; overridden in implementations that own external resources
     }
 
     @BeforeEach


### PR DESCRIPTION
## Summary

Triages four CodeQL / code-quality bot findings raised on the v0.7.0 release-cut PR (#110). Two real fixes, two false-positive suppressions with explicit rationale. No SPI / Core / Community runtime change; only test-code edits.

## Triage table

| Finding | File | Action | Why |
|:--|:--|:--|:--|
| Dereferenced variable may be null (Warning) | \`AbstractEventBackpressureTck.java\` | **FIX** | AssertJ \`isNotNull()\` does throw on null, but static analyzers can't see that. Add explicit \`Objects.requireNonNull\` after the AssertJ guard so the proven-non-null variable carries through subsequent dereferences. Same failure semantics either way. |
| Missing catch of NumberFormatException (Note) | \`PrometheusMetricsHandlerTest.java\` | **FIX** | \`Integer.parseInt(value)\` inside \`hasValueSatisfying\` could throw NFE on non-digit Content-Length. Adds \`assertThat(value).matches("\\\\d+")\` ahead of the parse — readable AssertJ failure instead of raw NFE stack trace. |
| Useless parameter \`current\` in \`reopenStore\` (Note) | \`AbstractDistributedFlowSnapshotStoreTck.java\` | **SUPPRESS** | Template-method contract parameter. Abstract base does not consume \`current\`; concrete bindings (e.g. \`CommunityJdbcFlowSnapshotStoreTckTest\`) extract the shared \`DataSource\` from it to simulate a kernel restart over the same database. Removing the parameter breaks the TCK contract. \`@SuppressWarnings("java:S1172")\` + Javadoc clarification. |
| Useless parameter \`current\` in \`disposeStore\` (Note) | same | **SUPPRESS** | Same template-method pattern. Default no-op does not consume \`current\`; overrides that own pool/container resources use it to close them between TCK runs. \`@SuppressWarnings("java:S1172")\` + Javadoc. |

## Bot signals NOT addressed here (operator decision)

These two bot signals on PR #110 are deliberately **not** included in this cleanup PR:

- **\`kafka-clients\` 3.9.1 vulnerabilities** (Apache Kafka producer message-corruption; sensitive-info DEBUG logs — high + moderate). Bumping the Kafka client may affect broker compatibility and the v0.7.0 \`AbstractKafkaEventEngineTck\` Testcontainers run; staging a separate PR (with broker matrix verification) is safer than a blind bump in the release-cut window.
- **"Unknown License" on self-modules** in dependency-review. Pre-existing — our own poms don't carry an \`<licenses>\` stanza, so dependency-review tags them as Null/Unknown. Resolution is to add an \`<licenses><license><name>Apache-2.0 with Commons Clause</name>...\` block in \`exeris-kernel-parent/pom.xml\` (per \`LICENSE-COMMUNITY\`); cosmetic for the release cut.

## Test plan

- [x] \`mvn -DskipTests verify\` (skip lints) green on the cleanup tip.
- [x] No SPI / Core / Community runtime touch.
- [ ] CI on this PR — full reactor.
- [ ] Verify the four bot findings disappear on PR #110 after this PR merges into \`development/0.7.0\` (and #111's merge from main lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)