### PR TITLE
v0.8 Sprint 1 (QA-010): decompose CommunityPersistenceEngine — close GodClass + TooManyMethods

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceEngine.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceEngine.java
@@ -21,16 +21,9 @@ import eu.exeris.kernel.spi.persistence.PersistenceEngine;
 import eu.exeris.kernel.spi.persistence.PersistenceHealthStatus;
 import eu.exeris.kernel.spi.security.StorageContext;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,8 +48,14 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @since 0.5.0
  */
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.TooManyMethods", "PMD.CouplingBetweenObjects",
-        "PMD.GodClass"})
+// Cohesion baseline post-QA-010 (v0.8 Sprint 1): migration bootstrap and pool warm-up
+// were extracted to dedicated helpers (CommunityPersistenceMigrationRunner,
+// CommunityPersistencePoolWarmup). The remaining cyclomatic complexity is dominated
+// by the per-request connection-acquisition decision tree (request-scope vs physical,
+// tenant pool selection, interceptor chain); coupling reflects the SPI integration
+// surface (PersistenceEngine + PhysicalConnectionSource + ConnectionInterceptor +
+// StorageContext) which is load-bearing by contract, not by accident.
+@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects"})
 final class CommunityPersistenceEngine implements PersistenceEngine, PhysicalConnectionSource {
 
     private static final String ENGINE_CLOSED_MESSAGE = "CommunityPersistenceEngine is closed";
@@ -106,50 +105,13 @@ final class CommunityPersistenceEngine implements PersistenceEngine, PhysicalCon
                 "BlockingTCP"
         );
 
-        maybeRunMigrations();
-        prewarmSharedPool();
-    }
-    /**
-     * Pre-warm the shared connection pool by acquiring N connections simultaneously,
-     * then returning them all. Holding all N at once forces HikariCP to create them
-     * concurrently, so the idle pool is fully populated before the first request arrives.
-     * Fail-fast on error to surface DB unavailability at startup.
-     */
-    private void prewarmSharedPool() {
-        int warmupConnections = config.poolWarmupConnections();
-        if (!config.poolWarmupEnabled() || warmupConnections <= 0) {
-            return;
-        }
-        int targetConnections = Math.min(warmupConnections, config.maxPoolSize());
-        List<Connection> heldConnections = new ArrayList<>(targetConnections);
-        try {
-            acquireWarmupConnections(targetConnections, heldConnections);
-        } catch (SQLException sqlEx) {
-            throw PersistenceProviderException.bootstrapFailure(
-                    CommunityPersistenceConstants.PROVIDER_ID,
-                    config.connectionUrl(),
-                    sqlEx);
-        } finally {
-            releaseConnectionsQuietly(heldConnections);
-        }
-    }
-
-    private void acquireWarmupConnections(int warmupConnections,
-                                          List<Connection> heldConnections) throws SQLException {
-        for (int i = 0; i < warmupConnections; i++) {
-            Connection connection = sharedPool.getConnection(); // NOPMD CloseResource -- held for warm-up
-            heldConnections.add(connection);
-            validateWarmupConnection(connection);
-        }
-    }
-
-    private void validateWarmupConnection(Connection connection) throws SQLException {
-        if (!connection.isValid(5)) {
-            throw PersistenceProviderException.bootstrapFailure(
-                    CommunityPersistenceConstants.PROVIDER_ID,
-                    config.connectionUrl(),
-                    new IllegalStateException("Connection validation returned false during pool warm-up"));
-        }
+        CommunityPersistenceMigrationRunner.runIfEnabled(
+                Boolean.parseBoolean(config.properties().getOrDefault(RUN_MIGRATIONS_KEY, "false")),
+                sharedPool,
+                MIGRATION_RESOURCES,
+                CommunityPersistenceConstants.PROVIDER_ID,
+                config.connectionUrl());
+        CommunityPersistencePoolWarmup.prewarm(sharedPool, config);
     }
 
     // =========================================================================
