### PR TITLE
v0.8 Sprint 1 (CI hotfix v4): widen CoreFlowEngineTest race-safe budget for 2-vCPU CI

### DIFF
--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/flow/CoreFlowEngineTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/flow/CoreFlowEngineTest.java
@@ -213,8 +213,16 @@ class CoreFlowEngineTest {
             }
         }
 
+        // 512 race iterations of schedule/park/wake on a single context drive the
+        // FlowScheduler hard enough that the post-loop settle conditions can take
+        // tens of seconds on a constrained 2-vCPU CI runner (the same JDK 26+35
+        // schedule-pressure window that motivated the v0.8 Sprint 0a VT carrier
+        // bump). Local 12-core boxes settle in well under a second. The post-loop
+        // budget is therefore 30 s instead of 5 s — enough headroom for CI without
+        // masking a real race regression (a regression would block indefinitely,
+        // not "almost finish in 6 s"). The method-level @Timeout matches.
         @Test
-        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @Timeout(value = 90, unit = TimeUnit.SECONDS)
         @DisplayName("immediate schedule, park, and wake on the same context is race-safe")
         void immediateScheduleParkWakeOnSameContextIsRaceSafe() throws InterruptedException {
             try (CoreFlowEngine engine = startedEngine(false)) {
@@ -246,7 +254,7 @@ class CoreFlowEngineTest {
                     }
                 }
 
-                awaitTrue(5_000, () -> engine.stats().completedFlows() >= 1
+                awaitTrue(30_000, () -> engine.stats().completedFlows() >= 1
                         || engine.scheduler().lookupParked(
                                 context.instanceIdMost(),
                                 context.instanceIdLeast()).isPresent());
@@ -256,7 +264,7 @@ class CoreFlowEngineTest {
                         context.instanceIdLeast());
                 if (parked.isPresent()) {
                     engine.scheduler().wake(parked.orElseThrow());
-                    awaitTrue(5_000, () -> engine.stats().completedFlows() >= 1);
+                    awaitTrue(30_000, () -> engine.stats().completedFlows() >= 1);
                 }
 
                 assertThat(engine.stats().failedFlows()).isZero();


### PR DESCRIPTION
## Summary

PR #121 + PR #122 each ran green individually, but the squash-merge run on `development/0.8.0` surfaced a new failure in **core** that did not show on either feature branch:

```
Failures:
  CoreFlowEngineTest$ScheduleAndWakeTests.immediateScheduleParkWakeOnSameContextIsRaceSafe:259
    Condition not met within 5000 ms

Tests run: 1084, Failures: 1, Errors: 0, Skipped: 8
```

The test drives the FlowScheduler through **512 schedule/park/wake race iterations** on a single context, then waits for the engine to settle — either complete the flow or land it in `parked` — with a 5 s `awaitTrue` budget, then wakes the parked instance and waits another 5 s for completion. On local 12-core boxes the engine settles in well under a second. On the constrained 2-vCPU GitHub Actions runner the post-loop settle window lands late enough to trip the 5 s deadline.

This is the same JDK 26+35 schedule-pressure window that motivated the v0.8 Sprint 0a VT carrier-pool bump for transport tests: tight deadlines + high contention + minimal carriers on CI produces flaky failures that do not reflect a real race regression. A real regression would block indefinitely, not "almost finish in 6 s".

## What changes

`exeris-kernel-core/src/test/java/.../CoreFlowEngineTest.java` — single test method:

```java
- @Timeout(value = 10, unit = TimeUnit.SECONDS)
+ @Timeout(value = 90, unit = TimeUnit.SECONDS)
  ...
-     awaitTrue(5_000, () -> engine.stats().completedFlows() >= 1 || ...lookupParked(...).isPresent());
+     awaitTrue(30_000, () -> engine.stats().completedFlows() >= 1 || ...lookupParked(...).isPresent());
  ...
-         awaitTrue(5_000, () -> engine.stats().completedFlows() >= 1);
+         awaitTrue(30_000, () -> engine.stats().completedFlows() >= 1);
```

Test-side jitter fix; no kernel-code change. The race-safety assertion itself is preserved — the new budget gives the scheduler enough headroom to dispatch the trailing wake on the 2-vCPU runner without weakening what the test actually verifies.

## Test plan

- [x] Local: `mvn -Dtest=CoreFlowEngineTest test` — 22/22 green (4/4 ScheduleAndWake including this race-safe test).
- [ ] CI: this PR's `build-and-verify` run on the feature branch passes — first observable signal that the wider budget covers the runner.
- [ ] CI: squash-merge run on `development/0.8.0` is green.

## Risk

Low. Single test method, test code only, budget widened in a direction that cannot hide a real regression (the production semantics still complete in well under a second locally; if the new 30 s budget is ever exceeded on CI, something genuinely broke).

## What this does not address

- **The underlying CI throughput problem** — JDK 26+35 schedule pressure on 2-vCPU runners. Same root cause as the transport carrier-pinning workaround in PR #121. Real fix is v0.8 Sprint 7 transport hardening + a broader CI runner sizing review once the v0.8 cadence stabilises.
- **Other tests that may still hit the same window** as new feature branches land. Each will get the same treatment per the established pattern (widen budget, keep assertion, document the CI-vs-local gap inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)