### PR TITLE
v0.8 Sprint 1 (QA-012): decompose Slf4jTelemetrySink — close GodClass + TooManyMethods + CyclomaticComplexity

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryJsonEscaper.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryJsonEscaper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.telemetry;
+
+/**
+ * Package-private JSON string-escape helper for {@link Slf4jTelemetrySink}.
+ *
+ * <p>Extracted from {@link Slf4jTelemetrySink} in v0.8 Sprint 1 (QA-012) as the
+ * leaf of the JSON serialization split. Owns {@link #escapeJson(String)} and
+ * {@link #appendJsonString(StringBuilder, String)}, both consumed by
+ * {@link Slf4jTelemetryJsonWriter} (top entry) and
+ * {@link Slf4jTelemetryRawArgsWriter} (rawArgs walker).
+ */
+final class Slf4jTelemetryJsonEscaper {
+
+    private static final char FIRST_PRINTABLE_ASCII = 0x20;
+
+    private Slf4jTelemetryJsonEscaper() {
+        // package-private static utility — never instantiated.
+    }
+
+    @SuppressWarnings("PMD.CyclomaticComplexity") // JSON escape table is spec-defined exhaustive case list.
+    /* default */ static String escapeJson(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            switch (current) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (current < FIRST_PRINTABLE_ASCII) {
+                        appendUnicodeEscape(escaped, current);
+                    } else {
+                        escaped.append(current);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    /* default */ static void appendJsonString(StringBuilder builder, String value) {
+        builder.append('"').append(escapeJson(value)).append('"');
+    }
+
+    private static void appendUnicodeEscape(StringBuilder builder, char value) {
+        builder.append("\\u00");
+        int high = (value >> 4) & 0x0F;
+        int low = value & 0x0F;
+        builder.append((char) (high < 10 ? '0' + high : 'a' + high - 10))
+               .append((char) (low < 10 ? '0' + low : 'a' + low - 10));
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryJsonWriter.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryJsonWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.telemetry;
+
+import eu.exeris.kernel.spi.config.KernelProfile;
+import eu.exeris.kernel.spi.exceptions.ExceptionDisclosure;
+import eu.exeris.kernel.spi.exceptions.ExerisKernelException;
+
+/**
+ * Package-private top-level JSON line builder for {@link Slf4jTelemetrySink}.
+ *
+ * <p>Extracted from {@link Slf4jTelemetrySink} in v0.8 Sprint 1 (QA-012) as the
+ * top entry of the JSON serialization split. Composes the canonical six-field
+ * event line ({@code timestamp/level/code/component/message/rawArgs}) and
+ * delegates string escaping to {@link Slf4jTelemetryJsonEscaper} and rawArgs
+ * walking to {@link Slf4jTelemetryRawArgsWriter}.
+ *
+ * <p>Disclosure-aware: when an {@link ExerisKernelException} is present the
+ * profile-driven {@link ExceptionDisclosure} rules govern both the rendered
+ * message and the rawArgs payload.</p>
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals") // JSON syntax tokens ("\":\"", "\",\"") repeat per spec.
+final class Slf4jTelemetryJsonWriter {
+
+    private Slf4jTelemetryJsonWriter() {
+        // package-private static utility — never instantiated.
+    }
+
+    /* default */ static String buildJsonLine(
+            String resolvedLevelName,
+            String code,
+            String component,
+            String timestamp,
+            ExerisKernelException exception,
+            KernelProfile profile) {
+        String message = buildStructuredMessage(exception, profile);
+        Object[] disclosed = exception == null
+                ? null
+                : ExceptionDisclosure.discloseRawArgs(exception, profile);
+        String rawArgs = Slf4jTelemetryRawArgsWriter.buildStructuredRawArgsJson(disclosed);
+        return "{"
+                + "\"timestamp\":\"" + Slf4jTelemetryJsonEscaper.escapeJson(timestamp) + "\","
+                + "\"level\":\"" + Slf4jTelemetryJsonEscaper.escapeJson(resolvedLevelName) + "\","
+                + "\"code\":\"" + Slf4jTelemetryJsonEscaper.escapeJson(code) + "\","
+                + "\"component\":\"" + Slf4jTelemetryJsonEscaper.escapeJson(component) + "\","
+                + "\"message\":\"" + Slf4jTelemetryJsonEscaper.escapeJson(message) + "\","
+                + "\"rawArgs\":" + rawArgs
+                + "}";
+    }
+
+    private static String buildStructuredMessage(ExerisKernelException exception, KernelProfile profile) {
+        if (exception == null) {
+            return "";
+        }
+        String disclosed = ExceptionDisclosure.discloseMessage(exception, profile);
+        if (disclosed != null && !disclosed.isBlank()) {
+            return disclosed;
+        }
+        String fallback = exception.getClass().getSimpleName();
+        return fallback != null ? fallback : "";
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryLogLevelResolver.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryLogLevelResolver.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.telemetry;
+
+import eu.exeris.kernel.spi.telemetry.EventLevel;
+
+/**
+ * Package-private log-level routing helper for {@link Slf4jTelemetrySink}.
+ *
+ * <p>Extracted from {@link Slf4jTelemetrySink} in v0.8 Sprint 1 (QA-012) to close
+ * {@code PMD.GodClass} + {@code PMD.CyclomaticComplexity} suppressions. JSON line
+ * construction is handled separately by {@link Slf4jTelemetryJsonWriter}.
+ *
+ * <p>Resolution combines two signals — the event's declared {@link EventLevel} and
+ * the EX-prefix of its code — and takes the higher of the two so a low-priority
+ * declared level cannot mask a critical code family (e.g., an {@code INFO}-level
+ * event with code {@code EX-MEM-1003} still emits at {@code ERROR}).
+ */
+final class Slf4jTelemetryLogLevelResolver {
+
+    private static final String[] ERROR_CODE_PREFIXES = {
+        "EX-MEM-", "EX-BOOT-", "EX-SEC-", "EX-PERS-", "EX-CFG-", "EX-GRPH-", "EX-HTTP-"
+    };
+
+    private static final String[] WARN_CODE_PREFIXES = {
+        "EX-NET-", "EX-RUN-", "EX-EVENT-", "EX-FLOW-"
+    };
+
+    private Slf4jTelemetryLogLevelResolver() {
+        // package-private static utility — never instantiated.
+    }
+
+    /* default */ static LogLevel resolve(EventLevel eventLevel, String code) {
+        LogLevel mappedByEvent = mapEventLevel(eventLevel);
+        LogLevel mappedByCode = mapCodeLevel(code);
+        return mappedByEvent.ordinal() >= mappedByCode.ordinal() ? mappedByEvent : mappedByCode;
+    }
+
+    private static LogLevel mapEventLevel(EventLevel eventLevel) {
+        return switch (eventLevel) {
+            case INFO -> LogLevel.INFO;
+            case WARN -> LogLevel.WARN;
+            case ERROR, FATAL -> LogLevel.ERROR;
+        };
+    }
+
+    private static LogLevel mapCodeLevel(String code) {
+        if (matchesAnyPrefix(code, ERROR_CODE_PREFIXES)) {
+            return LogLevel.ERROR;
+        }
+        if (matchesAnyPrefix(code, WARN_CODE_PREFIXES)) {
+            return LogLevel.WARN;
+        }
+        return LogLevel.INFO;
+    }
+
+    private static boolean matchesAnyPrefix(String code, String... prefixes) {
+        for (String prefix : prefixes) {
+            if (code.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* default */ enum LogLevel {
+        INFO,
+        WARN,
+        ERROR
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryRawArgsWriter.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetryRawArgsWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.telemetry;
+
+/**
+ * Package-private rawArgs JSON-array writer for {@link Slf4jTelemetrySink}.
+ *
+ * <p>Extracted from {@link Slf4jTelemetrySink} in v0.8 Sprint 1 (QA-012) as the
+ * middle layer of the JSON serialization split. Walks the disclosed rawArgs
+ * array and serializes each element to JSON; delegates string escaping to
+ * {@link Slf4jTelemetryJsonEscaper}.
+ *
+ * <p>Supported element types: boxed primitives, {@code String}, {@code Character},
+ * {@code Enum}, and arrays of any of the above (recursive). Unknown types are
+ * serialized as the literal string {@code "[unsupported]"}.</p>
+ */
+@SuppressWarnings({
+    "PMD.CyclomaticComplexity",   // boxed-primitive ladder is exhaustive and flat by design.
+    "PMD.UseVarargs"              // Object[] is the disclosed rawArgs payload passed verbatim from the caller.
+})
+final class Slf4jTelemetryRawArgsWriter {
+
+    private Slf4jTelemetryRawArgsWriter() {
+        // package-private static utility — never instantiated.
+    }
+
+    /* default */ static String buildStructuredRawArgsJson(Object[] rawArgs) {
+        if (rawArgs == null || rawArgs.length == 0) {
+            return "[]";
+        }
+        StringBuilder builder = new StringBuilder(rawArgs.length * 16);
+        builder.append('[');
+        for (int index = 0; index < rawArgs.length; index++) {
+            if (index > 0) {
+                builder.append(',');
+            }
+            appendStructuredRawArg(builder, rawArgs[index]);
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private static void appendStructuredRawArg(StringBuilder builder, Object value) {
+        if (value == null) {
+            builder.append("null");
+            return;
+        }
+        if (value instanceof Boolean || value instanceof Byte || value instanceof Short
+                || value instanceof Integer || value instanceof Long) {
+            builder.append(value);
+            return;
+        }
+        if (value instanceof Float floatValue) {
+            appendFiniteOrString(builder, floatValue, Float.isFinite(floatValue));
+            return;
+        }
+        if (value instanceof Double doubleValue) {
+            appendFiniteOrString(builder, doubleValue, Double.isFinite(doubleValue));
+            return;
+        }
+        if (value instanceof String stringValue) {
+            Slf4jTelemetryJsonEscaper.appendJsonString(builder, stringValue);
+            return;
+        }
+        if (value instanceof Character characterValue) {
+            Slf4jTelemetryJsonEscaper.appendJsonString(builder, characterValue.toString());
+            return;
+        }
+        if (value instanceof Enum<?> enumValue) {
+            Slf4jTelemetryJsonEscaper.appendJsonString(builder, enumValue.name());
+            return;
+        }
+        if (value.getClass().isArray()) {
+            appendStructuredArray(builder, value);
+            return;
+        }
+        Slf4jTelemetryJsonEscaper.appendJsonString(builder, "[unsupported]");
+    }
+
+    private static void appendFiniteOrString(StringBuilder builder, float value, boolean isFinite) {
+        if (isFinite) {
+            builder.append(value);
+        } else {
+            Slf4jTelemetryJsonEscaper.appendJsonString(builder, Float.toString(value));
+        }
+    }
+
+    private static void appendFiniteOrString(StringBuilder builder, double value, boolean isFinite) {
+        if (isFinite) {
+            builder.append(value);
+        } else {
+            Slf4jTelemetryJsonEscaper.appendJsonString(builder, Double.toString(value));
+        }
+    }
+
+    private static void appendStructuredArray(StringBuilder builder, Object array) {
+        int length = java.lang.reflect.Array.getLength(array);
+        builder.append('[');
+        for (int index = 0; index < length; index++) {
+            if (index > 0) {
+                builder.append(',');
+            }
+            appendStructuredRawArg(builder, java.lang.reflect.Array.get(array, index));
+        }
+        builder.append(']');
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetrySink.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/Slf4jTelemetrySink.java
@@ -8,10 +8,10 @@
  */
 package eu.exeris.kernel.community.telemetry;
 
+import eu.exeris.kernel.community.telemetry.Slf4jTelemetryLogLevelResolver.LogLevel;
 import eu.exeris.kernel.spi.config.KernelProfile;
 import eu.exeris.kernel.spi.exceptions.ExceptionDisclosure;
 import eu.exeris.kernel.spi.exceptions.ExerisKernelException;
-import eu.exeris.kernel.spi.telemetry.EventLevel;
 import eu.exeris.kernel.spi.telemetry.KernelEvent;
 import eu.exeris.kernel.spi.telemetry.TelemetrySink;
 import org.slf4j.Logger;
@@ -44,23 +44,24 @@ import java.util.function.Supplier;
  * only at the outermost emit boundary (try/finally) and is an intrinsic edge concern
  * of SLF4J structured logging — not kernel context propagation.</p>
  *
+ * <h2>Decomposition (v0.8 Sprint 1 QA-012)</h2>
+ * <p>JSON line construction is delegated to {@link Slf4jTelemetryJsonWriter}; log-level
+ * routing is delegated to {@link Slf4jTelemetryLogLevelResolver}. This sink owns the
+ * emit lifecycle (closed-flag guard, MDC scope, log adapter routing) and the
+ * test-facing adapter/scope interfaces. The split closes {@code PMD.GodClass} +
+ * {@code PMD.TooManyMethods} + {@code PMD.CyclomaticComplexity} suppressions
+ * previously held on this class.
+ *
  * @since 0.5.0
  */
 @SuppressWarnings({
-    "PMD.CyclomaticComplexity",
-    "PMD.TooManyMethods",
-    "PMD.GodClass",         // high WMC from JSON serialization; no clean decomposition without allocation
-    "PMD.UseTryWithResources",
-    "PMD.CloseResource",
-    "PMD.AvoidDuplicateLiterals",
-    "PMD.UseVarargs",
-    "PMD.ImplicitFunctionalInterface"
+    "PMD.UseTryWithResources",   // MDC scope close order is explicit (LIFO) — try-with-resources cannot express.
+    "PMD.CloseResource"          // MdcScope is an AutoCloseable lambda — PMD doesn't track lambda close semantics.
 })
 public final class Slf4jTelemetrySink implements TelemetrySink {
 
     private static final String DEFAULT_CODE = "EX-UNK-0000";
     private static final String SINK_NAME = "ExerisCommunity/Slf4jTelemetrySink";
-    private static final char FIRST_PRINTABLE_ASCII = 0x20;
 
     private final LogAdapter logger;
     private final MdcAdapter mdc;
@@ -94,7 +95,7 @@ public final class Slf4jTelemetrySink implements TelemetrySink {
 
         String code = sanitizeCode(event.code());
         String component = sanitizeNullable(event.component());
-        LogLevel resolvedLevel = resolveLogLevel(event.level(), code);
+        LogLevel resolvedLevel = Slf4jTelemetryLogLevelResolver.resolve(event.level(), code);
         String resolvedLevelName = resolvedLevel.name();
         String timestamp = event.timestamp().toString();
         ExerisKernelException exception = event.exception();
@@ -105,7 +106,8 @@ public final class Slf4jTelemetrySink implements TelemetrySink {
 
         MdcScope mdcScope = pushMdc(code, resolvedLevelName, component, timestamp);
         try {
-            String json = buildJsonLine(resolvedLevelName, code, component, timestamp, exception, profile);
+            String json = Slf4jTelemetryJsonWriter.buildJsonLine(
+                    resolvedLevelName, code, component, timestamp, exception, profile);
             switch (resolvedLevel) {
                 case INFO -> logger.info(json, disclosedThrowable);
                 case WARN -> logger.warn(json, disclosedThrowable);
@@ -169,152 +171,6 @@ public final class Slf4jTelemetrySink implements TelemetrySink {
         closed = true;
     }
 
-    private static String buildJsonLine(
-            String resolvedLevelName,
-            String code,
-            String component,
-            String timestamp,
-            ExerisKernelException exception,
-            KernelProfile profile) {
-        String message = buildStructuredMessage(exception, profile);
-        Object[] disclosed = exception == null
-                ? null
-                : ExceptionDisclosure.discloseRawArgs(exception, profile);
-        String rawArgs = buildStructuredRawArgsJson(disclosed);
-        return "{"
-                + "\"timestamp\":\"" + escapeJson(timestamp) + "\","
-                + "\"level\":\"" + escapeJson(resolvedLevelName) + "\","
-                + "\"code\":\"" + escapeJson(code) + "\","
-                + "\"component\":\"" + escapeJson(component) + "\","
-                + "\"message\":\"" + escapeJson(message) + "\","
-                + "\"rawArgs\":" + rawArgs
-                + "}";
-    }
-
-    private static String buildStructuredMessage(ExerisKernelException exception, KernelProfile profile) {
-        if (exception == null) {
-            return "";
-        }
-        String disclosed = ExceptionDisclosure.discloseMessage(exception, profile);
-        if (disclosed != null && !disclosed.isBlank()) {
-            return disclosed;
-        }
-        String fallback = exception.getClass().getSimpleName();
-        return fallback != null ? fallback : "";
-    }
-
-    private static LogLevel resolveLogLevel(EventLevel eventLevel, String code) {
-        LogLevel mappedByEvent = mapEventLevel(eventLevel);
-        LogLevel mappedByCode = mapCodeLevel(code);
-        return mappedByEvent.ordinal() >= mappedByCode.ordinal() ? mappedByEvent : mappedByCode;
-    }
-
-    private static LogLevel mapEventLevel(EventLevel eventLevel) {
-        return switch (eventLevel) {
-            case INFO -> LogLevel.INFO;
-            case WARN -> LogLevel.WARN;
-            case ERROR, FATAL -> LogLevel.ERROR;
-        };
-    }
-
-    private static LogLevel mapCodeLevel(String code) {
-        if (code.startsWith("EX-MEM-") || code.startsWith("EX-BOOT-") || code.startsWith("EX-SEC-")
-                || code.startsWith("EX-PERS-") || code.startsWith("EX-CFG-")
-                || code.startsWith("EX-GRPH-") || code.startsWith("EX-HTTP-")) {
-            return LogLevel.ERROR;
-        }
-        if (code.startsWith("EX-NET-") || code.startsWith("EX-RUN-")
-                || code.startsWith("EX-EVENT-") || code.startsWith("EX-FLOW-")) {
-            return LogLevel.WARN;
-        }
-        return LogLevel.INFO;
-    }
-
-    private static String buildStructuredRawArgsJson(Object[] rawArgs) {
-        if (rawArgs == null || rawArgs.length == 0) {
-            return "[]";
-        }
-        StringBuilder builder = new StringBuilder(rawArgs.length * 16);
-        builder.append('[');
-        for (int index = 0; index < rawArgs.length; index++) {
-            if (index > 0) {
-                builder.append(',');
-            }
-            appendStructuredRawArg(builder, rawArgs[index]);
-        }
-        builder.append(']');
-        return builder.toString();
-    }
-
-    private static void appendStructuredRawArg(StringBuilder builder, Object value) {
-        if (value == null) {
-            builder.append("null");
-            return;
-        }
-        if (value instanceof Boolean || value instanceof Byte || value instanceof Short
-                || value instanceof Integer || value instanceof Long) {
-            builder.append(value);
-            return;
-        }
-        if (value instanceof Float floatValue) {
-            appendFiniteOrString(builder, floatValue, Float.isFinite(floatValue));
-            return;
-        }
-        if (value instanceof Double doubleValue) {
-            appendFiniteOrString(builder, doubleValue, Double.isFinite(doubleValue));
-            return;
-        }
-        if (value instanceof String stringValue) {
-            appendJsonString(builder, stringValue);
-            return;
-        }
-        if (value instanceof Character characterValue) {
-            appendJsonString(builder, characterValue.toString());
-            return;
-        }
-        if (value instanceof Enum<?> enumValue) {
-            appendJsonString(builder, enumValue.name());
-            return;
-        }
-        if (value.getClass().isArray()) {
-            appendStructuredArray(builder, value);
-            return;
-        }
-        appendJsonString(builder, "[unsupported]");
-    }
-
-    private static void appendFiniteOrString(StringBuilder builder, float value, boolean isFinite) {
-        if (isFinite) {
-            builder.append(value);
-        } else {
-            appendJsonString(builder, Float.toString(value));
-        }
-    }
-
-    private static void appendFiniteOrString(StringBuilder builder, double value, boolean isFinite) {
-        if (isFinite) {
-            builder.append(value);
-        } else {
-            appendJsonString(builder, Double.toString(value));
-        }
-    }
-
-    private static void appendStructuredArray(StringBuilder builder, Object array) {
-        int length = java.lang.reflect.Array.getLength(array);
-        builder.append('[');
-        for (int index = 0; index < length; index++) {
-            if (index > 0) {
-                builder.append(',');
-            }
-            appendStructuredRawArg(builder, java.lang.reflect.Array.get(array, index));
-        }
-        builder.append(']');
-    }
-
-    private static void appendJsonString(StringBuilder builder, String value) {
-        builder.append('"').append(escapeJson(value)).append('"');
-    }
-
     private static String sanitizeCode(String code) {
         if (code == null || code.isBlank()) {
             return DEFAULT_CODE;
@@ -326,44 +182,6 @@ public final class Slf4jTelemetrySink implements TelemetrySink {
         return value == null ? "" : value;
     }
 
-    private static String escapeJson(String value) {
-        StringBuilder escaped = new StringBuilder(value.length() + 8);
-        for (int index = 0; index < value.length(); index++) {
-            char current = value.charAt(index);
-            switch (current) {
-                case '"' -> escaped.append("\\\"");
-                case '\\' -> escaped.append("\\\\");
-                case '\b' -> escaped.append("\\b");
-                case '\f' -> escaped.append("\\f");
-                case '\n' -> escaped.append("\\n");
-                case '\r' -> escaped.append("\\r");
-                case '\t' -> escaped.append("\\t");
-                default -> {
-                    if (current < FIRST_PRINTABLE_ASCII) {
-                        appendUnicodeEscape(escaped, current);
-                    } else {
-                        escaped.append(current);
-                    }
-                }
-            }
-        }
-        return escaped.toString();
-    }
-
-    private static void appendUnicodeEscape(StringBuilder builder, char value) {
-        builder.append("\\u00");
-        int high = (value >> 4) & 0x0F;
-        int low = value & 0x0F;
-        builder.append((char) (high < 10 ? '0' + high : 'a' + high - 10))
-               .append((char) (low < 10 ? '0' + low : 'a' + low - 10));
-    }
-
-    /* default */ enum LogLevel {
-        INFO,
-        WARN,
-        ERROR
-    }
-
     /* default */ interface LogAdapter {
         void info(String message, Throwable throwable);
 
@@ -372,11 +190,13 @@ public final class Slf4jTelemetrySink implements TelemetrySink {
         void error(String message, Throwable throwable);
     }
 
-    /* default */ interface MdcAdapter {
+    /* default */ @FunctionalInterface
+    interface MdcAdapter {
         MdcScope put(String key, String value);
     }
 
-    /* default */ interface MdcScope extends AutoCloseable {
+    /* default */ @FunctionalInterface
+    interface MdcScope extends AutoCloseable {
 
         @Override
         void close();


### PR DESCRIPTION
## Summary

Sprint 1 continuation after #119 (QA-010 PersistenceEngine) and #122 (QA-011 HttpRequestProcessor). Closes the third PMD `GodClass` of the sprint by splitting `Slf4jTelemetrySink` (429 LOC, 8-suppression class-level block) along its JSON serialization seam.

**3-way split of the JSON concern:**

- `Slf4jTelemetryJsonEscaper` — leaf string-escape helper (`escapeJson` + `appendJsonString` + `appendUnicodeEscape`)
- `Slf4jTelemetryRawArgsWriter` — middle layer rawArgs JSON-array writer; delegates string escaping to JsonEscaper
- `Slf4jTelemetryJsonWriter` — top entry composing the canonical six-field event line; delegates to the two helpers

**Separate extraction along log-level routing seam:**

- `Slf4jTelemetryLogLevelResolver` — EX-prefix → `LogLevel` mapping via static prefix table (CC drops from 12 to 2 on `mapCodeLevel`)

**Slf4jTelemetrySink retains:**

- emit lifecycle (closed-flag guard, MDC scope, log adapter routing)
- no-op `increment` / `gauge` / `latency` (contract preserved per Javadoc)
- test-facing `LogAdapter` / `MdcAdapter` / `MdcScope` interfaces + `Slf4j*` impls

**Public API surface unchanged.**

## Suppressions delta on the sink

**Removed (6):**

- `PMD.GodClass`
- `PMD.TooManyMethods`
- `PMD.CyclomaticComplexity`
- `PMD.AvoidDuplicateLiterals`
- `PMD.UseVarargs`
- `PMD.ImplicitFunctionalInterface`

**Retained (2) with explicit inline rationale:**

- `PMD.UseTryWithResources` — MDC scope close order is explicit LIFO; try-with-resources cannot express
- `PMD.CloseResource` — `MdcScope` is an `AutoCloseable` lambda; PMD doesn't track lambda close semantics

**On new helpers (targeted suppressions, all with inline rationale):**

- `Slf4jTelemetryJsonEscaper.escapeJson` — `PMD.CyclomaticComplexity` (JSON escape table is spec-defined exhaustive case list)
- `Slf4jTelemetryJsonWriter` (class) — `PMD.AvoidDuplicateLiterals` (JSON syntax tokens repeat per spec)
- `Slf4jTelemetryRawArgsWriter` (class) — `PMD.CyclomaticComplexity` (boxed-primitive ladder is exhaustive and flat by design) + `PMD.UseVarargs` (`Object[]` is the disclosed rawArgs payload passed verbatim from the caller)

**Mdc* interfaces** now `@FunctionalInterface` annotated (intent clarification — they were already SAM types via lambda usage).

## Test plan

- [x] `Slf4jTelemetrySinkTckTest` 8/8 green (TCK contract via `AbstractTelemetrySinkTck`)
- [x] `Slf4jTelemetrySinkTest$ExMapping` 5/5 green (EX-prefix → log level routing)
- [x] `Slf4jTelemetrySinkTest$Lifecycle` 1/1 green
- [x] `Slf4jTelemetrySinkDisclosureTest` 3/3 green (DEV/PROD/TEST profile disclosure)
- [x] Full reactor verify SUCCESS (SPI + TCK + Core + Community Testkit + Community + Build Config + Parent + Root)
- [x] PMD 0 violations on community module
- [x] Checkstyle 0 violations on community module
- [x] No test-side changes — nested `LogAdapter` / `MdcAdapter` / `MdcScope` test extension surface preserved verbatim

## Sprint 1 cumulative GodClass closure (after this PR)

| QA-* | Class | LOC | PR |
|------|-------|-----|-----|
| QA-010 | `CommunityPersistenceEngine` | 565→403 | #119 (merged) |
| QA-011 | `CommunityHttpRequestProcessor` | 408→258 | #122 (merged) |
| **QA-012** | **`Slf4jTelemetrySink`** | **429→218** | **this PR** |
| QA-013 | `NativeTcpCarrier` (1376 LOC, HEUR-061 carry-over) | next |
| QA-014 | `OutboxOrchestrator` | next |

3 GodClass markers closed cumulatively; target after Sprint 1 = -5 GodClass markers from v0.7.0 baseline (213 total suppressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)