@@ -322,20 +284,6 @@ final class CommunityPersistenceEngine implements PersistenceEngine, PhysicalCon
         closeSharedPoolSafely();
     }
 
-    @SuppressWarnings("PMD.CloseResource")
-    private void releaseConnectionsQuietly(List<Connection> connections) {
-        for (Connection connection : connections) {
-            if (connection == null) {
-                continue;
-            }
-            try {
-                connection.close();
-            } catch (SQLException _) {
-                // best-effort return to pool
-            }
-        }
-    }
-
     private CommunityTenantPoolRegistry.PoolShutdownPlan preparePoolShutdown() {
         synchronized (lifecycleLock) {
             if (closed) {
@@ -446,117 +394,6 @@ final class CommunityPersistenceEngine implements PersistenceEngine, PhysicalCon
                     + "got connectionTimeoutMs="
                             + config.connectionTimeoutMs() + ", maxPoolSize=" + config.maxPoolSize());
         }
-    }
-
-    private void maybeRunMigrations() {
-        if (!Boolean.parseBoolean(config.properties().getOrDefault(RUN_MIGRATIONS_KEY, "false"))) {
-            return;
-        }
-        List<String> resources = new ArrayList<>(MIGRATION_RESOURCES);
-        resources.sort(Comparator.naturalOrder());
-        try (Connection connection = sharedPool.getConnection()) {
-            runMigrationsInTransaction(connection, resources);
-        } catch (SQLException | IllegalStateException | UncheckedIOException ex) {
-            throw PersistenceProviderException.bootstrapFailure(
-                    CommunityPersistenceConstants.PROVIDER_ID,
-                    config.connectionUrl(),
-                    ex);
-        }
-    }
-
-    private void runMigrationsInTransaction(Connection connection,
-                                            List<String> resources) throws SQLException {
-        connection.setAutoCommit(false);
-        boolean committed = false;
-        try {
-            for (String resource : resources) {
-                executeMigrationScript(connection, resource);
-            }
-            connection.commit();
-            committed = true;
-        } finally {
-            restoreAutoCommit(connection, committed);
-        }
-    }
-
-    private void restoreAutoCommit(Connection connection, boolean committed) throws SQLException {
-        try {
-            if (!committed) {
-                connection.rollback();
-            }
-        } finally {
-            connection.setAutoCommit(true);
-        }
-    }
-
-    private void executeMigrationScript(Connection connection, String resourcePath) throws SQLException {
-        String migrationSql = readMigrationResource(resourcePath);
-        for (String statementSql : splitSqlStatements(migrationSql)) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute(statementSql);
-            }
-        }
-    }
-
-    @SuppressWarnings("PMD.LawOfDemeter")
-    private static String readMigrationResource(String resourcePath) {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try (InputStream inputStream = classLoader.getResourceAsStream(resourcePath)) {
-            if (inputStream == null) {
-                throw new IllegalStateException("Missing SQL migration resource: " + resourcePath);
-            }
-            byte[] bytes = inputStream.readAllBytes();
-            return new String(bytes, StandardCharsets.UTF_8);
-        } catch (IOException ioEx) {
-            throw new UncheckedIOException("Failed to read SQL migration resource: " + resourcePath, ioEx);
-        }
-    }
-
-    private static List<String> splitSqlStatements(String sql) {
-        if (sql == null || sql.isBlank()) {
-            return List.of();
-        }
-        StringBuilder current = new StringBuilder(sql.length());
-        List<String> statements = new ArrayList<>();
-        boolean inSingleQuote = false;
-
-        for (int i = 0; i < sql.length(); i++) {
-            char currentChar = sql.charAt(i);
-            if (currentChar == '\'' && (i == 0 || sql.charAt(i - 1) != '\\')) {
-                inSingleQuote = !inSingleQuote;
-            }
-            if (currentChar == ';' && !inSingleQuote) {
-                addStatement(statements, current);
-                current.setLength(0);
-                continue;
-            }
-            current.append(currentChar);
-        }
-        addStatement(statements, current);
-        return Collections.unmodifiableList(statements);
-    }
-
-    private static void addStatement(List<String> statements, StringBuilder current) {
-        String candidate = stripLineComments(current.toString()).trim();
-        if (!candidate.isEmpty()) {
-            statements.add(candidate);
-        }
-    }
-
-    private static String stripLineComments(String sql) {
-        String[] lines = sql.split("\\R");
-        StringBuilder builder = new StringBuilder(sql.length());
-        for (String line : lines) {
-            String trimmed = line.stripLeading();
-            if (trimmed.startsWith("--")) {
-                continue;
-            }
-            if (!builder.isEmpty()) {
-                builder.append('\n');
-            }
-            builder.append(line);
-        }
-        return builder.toString();
     }
 
     private int computeActiveConnections() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceMigrationRunner.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistenceMigrationRunner.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+import eu.exeris.kernel.spi.exceptions.persistence.PersistenceProviderException;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Community-internal SQL migration bootstrap helper. Extracted from
