### PR TITLE
v0.7.0 release-cut blockers: kafka-clients CVE bump + workflow id-token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 - SQ-005..011 quality batch: `catch(Throwable)` → `catch(Exception)` + semantic suppressions, `RuntimeFlowInstance` constructor arity reduction, `Math.clamp` adoption with `S2184` overflow guard, `tools/jfr-reporter` SonarCloud cleanup, `Thread.sleep` → `LockSupport.parkNanos` + bounded settle-window in tests, S5778 single-throwing-call discipline (Sprint 8c).
 - QA-008 `CommunityGraphCypherHelper` decomposed into `CypherExecutor` interface + `CommunityGraphCypherReader` + `CommunityGraphCypherWriter` + `CypherIdentifiers`; orchestrator preserves transactional cohesion via shared executor (Sprint 8d).
 - Hot-Path Collections Review (Sprint 8e) — design note recorded; no further runtime changes justified for v0.7 (`docs/release/hot-path-collections-review.md`). v0.8 watch-items: idempotency-guard packed `long[]`, `pendingWriteInterest` identity keyset, miss-cache ring rewrite.
+- Security: `kafka-clients` 3.9.1 → 3.9.2 (CVE-fixed: GHSA-5qcv-4rpc-jp93 producer message corruption via buffer pool race; GHSA-wf66-mphr-4c4r sensitive info exposure in DEBUG logs). 3.9.x line retained for broker compatibility; 4.x bump deferred to v0.8.
+- CI: `.github/workflows/claude-code-review.yml` — added `id-token: write` to job permissions. The action falls back to OIDC even with `claude_code_oauth_token` configured; missing permission caused "Failed to get OIDC token" check failures.
 
 ### Deferred — re-triaged to v0.8
 

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -29,7 +29,7 @@
         <redis.version>7.2.0</redis.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>
         <neo4j.driver.version>6.0.2</neo4j.driver.version>
-        <kafka-clients.version>3.9.1</kafka-clients.version>
+        <kafka-clients.version>3.9.2</kafka-clients.version>
 
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.23</logback.version>


### PR DESCRIPTION
## Summary

Closes two of the three CI blockers raised on PR #110 release-cut review. The third (TCK teardown timeout) is treated as a flake — operator-side CI re-run, not a code fix.

## Fixes

### 1. \`exeris-kernel-bom/pom.xml\`: \`kafka-clients\` 3.9.1 → 3.9.2

Patches two advisories:

| Advisory | Severity | Description |
|:--|:--|:--|
| GHSA-5qcv-4rpc-jp93 | HIGH | Producer Message Corruption and Misrouting via Buffer Pool Race Condition |
| GHSA-wf66-mphr-4c4r | MODERATE | Sensitive information exposure in DEBUG logs |

Stays on 3.9.x line so existing broker-matrix expectations hold. 4.x bump (latest 4.2.0) requires broker compatibility verification and is deferred to v0.8.

### 2. \`.github/workflows/claude-code-review.yml\`: \`id-token: write\`

Self-inflicted regression introduced via #111 merge-from-main resolution. The action falls back to OIDC even with \`claude_code_oauth_token\` configured; missing \`id-token: write\` caused "Failed to get OIDC token" check failures.

```diff
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
```

### 3. CHANGELOG entries

Two new bullets under "Changed / Quality" capturing both fixes.

## Deliberately NOT in this PR

- **TCK teardown timeout** (\`CommunityTransportCarrierPinningMultiReactor2TckTest\`) — pre-existing TCK-064-class flake (test introduced in #62, not v0.7-introduced). Matches the JDK 26+35 sporadic JVM instability note in operator memory. User-side CI re-run validation.
- **kafka-clients 4.x bump** — broker compat verification required; deferred to v0.8.
- **Performance follow-ups** from the review (\`AsyncTelemetrySink\` \`ArrayBlockingQueue\` → JCTools MPSC; \`JdbcFlowSnapshotStore\` Hikari \`cachePrepStmts\` Javadoc; \`KafkaEventCodec\` \`LoanedBuffer\`-backed payload; JFR coverage gaps for \`KafkaPublishBus\` / \`JdbcFlowSnapshotStore\` generic-SQL fail paths) — recorded for v0.7.1 / v0.8 watch-items.
- **Self-modules "Unknown License"** in dependency-review — pre-existing; cosmetic; deferred.

## Test plan

- [x] \`mvn -DskipTests verify\` (skip lints) green with kafka-clients 3.9.2.
- [x] No SPI / Core / Community runtime change beyond the dependency version.
- [ ] CI on this PR confirms the kafka CVE warnings disappear and the claude-code-review workflow succeeds.

## After this lands

1. Re-trigger CI on PR #110 (\`development/0.7.0\` → \`main\`); expect kafka CVE warnings cleared, workflow check green.
2. If the TCK teardown timeout reproduces on re-run → file a transport-side fix before tagging \`v0.7.0\`. If green ×3, treat as flake per operator memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)