### PR TITLE
v0.8 Sprint 1 (QA-011): decompose CommunityHttpRequestProcessor — close GodClass + TooManyMethods

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpAggregateTelemetry.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpAggregateTelemetry.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.jfr.HttpAggregateBufferForcedReleaseEvent;
+import eu.exeris.kernel.core.http.jfr.HttpAggregateBufferHeldEvent;
+
+/**
+ * Community-internal HTTP/1.1 aggregate-buffer telemetry helper. Extracted from
+ * {@link CommunityHttpRequestProcessor} in QA-011 (v0.8 Sprint 1) so the request
+ * processor carries one less responsibility: the *"how long has this aggregate buffer
+ * been held, what fraction of requests on it were actually pipelined, and should we
+ * force-release it back to the allocator?"* decision tree lives here.
+ *
+ * <h2>Why these heuristics</h2>
+ * <p>HTTP/1.1 keep-alive connections may host multiple requests in sequence. The
+ * processor pre-allocates an aggregate read buffer when the first request arrives and
+ * keeps it across the keep-alive loop so the second/third pipelined request can land
+ * in the same buffer without an extra allocation. The cost: a long-lived keep-alive
+ * connection with low pipelined traffic holds the buffer indefinitely.
+ *
+ * <p>Phase 1C (v0.6 telemetry) added two JFR signals:
+ * <ul>
+ *   <li>{@link HttpAggregateBufferHeldEvent} — emitted once a buffer has been held for
+ *       more than {@value #BUFFER_AGE_WARNING_THRESHOLD_MS} ms, carries the buffered
+ *       byte count and the running pipelined fraction.</li>
+ *   <li>{@link HttpAggregateBufferForcedReleaseEvent} — emitted when the heuristic
+ *       decides to release the buffer back to the allocator: pipelined fraction
+ *       dropped below {@value #PIPELINED_FRACTION_THRESHOLD} (5%) AND the buffer is
+ *       currently idle (zero buffered bytes from the last keep-alive iteration).</li>
+ * </ul>
+ *
+ * <h2>Statelessness</h2>
+ * <p>All methods are {@code static} — the helper reads counters from the supplied
+ * {@link ProcessingState} and emits events. No internal state is retained between
+ * invocations; per-connection state lives in {@code ProcessingState}.
+ *
+ * @since 0.8.0
+ */
+final class CommunityHttpAggregateTelemetry {
+
+    /** Emit a "buffer held too long" JFR signal once the buffer age exceeds this. */
+    private static final long BUFFER_AGE_WARNING_THRESHOLD_MS = 100;
+
+    /** Force-release threshold: if fewer than 5% of requests were pipelined, drop the buffer. */
+    private static final double PIPELINED_FRACTION_THRESHOLD = 0.05;
+
+    private CommunityHttpAggregateTelemetry() {
+        // utility — no instances
+    }
+
+    /**
+     * Inspects the aggregate buffer state, emits the "held too long" JFR signal when
+     * the age threshold is crossed, and force-releases the buffer (also emitting a
+     * forced-release JFR signal) when the pipelined fraction has dropped low enough
+     * to justify the de-allocation. No-op when the buffer is fresh.
+     *
+     * @param state               the per-connection processing state
+     * @param maxAggregateBytes   the configured aggregate ceiling — emitted in the
+     *                            "held" event so dashboards can show the held fraction
+     */
+    static void applyAndRelease(ProcessingState state, int maxAggregateBytes) {
+        long aggregateAgeMs = aggregateAgeMillis(state.aggregateAllocationTimeNs());
+        if (!shouldEmitAggregateHeldTelemetry(aggregateAgeMs)) {
+            return;
+        }
+
+        double pipelinedFraction = pipelinedFraction(state.totalRequestCount(), state.pipelinedRequestCount());
+        emitAggregateHeldTelemetry(aggregateAgeMs, state.bufferedBytes(), pipelinedFraction, maxAggregateBytes);
+        if (shouldForceReleaseAggregate(pipelinedFraction, state.bufferedBytes())) {
+            emitForcedReleaseTelemetry(state.bufferedBytes(), pipelinedFraction);
+            state.forceReleaseAggregate();
+        }
+    }
+
+    private static long aggregateAgeMillis(long aggregateAllocationTimeNs) {
+        return (System.nanoTime() - aggregateAllocationTimeNs) / 1_000_000;
+    }
+
+    private static boolean shouldEmitAggregateHeldTelemetry(long aggregateAgeMs) {
+        return aggregateAgeMs > BUFFER_AGE_WARNING_THRESHOLD_MS;
+    }
+
+    private static double pipelinedFraction(long totalRequestCount, long pipelinedRequestCount) {
+        return totalRequestCount > 0
+                ? (double) pipelinedRequestCount / totalRequestCount
+                : 0.0;
+    }
+
+    private static void emitAggregateHeldTelemetry(long aggregateAgeMs,
+                                                   long bufferedBytes,
+                                                   double pipelinedFraction,
+                                                   int maxAggregateBytes) {
+        HttpAggregateBufferHeldEvent.emit(
+                aggregateAgeMs,
+                (int) bufferedBytes,
+                maxAggregateBytes,
+                pipelinedFraction
+        );
+    }
+
+    private static boolean shouldForceReleaseAggregate(double pipelinedFraction, long bufferedBytes) {
+        return pipelinedFraction < PIPELINED_FRACTION_THRESHOLD && bufferedBytes == 0;
+    }
+
+    private static void emitForcedReleaseTelemetry(long bufferedBytes, double pipelinedFraction) {
+        HttpAggregateBufferForcedReleaseEvent.emit(
+                "low_pipelined_fraction",
+                (int) bufferedBytes,
+                PIPELINED_FRACTION_THRESHOLD,
+                pipelinedFraction
+        );
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpAggregateTelemetry.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpAggregateTelemetry.java
@@ -65,7 +65,7 @@ final class CommunityHttpAggregateTelemetry {
      * @param maxAggregateBytes   the configured aggregate ceiling — emitted in the
      *                            "held" event so dashboards can show the held fraction
      */
-    static void applyAndRelease(ProcessingState state, int maxAggregateBytes) {
+    /* default */ static void applyAndRelease(ProcessingState state, int maxAggregateBytes) {
         long aggregateAgeMs = aggregateAgeMillis(state.aggregateAllocationTimeNs());
         if (!shouldEmitAggregateHeldTelemetry(aggregateAgeMs)) {
             return;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpH2cUpgradeDetector.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpH2cUpgradeDetector.java
@@ -57,14 +57,14 @@ final class CommunityHttpH2cUpgradeDetector {
     private static final String HEADER_UPGRADE = "Upgrade";
     private static final String H2C_TOKEN = "h2c";
     private static final String UPGRADE_TOKEN = "upgrade";
-    /* default */ static final byte[] HTTP2_PRIOR_KNOWLEDGE_PREFACE =
+    private static final byte[] HTTP2_PRIOR_KNOWLEDGE_PREFACE =
             "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
 
     private final HttpConfig config;
     private final CommunityHttp2SessionProcessor http2SessionProcessor;
 
-    CommunityHttpH2cUpgradeDetector(HttpConfig config,
-                                    CommunityHttp2SessionProcessor http2SessionProcessor) {
+    /* default */ CommunityHttpH2cUpgradeDetector(HttpConfig config,
+                                                  CommunityHttp2SessionProcessor http2SessionProcessor) {
         this.config = Objects.requireNonNull(config, "config");
         this.http2SessionProcessor = Objects.requireNonNull(http2SessionProcessor, "http2SessionProcessor");
     }
@@ -73,7 +73,7 @@ final class CommunityHttpH2cUpgradeDetector {
      * Returns {@code true} when {@link HttpConfig#h2cUpgradeEnabled()} is set and the
      * configured {@link HttpConfig#maxVersion()} allows HTTP/2 negotiation.
      */
-    boolean isH2cEnabled() {
+    /* default */ boolean isH2cEnabled() {
         return config.h2cUpgradeEnabled() && supportsHttp2(config.maxVersion());
     }
 
@@ -83,10 +83,16 @@ final class CommunityHttpH2cUpgradeDetector {
      * untouched and returns {@code false}. The {@code maxVersion} policy gates the
      * detection — older configs see this method short-circuit to {@code false}.
      */
-    boolean shouldHandlePriorKnowledge(TransportStream stream,
-                                       HttpHandler handler,
-                                       ProcessingState state,
-                                       long totalBytes) {
+    @SuppressWarnings("PMD.CloseResource")
+    // The LoanedBuffer returned by state.aggregate() is the flyweight whose lifecycle
+    // is owned by ProcessingState across the keep-alive loop iterations; closing it
+    // here would break the request-loop invariant. The aggregate is closed by
+    // ProcessingState.close() through the try-with-resources in
+    // CommunityHttpRequestProcessor.process.
+    /* default */ boolean shouldHandlePriorKnowledge(TransportStream stream,
+                                                     HttpHandler handler,
+                                                     ProcessingState state,
+                                                     long totalBytes) {
         if (!supportsHttp2(config.maxVersion())) {
             return false;
         }
@@ -109,10 +115,10 @@ final class CommunityHttpH2cUpgradeDetector {
      * {@link #isH2cUpgradeIntent(List)} and that h2c upgrade is enabled via
      * {@link #isH2cEnabled()}.
      */
-    void handleHttp1UpgradeToH2c(ReadResult readResult,
-                                 TransportStream stream,
-                                 HttpHandler handler,
-                                 ProcessingState state) {
+    /* default */ void handleHttp1UpgradeToH2c(ReadResult readResult,
+                                               TransportStream stream,
+                                               HttpHandler handler,
+                                               ProcessingState state) {
         http2SessionProcessor.handleUpgrade(readResult, stream, handler, state);
     }
 
@@ -123,7 +129,7 @@ final class CommunityHttpH2cUpgradeDetector {
      * heap allocation that a {@code byte[]} copy + {@code Arrays.equals} would cost on
      * the request hot path.
      */
-    static boolean isHttp2PriorKnowledgePreface(MemorySegment segment, long totalBytes) {
+    /* default */ static boolean isHttp2PriorKnowledgePreface(MemorySegment segment, long totalBytes) {
         if (totalBytes < HTTP2_PRIOR_KNOWLEDGE_PREFACE.length) {
             return false;
         }
@@ -142,7 +148,7 @@ final class CommunityHttpH2cUpgradeDetector {
      * values may be CSV lists per RFC 7230 §6.7, so each value is split on commas
      * before token comparison.
      */
-    static boolean isH2cUpgradeIntent(List<HttpHeader> headers) {
+    /* default */ static boolean isH2cUpgradeIntent(List<HttpHeader> headers) {
         boolean hasUpgradeH2c = false;
         boolean hasConnectionUpgrade = false;
         for (HttpHeader header : headers) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpH2cUpgradeDetector.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpH2cUpgradeDetector.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpConfig;
+import eu.exeris.kernel.spi.http.HttpHandler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.transport.TransportStream;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Community-internal HTTP/2 upgrade-detection helper. Extracted from
+ * {@link CommunityHttpRequestProcessor} in QA-011 (v0.8 Sprint 1) so the request
+ * processor carries one less responsibility: the *"is this an h2c upgrade or HTTP/2
+ * prior-knowledge connection? if yes, transition to the HTTP/2 frame loop"* workflow
+ * lives here.
+ *
+ * <h2>Two upgrade paths</h2>
+ * <ul>
+ *   <li><b>Prior knowledge</b> — the client opens a TCP/TLS connection and sends the
+ *       24-byte HTTP/2 connection preface ({@code PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n})
+ *       as the first bytes. Detected via byte-by-byte preface compare on the read
+ *       aggregate buffer; on match the request loop hands control to the HTTP/2
+ *       session processor and exits.</li>
+ *   <li><b>HTTP/1.1 → h2c upgrade</b> — an HTTP/1.1 request arrives carrying both
+ *       {@code Upgrade: h2c} and {@code Connection: Upgrade}. Detected on the parsed
+ *       header list; the session processor switches modes after replying with
+ *       {@code 101 Switching Protocols}.</li>
+ * </ul>
+ *
+ * <h2>State and lifecycle</h2>
+ * <p>One detector instance per processor — owns the {@link HttpConfig} (for the
+ * {@code h2cUpgradeEnabled} / {@code maxVersion} policy gates) and the
+ * {@link CommunityHttp2SessionProcessor} (the actual frame-loop runner). Both are
+ * already constructed by the processor in v0.7 — this helper just bundles the
+ * decision logic that was previously spread across six instance methods plus a
+ * private static.
+ *
+ * @since 0.8.0
+ */
+final class CommunityHttpH2cUpgradeDetector {
+
+    private static final String HEADER_CONNECTION = "Connection";
+    private static final String HEADER_UPGRADE = "Upgrade";
+    private static final String H2C_TOKEN = "h2c";
+    private static final String UPGRADE_TOKEN = "upgrade";
+    /* default */ static final byte[] HTTP2_PRIOR_KNOWLEDGE_PREFACE =
+            "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+
+    private final HttpConfig config;
+    private final CommunityHttp2SessionProcessor http2SessionProcessor;
+
+    CommunityHttpH2cUpgradeDetector(HttpConfig config,
+                                    CommunityHttp2SessionProcessor http2SessionProcessor) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.http2SessionProcessor = Objects.requireNonNull(http2SessionProcessor, "http2SessionProcessor");
+    }
+
+    /**
+     * Returns {@code true} when {@link HttpConfig#h2cUpgradeEnabled()} is set and the
+     * configured {@link HttpConfig#maxVersion()} allows HTTP/2 negotiation.
+     */
+    boolean isH2cEnabled() {
+        return config.h2cUpgradeEnabled() && supportsHttp2(config.maxVersion());
+    }
+
+    /**
+     * If the aggregate buffer holds an HTTP/2 prior-knowledge preface, transitions to
+     * the HTTP/2 session loop and returns {@code true}; otherwise leaves the buffer
+     * untouched and returns {@code false}. The {@code maxVersion} policy gates the
+     * detection — older configs see this method short-circuit to {@code false}.
+     */
+    boolean shouldHandlePriorKnowledge(TransportStream stream,
+                                       HttpHandler handler,
+                                       ProcessingState state,
+                                       long totalBytes) {
+        if (!supportsHttp2(config.maxVersion())) {
+            return false;
+        }
+        LoanedBuffer aggregate = state.aggregate();
+        if (!isHttp2PriorKnowledgePreface(aggregate.segment(), totalBytes)) {
+            return false;
+        }
+        http2SessionProcessor.handlePriorKnowledge(
+                stream,
+                handler,
+                state,
+                totalBytes,
+                HTTP2_PRIOR_KNOWLEDGE_PREFACE.length);
+        return true;
+    }
+
+    /**
+     * Hands an already-parsed HTTP/1.1 upgrade request to the HTTP/2 session processor.
+     * Caller is responsible for first verifying the upgrade headers via
+     * {@link #isH2cUpgradeIntent(List)} and that h2c upgrade is enabled via
+     * {@link #isH2cEnabled()}.
+     */
+    void handleHttp1UpgradeToH2c(ReadResult readResult,
+                                 TransportStream stream,
+                                 HttpHandler handler,
+                                 ProcessingState state) {
+        http2SessionProcessor.handleUpgrade(readResult, stream, handler, state);
+    }
+
+    /**
+     * Returns {@code true} when the first
+     * {@link #HTTP2_PRIOR_KNOWLEDGE_PREFACE}{@code .length} bytes of {@code segment}
+     * exactly match the HTTP/2 connection preface. Operates byte-by-byte to avoid the
+     * heap allocation that a {@code byte[]} copy + {@code Arrays.equals} would cost on
+     * the request hot path.
+     */
+    static boolean isHttp2PriorKnowledgePreface(MemorySegment segment, long totalBytes) {
+        if (totalBytes < HTTP2_PRIOR_KNOWLEDGE_PREFACE.length) {
+            return false;
+        }
+        for (int index = 0; index < HTTP2_PRIOR_KNOWLEDGE_PREFACE.length; index++) {
+            byte actual = segment.get(ValueLayout.JAVA_BYTE, index);
+            if (actual != HTTP2_PRIOR_KNOWLEDGE_PREFACE[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code true} when {@code headers} carry both {@code Upgrade: h2c} and
+     * {@code Connection: Upgrade}. Header names compared case-insensitively; both
+     * values may be CSV lists per RFC 7230 §6.7, so each value is split on commas
+     * before token comparison.
+     */
+    static boolean isH2cUpgradeIntent(List<HttpHeader> headers) {
+        boolean hasUpgradeH2c = false;
+        boolean hasConnectionUpgrade = false;
+        for (HttpHeader header : headers) {
+            if (header.nameEqualsIgnoreCase(HEADER_UPGRADE)
+                    && containsCsvTokenIgnoreCase(header.value(), H2C_TOKEN)) {
+                hasUpgradeH2c = true;
+            }
+            if (header.nameEqualsIgnoreCase(HEADER_CONNECTION)
+                    && containsCsvTokenIgnoreCase(header.value(), UPGRADE_TOKEN)) {
+                hasConnectionUpgrade = true;
+            }
+        }
+        return hasUpgradeH2c && hasConnectionUpgrade;
+    }
+
+    private static boolean supportsHttp2(HttpVersion maxVersion) {
+        return maxVersion == HttpVersion.HTTP_2 || maxVersion == HttpVersion.HTTP_3;
+    }
+
+    private static boolean containsCsvTokenIgnoreCase(String headerValue, String token) {
+        int start = 0;
+        int length = headerValue.length();
+        while (start < length) {
+            int end = headerValue.indexOf(',', start);
+            if (end < 0) {
+                end = length;
+            }
+            String candidate = headerValue.substring(start, end).trim();
+            if (candidate.equalsIgnoreCase(token)) {
+                return true;
+            }
+            start = end + 1;
+        }
+        return false;
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -10,33 +10,34 @@ package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.community.persistence.PersistenceSessionBox;
 import eu.exeris.kernel.core.http.http1.Http1Codec;
-import eu.exeris.kernel.core.http.jfr.HttpAggregateBufferForcedReleaseEvent;
-import eu.exeris.kernel.core.http.jfr.HttpAggregateBufferHeldEvent;
 import eu.exeris.kernel.core.security.SecurityInterceptor;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpConfig;
 import eu.exeris.kernel.spi.http.HttpHandler;
-import eu.exeris.kernel.spi.http.HttpHeader;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpResponseBodyEncoderRegistry;
-import eu.exeris.kernel.spi.http.HttpVersion;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.persistence.PersistenceEngine;
 import eu.exeris.kernel.spi.transport.TransportStream;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Objects;
 
+// Cohesion baseline post-QA-011 (v0.8 Sprint 1): h2c/HTTP-2 upgrade detection and
+// aggregate-buffer telemetry were extracted to dedicated helpers
+// (CommunityHttpH2cUpgradeDetector, CommunityHttpAggregateTelemetry). The remaining
+// suppressions reflect intrinsic processor responsibilities: the request loop is the
+// natural integration point that catches generic stream errors (graceful close
+// detection is testable and locked in `isExpectedStreamClose`), the
+// try-with-resources lifecycle on `TransportStream` / `ProcessingState` is
+// purposeful (CloseResource suppression covers the buffer flyweight that is shared
+// across loop iterations by design), and the keep-alive iteration / read-aggregate
+// branching dominates the residual cyclomatic complexity.
 @SuppressWarnings({
     "PMD.AvoidCatchingGenericException",
     "PMD.CloseResource",
-    "PMD.CyclomaticComplexity",
-    "PMD.GodClass",
-    "PMD.TooManyMethods"
+    "PMD.CyclomaticComplexity"
 })
 public final class CommunityHttpRequestProcessor {
 
@@ -51,25 +52,16 @@ public final class CommunityHttpRequestProcessor {
 
     private static final System.Logger LOG =
             System.getLogger(CommunityHttpRequestProcessor.class.getName());
-    private static final String HEADER_CONNECTION = "Connection";
-    private static final String HEADER_UPGRADE = "Upgrade";
-    private static final String H2C_TOKEN = "h2c";
-    private static final String UPGRADE_TOKEN = "upgrade";
     private static final int READ_CHUNK_BYTES = 8 * 1024;
     private static final int INITIAL_HTTP1_AGGREGATE_BYTES = 16 * 1024;
     private static final int MAX_AGGREGATE_BYTES = 1 * 1024 * 1024;
-    private static final byte[] HTTP2_PRIOR_KNOWLEDGE_PREFACE =
-            "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
-    
-    // Phase 1C: HTTP buffer lifecycle tracking
-    private static final long BUFFER_AGE_WARNING_THRESHOLD_MS = 100;
-    private static final double PIPELINED_FRACTION_THRESHOLD = 0.05; // If pipelined < 5%, force release
 
     private final MemoryAllocator allocator;
     private final HttpResponseBodyEncoderRegistry encoderRegistry;
     private final HttpConfig config;
     private final CommunityHttpRequestDispatcher requestDispatcher;
     private final CommunityHttp2SessionProcessor http2SessionProcessor;
+    private final CommunityHttpH2cUpgradeDetector upgradeDetector;
 
     /* default */ CommunityHttpRequestProcessor(MemoryAllocator allocator,
                                                 HttpResponseBodyEncoderRegistry encoderRegistry) {
@@ -101,6 +93,7 @@ public final class CommunityHttpRequestProcessor {
                 this.requestDispatcher,
                 READ_CHUNK_BYTES,
                 MAX_AGGREGATE_BYTES);
+        this.upgradeDetector = new CommunityHttpH2cUpgradeDetector(this.config, this.http2SessionProcessor);
     }
 
     // Aggregate buffer lifecycle is intentionally stateful across loop iterations to
@@ -138,16 +131,17 @@ public final class CommunityHttpRequestProcessor {
             return false;
         }
 
-        if (isH2cEnabled() && isH2cUpgradeIntent(readResult.headers())) {
+        if (upgradeDetector.isH2cEnabled()
+                && CommunityHttpH2cUpgradeDetector.isH2cUpgradeIntent(readResult.headers())) {
             if (LOG.isLoggable(System.Logger.Level.INFO)) {
                 LOG.log(System.Logger.Level.INFO,
                         "HTTP/1.1 h2c upgrade requested; switching to HTTP/2 frame-loop mode");
             }
-            handleHttp1UpgradeToH2c(readResult, stream, handler, state);
+            upgradeDetector.handleHttp1UpgradeToH2c(readResult, stream, handler, state);
             return false;
         }
 
-        trackPipelinedRequest(state);
+        state.recordRequest();
         handleRequest(readResult, state.aggregate(), stream, handler);
 
         state.updateBufferedBytes(CommunityHttp1RequestReader.retainUnreadBytes(
@@ -157,27 +151,9 @@ public final class CommunityHttpRequestProcessor {
             return false;
         }
 
-        applyAggregateTelemetryAndRelease(state);
+        CommunityHttpAggregateTelemetry.applyAndRelease(state, MAX_AGGREGATE_BYTES);
         state.releaseAggregateIfIdle();
         return true;
-    }
-
-    private static void trackPipelinedRequest(ProcessingState state) {
-        state.recordRequest();
-    }
-
-    private static void applyAggregateTelemetryAndRelease(ProcessingState state) {
-        long aggregateAgeMs = aggregateAgeMillis(state.aggregateAllocationTimeNs());
-        if (!shouldEmitAggregateHeldTelemetry(aggregateAgeMs)) {
-            return;
-        }
-
-        double pipelinedFraction = pipelinedFraction(state.totalRequestCount(), state.pipelinedRequestCount());
-        emitAggregateHeldTelemetry(aggregateAgeMs, state.bufferedBytes(), pipelinedFraction);
-        if (shouldForceReleaseAggregate(pipelinedFraction, state.bufferedBytes())) {
-            emitForcedReleaseTelemetry(state.bufferedBytes(), pipelinedFraction);
-            state.forceReleaseAggregate();
-        }
     }
 
     private void handleRequest(ReadResult readResult,
@@ -198,44 +174,6 @@ public final class CommunityHttpRequestProcessor {
             bodyBuffer.setSize(bodyLength);
             dispatchRequest(readResult, bodyBuffer, stream, handler);
         }
-    }
-
-    private static long aggregateAgeMillis(long aggregateAllocationTimeNs) {
-        return (System.nanoTime() - aggregateAllocationTimeNs) / 1_000_000;
-    }
-
-    private static boolean shouldEmitAggregateHeldTelemetry(long aggregateAgeMs) {
-        return aggregateAgeMs > BUFFER_AGE_WARNING_THRESHOLD_MS;
-    }
-
-    private static double pipelinedFraction(long totalRequestCount, long pipelinedRequestCount) {
-        return totalRequestCount > 0
-                ? (double) pipelinedRequestCount / totalRequestCount
-                : 0.0;
-    }
-
-    private static void emitAggregateHeldTelemetry(long aggregateAgeMs,
-                                                   long bufferedBytes,
-                                                   double pipelinedFraction) {
-        HttpAggregateBufferHeldEvent.emit(
-                aggregateAgeMs,
-                (int) bufferedBytes,
-                MAX_AGGREGATE_BYTES,
-                pipelinedFraction
-        );
-    }
-
-    private static boolean shouldForceReleaseAggregate(double pipelinedFraction, long bufferedBytes) {
-        return pipelinedFraction < PIPELINED_FRACTION_THRESHOLD && bufferedBytes == 0;
-    }
-
-    private static void emitForcedReleaseTelemetry(long bufferedBytes, double pipelinedFraction) {
-        HttpAggregateBufferForcedReleaseEvent.emit(
-                "low_pipelined_fraction",
-                (int) bufferedBytes,
-                PIPELINED_FRACTION_THRESHOLD,
-                pipelinedFraction
-        );
     }
 
     private static boolean isExpectedStreamClose(RuntimeException streamError) {
@@ -277,7 +215,7 @@ public final class CommunityHttpRequestProcessor {
         LoanedBuffer aggregate = state.aggregate();
         long total = bufferedBytes;
 
-        if (shouldHandlePriorKnowledge(stream, handler, state, total)) {
+        if (upgradeDetector.shouldHandlePriorKnowledge(stream, handler, state, total)) {
             return null;
         }
 
@@ -303,7 +241,7 @@ public final class CommunityHttpRequestProcessor {
                 total += read;
                 aggregate.setSize(total);
 
-                if (shouldHandlePriorKnowledge(stream, handler, state, total)) {
+                if (upgradeDetector.shouldHandlePriorKnowledge(stream, handler, state, total)) {
                     return null;
                 }
 
@@ -316,93 +254,5 @@ public final class CommunityHttpRequestProcessor {
         return null;
     }
 
-
-    private boolean isH2cEnabled() {
-        return config.h2cUpgradeEnabled() && supportsHttp2(config.maxVersion());
-    }
-
-    private static boolean supportsHttp2(HttpVersion maxVersion) {
-        return maxVersion == HttpVersion.HTTP_2 || maxVersion == HttpVersion.HTTP_3;
-    }
-
-    private boolean shouldHandlePriorKnowledge(TransportStream stream,
-                                               HttpHandler handler,
-                                               ProcessingState state,
-                                               long totalBytes) {
-        if (!supportsHttp2(config.maxVersion())) {
-            return false;
-        }
-        LoanedBuffer aggregate = state.aggregate();
-        if (!isHttp2PriorKnowledgePreface(aggregate.segment(), totalBytes)) {
-            return false;
-        }
-        handleHttp2PriorKnowledge(stream, handler, state, totalBytes);
-        return true;
-    }
-
-    private void handleHttp2PriorKnowledge(TransportStream stream,
-                                           HttpHandler handler,
-                                           ProcessingState state,
-                                           long totalBytes) {
-        http2SessionProcessor.handlePriorKnowledge(
-                stream,
-                handler,
-                state,
-                totalBytes,
-                HTTP2_PRIOR_KNOWLEDGE_PREFACE.length);
-    }
-
-    private void handleHttp1UpgradeToH2c(ReadResult readResult,
-                                         TransportStream stream,
-                                         HttpHandler handler,
-                                         ProcessingState state) {
-        http2SessionProcessor.handleUpgrade(readResult, stream, handler, state);
-    }
-
-    /* default */ static boolean isHttp2PriorKnowledgePreface(MemorySegment segment, long totalBytes) {
-        if (totalBytes < HTTP2_PRIOR_KNOWLEDGE_PREFACE.length) {
-            return false;
-        }
-        for (int index = 0; index < HTTP2_PRIOR_KNOWLEDGE_PREFACE.length; index++) {
-            byte actual = segment.get(ValueLayout.JAVA_BYTE, index);
-            if (actual != HTTP2_PRIOR_KNOWLEDGE_PREFACE[index]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /* default */ static boolean isH2cUpgradeIntent(List<HttpHeader> headers) {
-        boolean hasUpgradeH2c = false;
-        boolean hasConnectionUpgrade = false;
-        for (HttpHeader header : headers) {
-            if (header.nameEqualsIgnoreCase(HEADER_UPGRADE)
-                    && containsCsvTokenIgnoreCase(header.value(), H2C_TOKEN)) {
-                hasUpgradeH2c = true;
-            }
-            if (header.nameEqualsIgnoreCase(HEADER_CONNECTION)
-                    && containsCsvTokenIgnoreCase(header.value(), UPGRADE_TOKEN)) {
-                hasConnectionUpgrade = true;
-            }
-        }
-        return hasUpgradeH2c && hasConnectionUpgrade;
-    }
-
-    private static boolean containsCsvTokenIgnoreCase(String headerValue, String token) {
-        int start = 0;
-        int length = headerValue.length();
-        while (start < length) {
-            int end = headerValue.indexOf(',', start);
-            if (end < 0) {
-                end = length;
-            }
-            String candidate = headerValue.substring(start, end).trim();
-            if (candidate.equalsIgnoreCase(token)) {
-                return true;
-            }
-            start = end + 1;
-        }
-        return false;
-    }
 
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
@@ -110,7 +110,7 @@ class CommunityHttpRequestProcessorTest {
             MemorySegment.copy(MemorySegment.ofArray(preface), 0, buffer.segment(), 0, preface.length);
             buffer.setSize(preface.length);
 
-            assertThat(CommunityHttpRequestProcessor.isHttp2PriorKnowledgePreface(buffer.segment(), buffer.size()))
+            assertThat(CommunityHttpH2cUpgradeDetector.isHttp2PriorKnowledgePreface(buffer.segment(), buffer.size()))
                     .isTrue();
         }
     }
@@ -122,7 +122,7 @@ class CommunityHttpRequestProcessorTest {
             MemorySegment.copy(MemorySegment.ofArray(request), 0, buffer.segment(), 0, request.length);
             buffer.setSize(request.length);
 
-            assertThat(CommunityHttpRequestProcessor.isHttp2PriorKnowledgePreface(buffer.segment(), buffer.size()))
+            assertThat(CommunityHttpH2cUpgradeDetector.isHttp2PriorKnowledgePreface(buffer.segment(), buffer.size()))
                     .isFalse();
         }
     }
@@ -133,7 +133,7 @@ class CommunityHttpRequestProcessorTest {
                 new HttpHeader("cOnNeCtIoN", "keep-alive, UpGrAdE"),
                 new HttpHeader("UpGrAdE", "H2C"));
 
-        assertThat(CommunityHttpRequestProcessor.isH2cUpgradeIntent(headers)).isTrue();
+        assertThat(CommunityHttpH2cUpgradeDetector.isH2cUpgradeIntent(headers)).isTrue();
     }
 
     @Test
@@ -142,7 +142,7 @@ class CommunityHttpRequestProcessorTest {
                 new HttpHeader("Connection", "keep-alive"),
                 new HttpHeader("Upgrade", "h2c"));
 
-        assertThat(CommunityHttpRequestProcessor.isH2cUpgradeIntent(headers)).isFalse();
+        assertThat(CommunityHttpH2cUpgradeDetector.isH2cUpgradeIntent(headers)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Extracts two responsibility-bundles from `CommunityHttpRequestProcessor` into dedicated Community-internal helpers, closing the `PMD.GodClass` + `PMD.TooManyMethods` class-level suppressions. The processor shrinks **408 → 258 LOC (−150)**.

- **`CommunityHttpH2cUpgradeDetector`** (new, package-private, instance class) — owns the *"is this an h2c upgrade or HTTP/2 prior-knowledge connection? if yes, transition to the HTTP/2 frame loop"* workflow. Constructor-injected `HttpConfig` + `CommunityHttp2SessionProcessor`. **8 methods + 5 constants** moved out: `isH2cEnabled`, `shouldHandlePriorKnowledge`, `handleHttp1UpgradeToH2c` (instance — need session-processor state), `supportsHttp2`, `isHttp2PriorKnowledgePreface`, `isH2cUpgradeIntent`, `containsCsvTokenIgnoreCase` (pure static helpers), plus the HTTP/2 connection preface byte array and the four upgrade-header token literals.
- **`CommunityHttpAggregateTelemetry`** (new, package-private, static utility) — owns the Phase 1C v0.6 aggregate-buffer telemetry: *"how long has this aggregate been held, what fraction of requests were pipelined, should we force-release it?"*. Single entry: `applyAndRelease(state, maxAggregateBytes)`. **7 methods + 2 thresholds** moved out.

## Suppression delta

```
Before: {AvoidCatchingGenericException, CloseResource, CyclomaticComplexity, GodClass, TooManyMethods}
After:  {AvoidCatchingGenericException, CloseResource, CyclomaticComplexity}
```

The remaining three suppressions are documented in the class header with their root cause:
- **`AvoidCatchingGenericException`** — the request loop catches a generic `RuntimeException` to surface stream-close races as a clean return; `isExpectedStreamClose` carries the testable predicate.
- **`CloseResource`** — the aggregate `LoanedBuffer` is the flyweight that the keep-alive loop reuses across iterations; the try-with-resources on `TransportStream` + `ProcessingState` is the correct lifecycle.
- **`CyclomaticComplexity`** — `processIteration` + `readRequest` branching on keep-alive / aggregate-capacity / HTTP-2-upgrade is intrinsic to the codec contract; further decomposition would fragment the request lifecycle.

`PMD.GodClass` + `PMD.TooManyMethods` are gone — QA-011 exit criterion met.

## Test surface preserved

`CommunityHttpRequestProcessorTest` previously called `CommunityHttpRequestProcessor.isHttp2PriorKnowledgePreface` and `CommunityHttpRequestProcessor.isH2cUpgradeIntent` directly. Both methods moved to `CommunityHttpH2cUpgradeDetector` (same package — both classes are package-private), so the test now calls them on the new home. Behavioural assertions unchanged.

## Test plan

- [x] Local: full `mvn test` non-integration sweep across all 10 modules — BUILD SUCCESS.
- [x] Local: `CommunityHttpRequestProcessorTest` (including the 4 upgrade-detection cases moved to delegate calls) — green.
- [ ] CI: full PMD/Checkstyle/SpotBugs/Sonar pass to confirm the suppression block closure registers in the dashboard.

## Note on JVM crashes during this development

The first test run hit a sporadic JDK 26+35 SIGSEGV in G1 mid-`testCompile`, a documented preexisting condition (operator memory: "JDK 26+35 sporadic JVM crashes — just retry"). The second run finished cleanly with `Tests run: 708, Failures: 0, Errors: 0, Skipped: 8` across the Community module. Not a regression introduced by this PR.

## v0.8 Sprint 1 progress after this PR

| Sub-track | Status |
|:--|:--|
| SEC-100 + SEC-102 + BUILD-101 (dep hygiene) | merged (#118) |
| CI infra: SNAPSHOT deploy | merged (#120) |
| CI hotfix: VT scheduler flags on main job | open (#121) |
| QA-010 `CommunityPersistenceEngine` | merged (#119) |
| QA-011 `CommunityHttpRequestProcessor` | **this PR** |
| QA-012 `Slf4jTelemetrySink` | next |
| QA-013 `NativeTcpCarrier` (HEUR-061 carry-over) | queued |
| QA-014 `OutboxOrchestrator` | queued |
| SQ-100 SonarCloud top-15 | queued |

Cumulative PMD suppression delta after this PR merges: **−4** (out of the −5 Sprint 1 target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)