+ * {@link CommunityPersistenceEngine} in QA-010 (v0.8 Sprint 1) to reduce the engine's
+ * responsibility surface — the engine owns connection lifecycle and admission control;
+ * this helper owns the "read SQL resources from the classpath, split into statements,
+ * execute them inside one transaction" workflow.
+ *
+ * <h2>Workflow</h2>
+ * <p>{@link #runIfEnabled(boolean, DataSource, List, String, String)} is a no-op when
+ * the run-migrations flag is {@code false}; otherwise it acquires a single connection
+ * from the supplied pool, sets auto-commit off, executes every statement from every
+ * resource in {@link Comparator#naturalOrder() natural order} of the resource list,
+ * and either commits on success or rolls back on any failure before restoring
+ * auto-commit.
+ *
+ * <h2>SQL splitting</h2>
+ * <p>Statement boundaries are detected on top-level {@code ;} characters outside
+ * single-quoted string literals. Single-line comments ({@code --}) are stripped before
+ * the trimmed candidate is emitted. The semantics match the legacy in-engine logic
+ * verbatim — see {@code CommunityPersistenceEngineMigrationTest} for the locked-in
+ * behaviour against the {@code V0.5.0__create_outbox.sql} and
+ * {@code V0.7.0__create_saga_state.sql} migration scripts.
+ *
+ * <h2>Error handling</h2>
+ * <p>Any {@link SQLException}, {@link IllegalStateException} (missing resource), or
+ * {@link UncheckedIOException} (read failure) surfaces as
+ * {@link PersistenceProviderException#bootstrapFailure(String, String, Throwable)}
+ * carrying the provider identity and JDBC URL so operators can trace the failure to a
+ * specific bootstrap.
+ *
+ * @since 0.8.0
+ */
+final class CommunityPersistenceMigrationRunner {
+
+    private CommunityPersistenceMigrationRunner() {
+        // utility — no instances
+    }
+
+    /**
+     * Runs every migration in {@code resources} (sorted in natural order) against the
+     * supplied {@code dataSource} inside a single transaction. Returns immediately when
+     * {@code enabled} is {@code false}.
+     *
+     * @param enabled        whether migrations should run (resolved from config)
+     * @param dataSource     pooled JDBC datasource; one connection is acquired and released
+     * @param resources      classpath migration resource paths (e.g. {@code db/migration/V…sql})
+     * @param providerId     persistence-provider identifier used in bootstrap-failure reporting
+     * @param connectionUrl  JDBC URL used in bootstrap-failure reporting
+     * @throws PersistenceProviderException when a resource cannot be read or any
+     *         statement fails to execute; the underlying cause is preserved.
+     */
+    static void runIfEnabled(boolean enabled,
+                             DataSource dataSource,
+                             List<String> resources,
+                             String providerId,
+                             String connectionUrl) {
+        if (!enabled) {
+            return;
+        }
+        List<String> sorted = new ArrayList<>(resources);
+        sorted.sort(Comparator.naturalOrder());
+        try (Connection connection = dataSource.getConnection()) {
+            runMigrationsInTransaction(connection, sorted);
+        } catch (SQLException | IllegalStateException | UncheckedIOException ex) {
+            throw PersistenceProviderException.bootstrapFailure(providerId, connectionUrl, ex);
+        }
+    }
+
+    private static void runMigrationsInTransaction(Connection connection,
+                                                   List<String> resources) throws SQLException {
+        connection.setAutoCommit(false);
+        boolean committed = false;
+        try {
+            for (String resource : resources) {
+                executeMigrationScript(connection, resource);
+            }
+            connection.commit();
+            committed = true;
+        } finally {
+            restoreAutoCommit(connection, committed);
+        }
+    }
+
+    private static void restoreAutoCommit(Connection connection, boolean committed) throws SQLException {
+        try {
+            if (!committed) {
+                connection.rollback();
+            }
+        } finally {
+            connection.setAutoCommit(true);
+        }
+    }
+
+    private static void executeMigrationScript(Connection connection, String resourcePath) throws SQLException {
+        String migrationSql = readMigrationResource(resourcePath);
+        for (String statementSql : splitSqlStatements(migrationSql)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(statementSql);
+            }
+        }
+    }
+
+    @SuppressWarnings("PMD.LawOfDemeter")
+    private static String readMigrationResource(String resourcePath) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        try (InputStream inputStream = classLoader.getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("Missing SQL migration resource: " + resourcePath);
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException ioEx) {
+            throw new UncheckedIOException("Failed to read SQL migration resource: " + resourcePath, ioEx);
+        }
+    }
+
+    private static List<String> splitSqlStatements(String sql) {
+        if (sql == null || sql.isBlank()) {
+            return List.of();
+        }
+        StringBuilder current = new StringBuilder(sql.length());
+        List<String> statements = new ArrayList<>();
+        boolean inSingleQuote = false;
+
+        for (int i = 0; i < sql.length(); i++) {
+            char currentChar = sql.charAt(i);
+            if (currentChar == '\'' && (i == 0 || sql.charAt(i - 1) != '\\')) {
+                inSingleQuote = !inSingleQuote;
+            }
+            if (currentChar == ';' && !inSingleQuote) {
+                addStatement(statements, current);
+                current.setLength(0);
+                continue;
+            }
+            current.append(currentChar);
+        }
+        addStatement(statements, current);
+        return Collections.unmodifiableList(statements);
+    }
+
+    private static void addStatement(List<String> statements, StringBuilder current) {
+        String candidate = stripLineComments(current.toString()).trim();
+        if (!candidate.isEmpty()) {
+            statements.add(candidate);
+        }
+    }
+
+    private static String stripLineComments(String sql) {
+        String[] lines = sql.split("\\R");
+        StringBuilder builder = new StringBuilder(sql.length());
+        for (String line : lines) {
+            String trimmed = line.stripLeading();
+            if (trimmed.startsWith("--")) {
+                continue;
+            }
+            if (!builder.isEmpty()) {
+                builder.append('\n');
+            }
+            builder.append(line);
+        }
+        return builder.toString();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistencePoolWarmup.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityPersistencePoolWarmup.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+import com.zaxxer.hikari.HikariDataSource;
+import eu.exeris.kernel.spi.exceptions.persistence.PersistenceProviderException;
+import eu.exeris.kernel.spi.persistence.PersistenceConfig;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Community-internal connection-pool warm-up helper. Extracted from
+ * {@link CommunityPersistenceEngine} in QA-010 (v0.8 Sprint 1) so the engine carries
+ * one less responsibility: the "hold N connections at once to force HikariCP to
+ * materialise them concurrently before the first user request arrives" workflow lives
+ * here.
+ *
+ * <h2>Why hold connections, not loop {@code getConnection()/close()}</h2>
+ * <p>HikariCP creates a fresh connection on demand only when there is no idle
+ * connection to hand out. A loop of {@code getConnection()} immediately followed by
+ * {@code close()} would return the same connection to the pool every iteration — so
+ * the pool would never grow past one. Holding all {@code N} connections at once forces
+ * Hikari to create them concurrently; once they are released the pool is fully idle
+ * and ready for the request load.
+ *
+ * <h2>Fail-fast on bootstrap</h2>
+ * <p>If any acquired connection fails {@link Connection#isValid(int)} the helper
+ * surfaces {@link PersistenceProviderException#bootstrapFailure} so a misconfigured
+ * database (auth, network) shows up at engine construction rather than on first
+ * request.
+ *
+ * @since 0.8.0
+ */
+final class CommunityPersistencePoolWarmup {
+
+    private CommunityPersistencePoolWarmup() {
+        // utility — no instances
+    }
+
+    /**
+     * Pre-warms {@code sharedPool} to {@code min(config.poolWarmupConnections(),
+     * config.maxPoolSize())} concurrent connections. No-op when warm-up is disabled or
+     * the requested count is non-positive. Held connections are always released —
+     * success or failure.
+     *
+     * @param sharedPool the HikariCP pool to warm up
+     * @param config     persistence config (warm-up flag, target count, max pool size)
+     * @throws PersistenceProviderException when an acquired connection fails validation
+     *         or pool acquisition itself raises an SQL error.
+     */
+    static void prewarm(HikariDataSource sharedPool, PersistenceConfig config) {
+        int warmupConnections = config.poolWarmupConnections();
+        if (!config.poolWarmupEnabled() || warmupConnections <= 0) {
+            return;
+        }
+        int targetConnections = Math.min(warmupConnections, config.maxPoolSize());
+        List<Connection> heldConnections = new ArrayList<>(targetConnections);
+        try {
+            acquireWarmupConnections(sharedPool, targetConnections, heldConnections, config);
+        } catch (SQLException sqlEx) {
+            throw PersistenceProviderException.bootstrapFailure(
+                    CommunityPersistenceConstants.PROVIDER_ID,
+                    config.connectionUrl(),
+                    sqlEx);
+        } finally {
+            releaseConnectionsQuietly(heldConnections);
+        }
+    }
+
+    private static void acquireWarmupConnections(HikariDataSource sharedPool,
+                                                 int warmupConnections,
+                                                 List<Connection> heldConnections,
+                                                 PersistenceConfig config) throws SQLException {
+        for (int i = 0; i < warmupConnections; i++) {
+            Connection connection = sharedPool.getConnection(); // NOPMD CloseResource -- held for warm-up
+            heldConnections.add(connection);
+            validateWarmupConnection(connection, config);
+        }
+    }
+
+    private static void validateWarmupConnection(Connection connection,
+                                                 PersistenceConfig config) throws SQLException {
+        if (!connection.isValid(5)) {
+            throw PersistenceProviderException.bootstrapFailure(
+                    CommunityPersistenceConstants.PROVIDER_ID,
+                    config.connectionUrl(),
+                    new IllegalStateException("Connection validation returned false during pool warm-up"));
+        }
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    private static void releaseConnectionsQuietly(List<Connection> connections) {
+        for (Connection connection : connections) {
+            if (connection == null) {
+                continue;
+            }
+            try {
+                connection.close();
+            } catch (SQLException _) {
+                // best-effort return to pool
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts two responsibility-bundles from `CommunityPersistenceEngine` into dedicated Community-internal helpers, closing the `PMD.GodClass` + `PMD.TooManyMethods` class-level suppressions. The engine shrinks **565 → 403 LOC (−162)**.

- **`CommunityPersistenceMigrationRunner`** (new, package-private) — owns the *"read SQL migration resources from the classpath, split into statements on top-level `;` outside single-quoted literals, strip line comments, execute every statement inside one transaction with explicit auto-commit lifecycle"* workflow. **8 methods moved out**: `maybeRunMigrations`, `runMigrationsInTransaction`, `restoreAutoCommit`, `executeMigrationScript`, `readMigrationResource`, `splitSqlStatements`, `addStatement`, `stripLineComments`. Behavioural semantics preserved verbatim against the `V0.5.0__create_outbox.sql` and `V0.7.0__create_saga_state.sql` scripts pinned by `CommunityPersistenceEngineMigrationTest` (2/2 green locally).
- **`CommunityPersistencePoolWarmup`** (new, package-private) — owns the *"hold N connections at once to force HikariCP to materialise them concurrently before the first request arrives"* workflow with fail-fast on `Connection.isValid()`. **4 methods moved out**: `prewarmSharedPool`, `acquireWarmupConnections`, `validateWarmupConnection`, `releaseConnectionsQuietly`.

## Suppression delta

```
Before: {PMD.CyclomaticComplexity, PMD.TooManyMethods, PMD.CouplingBetweenObjects, PMD.GodClass}
After:  {PMD.CyclomaticComplexity, PMD.CouplingBetweenObjects}
```

The two remaining suppressions are documented in the class header with their root cause:
- **`CyclomaticComplexity`** — the per-request connection-acquisition decision tree (request-scope vs physical, tenant pool selection, interceptor chain) dominates the remaining complexity. Further decomposition would fragment a single SPI contract; deferred unless a future profile shows a meaningful payoff.
- **`CouplingBetweenObjects`** — reflects the SPI integration surface (`PersistenceEngine` + `PhysicalConnectionSource` + `ConnectionInterceptor` + `StorageContext`) which is load-bearing by contract, not by accident.

`PMD.GodClass` + `PMD.TooManyMethods` are gone — QA-010 exit criterion met.

## Why two helpers, not one

Migration bootstrap and pool warm-up are independent lifecycle phases that happen to both run during engine construction. Combining them in one `CommunityPersistenceEngineBootstrapHelper` would create a faux-aggregate that obscures the actual responsibilities. The QA-008 precedent from v0.7 Sprint 8d split `CommunityGraphCypherHelper` into four single-purpose helpers for the same reason — single-responsibility wins over file-count economy.

## Test plan

- [x] Local: full `mvn test` non-integration sweep across all 10 modules — BUILD SUCCESS.
- [x] Local: `CommunityPersistenceEngineMigrationTest` (regression coverage for the extracted migration workflow against H2) — 2/2 green.
- [ ] CI: full PMD/Checkstyle/SpotBugs/Sonar pass to confirm the suppression block closure registers in the dashboard.
- [ ] CI: Testcontainers `CommunityPersistenceIsolationLeakIT` + `CommunityPersistenceTenantIsolationIT` (gated on Docker) — sanity that the extracted warm-up does not regress the multi-tenant pool lifecycle.

## v0.8 quality-batch progress

| Sprint 1 sub-track | Status |
|:--|:--|
| SEC-100 + SEC-102 + BUILD-101 (dep hygiene) | merged (PR #118) |
| QA-010 `CommunityPersistenceEngine` | **this PR** |
| QA-011 `CommunityHttpRequestProcessor` | next |
| QA-012 `Slf4jTelemetrySink` | queued |
| QA-013 `NativeTcpCarrier` (HEUR-061 carry-over) | queued |
| QA-014 `OutboxOrchestrator` | queued |
| SQ-100 SonarCloud top-15 | queued |

Cumulative PMD suppression delta after this PR merges: **−2** (out of the −5 Sprint 1 target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)