### PR TITLE
v0.8 Sprint 1 (QA-013a): extract NativeTcpSocketBackend + NativeTcpSocketProbe from NativeTcpCarrier

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -14,8 +14,6 @@ import eu.exeris.kernel.core.memory.WatermarkManager;
 import eu.exeris.kernel.core.transport.scheduler.AdmissionController;
 import eu.exeris.kernel.core.transport.scheduler.PaqsScheduler;
 import eu.exeris.kernel.core.transport.scheduler.StreamLoadShedder;
-import eu.exeris.kernel.core.transport.syscall.CoreSyscallLoader;
-import eu.exeris.kernel.core.transport.syscall.SyscallHandles;
 import eu.exeris.kernel.spi.crypto.CryptoProviderConfig;
 import eu.exeris.kernel.spi.crypto.KernelCryptoProvider;
 import eu.exeris.kernel.spi.crypto.TlsEngine;
@@ -33,10 +31,6 @@ import eu.exeris.kernel.spi.transport.TransportStats;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 
 import java.io.IOException;
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.CancelledKeyException;
@@ -47,7 +41,6 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
@@ -80,25 +73,6 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     private static final System.Logger LOG = System.getLogger(NativeTcpCarrier.class.getName());
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
-    private static final String SOCKET_BACKEND_PROPERTY = "exeris.community.transport.socket.backend";
-    private static final String SOCKET_BACKEND_ENV = "EXERIS_COMMUNITY_TRANSPORT_SOCKET_BACKEND";
-    private static final String SOCKET_BACKEND_ENV_ALIAS = "SOCKET_BACKEND_ENV";
-    private static final String SOCKET_BACKEND_AUTO = "auto";
-    private static final String SOCKET_BACKEND_NIO = "nio";
-    private static final String SOCKET_BACKEND_POSIX_HYBRID = "posix-hybrid";
-    private static final String ACTIVE_NIO_FALLBACK_DETAIL = "continuing on the active NIO fallback.";
-    private static final String LOOPBACK_HOST = InetAddress.getLoopbackAddress().getHostAddress();
-    private static final byte LOOPBACK_FIRST_OCTET = 127;
-    private static final byte LOOPBACK_SECOND_OCTET = 0;
-    private static final byte LOOPBACK_THIRD_OCTET = 0;
-    private static final byte LOOPBACK_FOURTH_OCTET = 1;
-    private static final int AF_INET = 2;
-    private static final int SOCK_STREAM = 1;
-    private static final int DEFAULT_IP_PROTOCOL = 0;
-    private static final int SOCKADDR_IN_SIZE = 16;
-    private static final boolean SOCKADDR_INCLUDES_LENGTH = usesBsdSockaddrLayout();
-    private static final boolean IS_WINDOWS_RUNTIME =
-            System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
     private static final long CLIENT_TLS_INGRESS_IDLE_BACKOFF_INITIAL_NANOS = 250_000L;
     private static final long CLIENT_TLS_INGRESS_IDLE_BACKOFF_MAX_NANOS = 2_000_000L;
     private static final long CLIENT_WRITER_BACKOFF_INITIAL_NANOS = 250_000L;
@@ -110,17 +84,10 @@ public final class NativeTcpCarrier implements TransportEngine {
     private final MemoryAllocator allocator;
     private final KernelCryptoProvider cryptoProvider;
     private final CryptoProviderConfig cryptoConfig;
-    private final SocketBackendMode requestedSocketBackend;
-    private final Arena socketBackendArena;
-    private final SyscallHandles socketHandles;
-    private final boolean ffmSocketBackendArmed;
+    private final NativeTcpSocketBackend backend;
 
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final AtomicBoolean serverSocketValidationAttempted = new AtomicBoolean(false);
-    private final AtomicBoolean serverSocketValidationSuccessful = new AtomicBoolean(false);
-    private final AtomicBoolean clientSocketValidationAttempted = new AtomicBoolean(false);
-    private final AtomicBoolean clientSocketValidationSuccessful = new AtomicBoolean(false);
 
     private final AtomicLong streamSeq = new AtomicLong(1);
     private final AtomicLong connectionSeq = new AtomicLong(1);
@@ -158,17 +125,13 @@ public final class NativeTcpCarrier implements TransportEngine {
         this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
         this.cryptoProvider = cryptoProvider;
         this.cryptoConfig = cryptoConfig;
-        SocketBackendSelection backendSelection = SocketBackendSelection.resolve();
-        this.requestedSocketBackend = backendSelection.requestedMode();
-        this.socketBackendArena = backendSelection.socketBackendArena();
-        this.socketHandles = backendSelection.socketHandles();
-        this.ffmSocketBackendArmed = backendSelection.ffmSocketBackendArmed();
+        this.backend = new NativeTcpSocketBackend();
         LOG.log(System.Logger.Level.INFO, () ->
                 "[NativeTcpCarrier] Community socket backend mode="
-                        + backendSelection.requestedMode().configValue()
-                        + ", active=" + activeSocketBackend()
-                        + ", ffmArmed=" + backendSelection.ffmSocketBackendArmed()
-                        + " - " + backendSelection.detail());
+                        + backend.requestedSocketBackend()
+                        + ", active=" + backend.activeSocketBackend()
+                        + ", ffmArmed=" + backend.isFfmSocketBackendArmed()
+                        + " - " + backend.detail());
     }
 
     @Override
@@ -254,7 +217,7 @@ public final class NativeTcpCarrier implements TransportEngine {
         SocketChannel channel = null;
         TlsEngine tlsEngine = null;
         try {
-            validateClientSocketBackendOnce(host, port);
+            backend.validateClientSocketBackendOnce(allocator, host, port);
             channel = SocketChannel.open();
             channel.configureBlocking(true);
             channel.connect(new InetSocketAddress(host, port));
@@ -279,7 +242,7 @@ public final class NativeTcpCarrier implements TransportEngine {
                     tlsEngine,
                     () -> requestClientWriteFlush(connectedChannel),
                     () -> onStreamClosed(connectedChannel),
-                    socketHandles);
+                    backend.socketHandles());
             if (tlsEngine instanceof eu.exeris.kernel.community.crypto.CommunityTlsEngine) {
                 stream.markTlsBoundFromCarrier();
             }
@@ -338,52 +301,31 @@ public final class NativeTcpCarrier implements TransportEngine {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
-        Arena arena = socketBackendArena;
-        try (arena) {
-            try {
-                stop();
-            } finally {
-                bestEffortWsaCleanup(socketHandles);
-            }
-        }
-    }
-
-    private static void bestEffortWsaCleanup(SyscallHandles handles) {
-        if (handles == null || !handles.hasWsaCleanup()) {
-            return;
-        }
         try {
-            handles.wsaCleanup().invokeExact();
-        } catch (Throwable _) {
-            // best effort
+            stop();
+        } finally {
+            backend.close();
         }
     }
 
     /* default */ String requestedSocketBackend() {
-        return requestedSocketBackend.configValue();
+        return backend.requestedSocketBackend();
     }
 
     /* default */ String activeSocketBackend() {
-        if (requestedSocketBackend == SocketBackendMode.NIO) {
-            return SOCKET_BACKEND_NIO;
-        }
-        return isPosixHybridBackendActive() ? SOCKET_BACKEND_POSIX_HYBRID : SOCKET_BACKEND_NIO;
-    }
-
-    private boolean isPosixHybridBackendActive() {
-        return ffmSocketBackendArmed;
+        return backend.activeSocketBackend();
     }
 
     /* default */ boolean isFfmSocketBackendArmed() {
-        return ffmSocketBackendArmed;
+        return backend.isFfmSocketBackendArmed();
     }
 
     /* default */ boolean isServerSocketValidationSuccessful() {
-        return serverSocketValidationSuccessful.get();
+        return backend.isServerSocketValidationSuccessful();
     }
 
     /* default */ boolean isClientSocketValidationSuccessful() {
-        return clientSocketValidationSuccessful.get();
+        return backend.isClientSocketValidationSuccessful();
     }
 
     /* default */ int listenerBacklog() {
@@ -412,7 +354,7 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     private void startServerRuntime() {
         try {
-            validateServerSocketBootstrapOnce();
+            backend.validateServerSocketBootstrapOnce(allocator);
             int reactorCount = Math.max(1, config.reactorCount());
             reactors.clear();
             for (int i = 0; i < reactorCount; i++) {
@@ -542,7 +484,7 @@ public final class NativeTcpCarrier implements TransportEngine {
                 tlsEngine,
                 () -> requestWriteInterest(channel),
                 () -> onStreamClosed(channel),
-                socketHandles);
+                backend.socketHandles());
         if (tlsEngine instanceof eu.exeris.kernel.community.crypto.CommunityTlsEngine) {
             stream.markTlsBoundFromCarrier();
         }
@@ -813,172 +755,6 @@ public final class NativeTcpCarrier implements TransportEngine {
         communityTlsEngine.bindFileDescriptor(SocketChannelFdAccess.requireFd(channel));
     }
 
-    private void validateServerSocketBootstrapOnce() {
-        if (!ffmSocketBackendArmed || !serverSocketValidationAttempted.compareAndSet(false, true)) {
-            return;
-        }
-        serverSocketValidationSuccessful.set(runServerSocketValidationProbe());
-        if (!serverSocketValidationSuccessful.get()) {
-            LOG.log(System.Logger.Level.DEBUG,
-                    "Core socket seam could not be validated for the server path; continuing on the active NIO path.");
-        }
-    }
-
-    private void validateClientSocketBackendOnce(String host, int port) {
-        if (!ffmSocketBackendArmed || !clientSocketValidationAttempted.compareAndSet(false, true)) {
-            return;
-        }
-        clientSocketValidationSuccessful.set(runClientSocketValidationProbe(host, port));
-        if (!clientSocketValidationSuccessful.get()) {
-            LOG.log(System.Logger.Level.DEBUG, () ->
-                    "Core socket seam could not be validated for the client path " + host + ':' + port
-                            + "; continuing on the active NIO path.");
-        }
-    }
-
-    private SyscallHandles resolvedSocketHandlesForValidation() {
-        if (!ffmSocketBackendArmed) {
-            return null;
-        }
-        SyscallHandles handles = this.socketHandles;
-        return handles != null && handles.supportsPlainSocketIo() ? handles : null;
-    }
-
-    private boolean runServerSocketValidationProbe() {
-        SyscallHandles handles = resolvedSocketHandlesForValidation();
-        return handles != null && validateServerSocketBootstrap(handles);
-    }
-
-    private boolean runClientSocketValidationProbe(String host, int port) {
-        SyscallHandles handles = resolvedSocketHandlesForValidation();
-        return handles != null && validateClientSocketConnect(handles, host, port);
-    }
-
-    private boolean validateServerSocketBootstrap(SyscallHandles handles) {
-        int socketFd = -1;
-        try (LoanedBuffer scratch = allocator.allocateInfrastructure(SOCKADDR_IN_SIZE)) {
-            socketFd = openPosixStreamSocket(handles);
-            MemorySegment sockaddr = scratch.segment().asSlice(0, SOCKADDR_IN_SIZE);
-            writeIpv4Sockaddr(sockaddr,
-                    0,
-                    LOOPBACK_FIRST_OCTET,
-                    LOOPBACK_SECOND_OCTET,
-                    LOOPBACK_THIRD_OCTET,
-                    LOOPBACK_FOURTH_OCTET);
-            return bindSocket(handles, socketFd, sockaddr) == 0
-                    && listenSocket(handles, socketFd) == 0;
-        } catch (RuntimeException _) {
-            LOG.log(System.Logger.Level.DEBUG,
-                    "Core socket server bootstrap probe failed; compatibility fallback remains active.");
-            return false;
-        } finally {
-            closePosixSocketQuietly(handles, socketFd);
-        }
-    }
-
-    private boolean validateClientSocketConnect(SyscallHandles handles, String host, int port) {
-        int socketFd = -1;
-        try (ServerSocketChannel probeListener = ServerSocketChannel.open();
-             LoanedBuffer scratch = allocator.allocateInfrastructure(SOCKADDR_IN_SIZE)) {
-            probeListener.bind(new InetSocketAddress(LOOPBACK_HOST, 0));
-            int probePort = ((InetSocketAddress) probeListener.getLocalAddress()).getPort();
-
-            socketFd = openPosixStreamSocket(handles);
-            MemorySegment sockaddr = scratch.segment().asSlice(0, SOCKADDR_IN_SIZE);
-            writeIpv4Sockaddr(sockaddr,
-                    probePort,
-                    LOOPBACK_FIRST_OCTET,
-                    LOOPBACK_SECOND_OCTET,
-                    LOOPBACK_THIRD_OCTET,
-                    LOOPBACK_FOURTH_OCTET);
-            if (connectSocket(handles, socketFd, sockaddr) != 0) {
-                return false;
-            }
-
-            try (SocketChannel accepted = probeListener.accept()) {
-                return accepted != null;
-            }
-        } catch (IOException | RuntimeException _) {
-            LOG.log(System.Logger.Level.DEBUG, () ->
-                    "Core socket client probe failed for " + host + ':' + port
-                            + "; compatibility fallback remains active.");
-            return false;
-        } finally {
-            closePosixSocketQuietly(handles, socketFd);
-        }
-    }
-
-    private static void writeIpv4Sockaddr(MemorySegment target,
-                                          int port,
-                                          byte firstOctet,
-                                          byte secondOctet,
-                                          byte thirdOctet,
-                                          byte fourthOctet) {
-        target.fill((byte) 0);
-        if (SOCKADDR_INCLUDES_LENGTH) {
-            target.set(ValueLayout.JAVA_BYTE, 0, (byte) SOCKADDR_IN_SIZE);
-            target.set(ValueLayout.JAVA_BYTE, 1, (byte) AF_INET);
-        } else {
-            target.set(ValueLayout.JAVA_SHORT, 0, (short) AF_INET);
-        }
-        target.set(ValueLayout.JAVA_BYTE, 2, (byte) ((port >>> 8) & 0xFF));
-        target.set(ValueLayout.JAVA_BYTE, 3, (byte) (port & 0xFF));
-        target.set(ValueLayout.JAVA_BYTE, 4, firstOctet);
-        target.set(ValueLayout.JAVA_BYTE, 5, secondOctet);
-        target.set(ValueLayout.JAVA_BYTE, 6, thirdOctet);
-        target.set(ValueLayout.JAVA_BYTE, 7, fourthOctet);
-    }
-
-    private static boolean usesBsdSockaddrLayout() {
-        String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-        return osName.contains("mac")
-                || osName.contains("darwin")
-                || osName.contains("bsd");
-    }
-
-    private static int openPosixStreamSocket(SyscallHandles handles) {
-        try {
-            return (int) handles.socket().invokeExact(AF_INET, SOCK_STREAM, DEFAULT_IP_PROTOCOL);
-        } catch (Throwable ex) {
-            throw new IllegalStateException("Core socket() probe failed", ex);
-        }
-    }
-
-    private static int bindSocket(SyscallHandles handles, int socketFd, MemorySegment sockaddr) {
-        try {
-            return (int) handles.bind().invokeExact(socketFd, sockaddr, SOCKADDR_IN_SIZE);
-        } catch (Throwable ex) {
-            throw new IllegalStateException("Core bind() probe failed", ex);
-        }
-    }
-
-    private static int connectSocket(SyscallHandles handles, int socketFd, MemorySegment sockaddr) {
-        try {
-            return (int) handles.connect().invokeExact(socketFd, sockaddr, SOCKADDR_IN_SIZE);
-        } catch (Throwable ex) {
-            throw new IllegalStateException("Core connect() probe failed", ex);
-        }
-    }
-
-    private static int listenSocket(SyscallHandles handles, int socketFd) {
-        try {
-            return (int) handles.listen().invokeExact(socketFd, 1);
-        } catch (Throwable ex) {
-            throw new IllegalStateException("Core listen() probe failed", ex);
-        }
-    }
-
-    private static void closePosixSocketQuietly(SyscallHandles handles, int socketFd) {
-        if (socketFd < 0) {
-            return;
-        }
-        try {
-            int _ = (int) handles.close().invokeExact(socketFd);
-        } catch (Throwable _) {
-            // best effort cleanup on the validation probe path
-        }
-    }
-
     private void closeSelectorAndChannels() {
         for (ChannelRuntimeRegistry.ChannelRuntimeState runtime : new ArrayList<>(runtimeByChannel.values())) {
             runtime.stream().close();
@@ -1026,157 +802,6 @@ public final class NativeTcpCarrier implements TransportEngine {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-    }
-
-    private enum SocketBackendMode {
-        AUTO(SOCKET_BACKEND_AUTO),
-        NIO(SOCKET_BACKEND_NIO),
-        POSIX_HYBRID(SOCKET_BACKEND_POSIX_HYBRID);
-
-        private final String configValue;
-
-        SocketBackendMode(String configValue) {
-            this.configValue = configValue;
-        }
-
-        private String configValue() {
-            return configValue;
-        }
-
-        private static SocketBackendMode resolveConfiguredMode() {
-            String configured = System.getProperty(SOCKET_BACKEND_PROPERTY);
-            if (configured == null || configured.isBlank()) {
-                configured = System.getProperty(SOCKET_BACKEND_ENV_ALIAS);
-            }
-            if (configured == null || configured.isBlank()) {
-                configured = System.getenv(SOCKET_BACKEND_ENV);
-            }
-            if (configured == null || configured.isBlank()) {
-                configured = System.getenv(SOCKET_BACKEND_ENV_ALIAS);
-            }
-            if (configured == null || configured.isBlank()) {
-                return AUTO;
-            }
-            return switch (configured.trim().toLowerCase(Locale.ROOT)) {
-                case SOCKET_BACKEND_AUTO -> AUTO;
-                case SOCKET_BACKEND_NIO -> NIO;
-                case SOCKET_BACKEND_POSIX_HYBRID -> POSIX_HYBRID;
-                default -> {
-                    String invalidMode = configured;
-                    LOG.log(System.Logger.Level.WARNING, () ->
-                            "Unknown Community socket backend mode '" + invalidMode + "'; defaulting to auto.");
-                    yield AUTO;
-                }
-            };
-        }
-    }
-
-    private record SocketBackendSelection(SocketBackendMode requestedMode,
-                                          Arena socketBackendArena,
-                                          SyscallHandles socketHandles,
-                                          boolean ffmSocketBackendArmed,
-                                          String detail) {
-
-        private static SocketBackendSelection resolve() {
-            SocketBackendMode configuredMode = SocketBackendMode.resolveConfiguredMode();
-            if (configuredMode == SocketBackendMode.NIO) {
-                return new SocketBackendSelection(
-                        configuredMode,
-                        null,
-                        null,
-                        false,
-                        "NIO backend pinned explicitly; Core syscall load skipped.");
-            }
-            if (IS_WINDOWS_RUNTIME) {
-                String detail = configuredMode == SocketBackendMode.POSIX_HYBRID
-                        ? resolveRequestedFallbackDetail(true, true)
-                        : resolveAutoFallbackDetail(true, true);
-                return new SocketBackendSelection(configuredMode, null, null, false, detail);
-            }
-
-            //CHECKSTYLE:OFF
-            // Direct shared-arena allocation: the Community carrier is the sole owner of
-            // the socket backend seam lifetime. Shared scope is required because resolved
-            // syscall handles are used across transport threads, and carrier.close()
-            // deterministically closes this arena.
-            Arena arena = Arena.ofShared();
-            //CHECKSTYLE:ON
-            SyscallHandles handles = null;
-            try {
-                handles = CoreSyscallLoader.load(arena);
-            } catch (IllegalCallerException | IllegalStateException | UnsupportedOperationException ex) {
-                LOG.log(System.Logger.Level.DEBUG,
-                        "[NativeTcpCarrier] Community-owned Core socket load unavailable; continuing on NIO fallback.",
-                        ex);
-            }
-
-            if (handles == null) {
-                closeQuietly(arena);
-                String detail;
-                if (configuredMode == SocketBackendMode.POSIX_HYBRID) {
-                    detail = "Core socket seam was requested explicitly but is unavailable; "
-                            + ACTIVE_NIO_FALLBACK_DETAIL;
-                } else {
-                    detail = "Core socket seam probe unavailable on this platform; "
-                            + ACTIVE_NIO_FALLBACK_DETAIL;
-                }
-                return new SocketBackendSelection(configuredMode, null, null, false, detail);
-            }
-
-            boolean plainSocketIoAvailable = handles.supportsPlainSocketIo();
-            boolean fdAccessAvailable = SocketChannelFdAccess.isRuntimeFdAccessAvailable();
-            boolean winsockModel = handles.hasIoctlsocket();
-            boolean seamArmed = plainSocketIoAvailable && fdAccessAvailable && !winsockModel;
-            String detail = resolveDetail(configuredMode, seamArmed, plainSocketIoAvailable, winsockModel);
-            return new SocketBackendSelection(configuredMode, arena, handles, seamArmed, detail);
-        }
-
-        private static String resolveDetail(SocketBackendMode configuredMode,
-                                            boolean seamArmed,
-                                            boolean plainSocketIoAvailable,
-                                            boolean winsockModel) {
-            if (seamArmed) {
-                return "Core socket seam armed for plain TCP traffic; "
-                        + "selector ownership and NIO fallback remain intact.";
-            }
-            if (configuredMode == SocketBackendMode.POSIX_HYBRID) {
-                return resolveRequestedFallbackDetail(plainSocketIoAvailable, winsockModel);
-            }
-            return resolveAutoFallbackDetail(plainSocketIoAvailable, winsockModel);
-        }
-
-        private static String resolveRequestedFallbackDetail(boolean plainSocketIoAvailable,
-                                                             boolean winsockModel) {
-            if (!plainSocketIoAvailable) {
-                return "Core socket seam was requested explicitly but is unavailable; "
-                        + ACTIVE_NIO_FALLBACK_DETAIL;
-            }
-            if (winsockModel) {
-                return "Core socket seam was requested explicitly but this platform uses the Winsock model; "
-                        + ACTIVE_NIO_FALLBACK_DETAIL;
-            }
-            return "Core socket seam was requested explicitly but "
-                    + "SocketChannel FD access is blocked by runtime openness; "
-                    + "add the required --add-opens flags or "
-                    + ACTIVE_NIO_FALLBACK_DETAIL;
-        }
-
-        private static String resolveAutoFallbackDetail(boolean plainSocketIoAvailable,
-                                                        boolean winsockModel) {
-            if (!plainSocketIoAvailable) {
-                return "Core socket seam resolved without plain socket syscall support; "
-                        + ACTIVE_NIO_FALLBACK_DETAIL;
-            }
-            if (winsockModel) {
-                return "Core socket seam resolved on a Winsock platform; "
-                        + ACTIVE_NIO_FALLBACK_DETAIL;
-            }
-            return "Core socket seam resolved but SocketChannel FD access "
-                    + "is blocked by runtime openness; "
-                    + "add the required --add-opens flags or "
-                    + ACTIVE_NIO_FALLBACK_DETAIL;
-        }
-
     }
 
     private enum ReactorRequestType {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpSocketBackend.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpSocketBackend.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import eu.exeris.kernel.community.crypto.SocketChannelFdAccess;
+import eu.exeris.kernel.core.transport.syscall.CoreSyscallLoader;
+import eu.exeris.kernel.core.transport.syscall.SyscallHandles;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.lang.foreign.Arena;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Community socket-backend selector and bootstrap-validation lifecycle owner.
+ *
+ * <p>Extracted from {@link NativeTcpCarrier} in v0.8 Sprint 1 (QA-013a). Owns:
+ *
+ * <ul>
+ *   <li>The {@link SocketBackendMode} selection from JVM property / env vars.</li>
+ *   <li>The {@link SocketBackendSelection} resolution result (mode + arena +
+ *       syscall handles + armed flag + diagnostic detail string).</li>
+ *   <li>The shared {@link Arena} that owns the syscall-handle lifetime
+ *       (deterministically closed by {@link #close()}).</li>
+ *   <li>The {@link AtomicBoolean} latches that turn first-server-start and
+ *       first-client-connect into one-shot validation triggers.</li>
+ * </ul>
+ *
+ * <p>Native socket helpers (FFM downcalls, sockaddr serialization, server/
+ * client probes) live in {@link NativeTcpSocketProbe}; this class only owns
+ * state and routes validation calls through to the probe helpers.
+ */
+final class NativeTcpSocketBackend {
+
+    /* default */ static final String SOCKET_BACKEND_PROPERTY = "exeris.community.transport.socket.backend";
+    /* default */ static final String SOCKET_BACKEND_ENV = "EXERIS_COMMUNITY_TRANSPORT_SOCKET_BACKEND";
+    /* default */ static final String SOCKET_BACKEND_ENV_ALIAS = "SOCKET_BACKEND_ENV";
+    /* default */ static final String SOCKET_BACKEND_AUTO = "auto";
+    /* default */ static final String SOCKET_BACKEND_NIO = "nio";
+    /* default */ static final String SOCKET_BACKEND_POSIX_HYBRID = "posix-hybrid";
+
+    private static final System.Logger LOG = System.getLogger(NativeTcpSocketBackend.class.getName());
+    private static final String ACTIVE_NIO_FALLBACK_DETAIL = "continuing on the active NIO fallback.";
+
+    private final SocketBackendSelection selection;
+    private final AtomicBoolean serverSocketValidationAttempted = new AtomicBoolean(false);
+    private final AtomicBoolean serverSocketValidationSuccessful = new AtomicBoolean(false);
+    private final AtomicBoolean clientSocketValidationAttempted = new AtomicBoolean(false);
+    private final AtomicBoolean clientSocketValidationSuccessful = new AtomicBoolean(false);
+
+    /* default */ NativeTcpSocketBackend() {
+        this.selection = SocketBackendSelection.resolve();
+    }
+
+    /* default */ String requestedSocketBackend() {
+        return selection.requestedMode().configValue();
+    }
+
+    /* default */ String activeSocketBackend() {
+        if (selection.requestedMode() == SocketBackendMode.NIO) {
+            return SOCKET_BACKEND_NIO;
+        }
+        return selection.ffmSocketBackendArmed() ? SOCKET_BACKEND_POSIX_HYBRID : SOCKET_BACKEND_NIO;
+    }
+
+    /* default */ boolean isFfmSocketBackendArmed() {
+        return selection.ffmSocketBackendArmed();
+    }
+
+    /* default */ boolean isServerSocketValidationSuccessful() {
+        return serverSocketValidationSuccessful.get();
+    }
+
+    /* default */ boolean isClientSocketValidationSuccessful() {
+        return clientSocketValidationSuccessful.get();
+    }
+
+    /* default */ SyscallHandles socketHandles() {
+        return selection.socketHandles();
+    }
+
+    /* default */ String detail() {
+        return selection.detail();
+    }
+
+    /* default */ void validateServerSocketBootstrapOnce(MemoryAllocator allocator) {
+        if (!isFfmSocketBackendArmed() || !serverSocketValidationAttempted.compareAndSet(false, true)) {
+            return;
+        }
+        SyscallHandles handles = resolvedSocketHandlesForValidation();
+        boolean successful = handles != null
+                && NativeTcpSocketProbe.validateServerSocketBootstrap(allocator, handles);
+        serverSocketValidationSuccessful.set(successful);
+        if (!successful) {
+            LOG.log(System.Logger.Level.DEBUG,
+                    "Core socket seam could not be validated for the server path; continuing on the active NIO path.");
+        }
+    }
+
+    /* default */ void validateClientSocketBackendOnce(MemoryAllocator allocator, String host, int port) {
+        if (!isFfmSocketBackendArmed() || !clientSocketValidationAttempted.compareAndSet(false, true)) {
+            return;
+        }
+        SyscallHandles handles = resolvedSocketHandlesForValidation();
+        boolean successful = handles != null
+                && NativeTcpSocketProbe.validateClientSocketConnect(allocator, handles, host, port);
+        clientSocketValidationSuccessful.set(successful);
+        if (!successful) {
+            LOG.log(System.Logger.Level.DEBUG, () ->
+                    "Core socket seam could not be validated for the client path " + host + ':' + port
+                            + "; continuing on the active NIO path.");
+        }
+    }
+
+    @SuppressWarnings("PMD.CloseResource") // arena is intentionally closed here as the seam's lifetime owner.
+    /* default */ void close() {
+        SyscallHandles handles = selection.socketHandles();
+        Arena arena = selection.socketBackendArena();
+        try {
+            if (arena != null) {
+                arena.close();
+            }
+        } finally {
+            NativeTcpSocketProbe.bestEffortWsaCleanup(handles);
+        }
+    }
+
+    private SyscallHandles resolvedSocketHandlesForValidation() {
+        if (!isFfmSocketBackendArmed()) {
+            return null;
+        }
+        SyscallHandles handles = selection.socketHandles();
+        return handles != null && handles.supportsPlainSocketIo() ? handles : null;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException") // best-effort close swallows any cleanup exception.
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception _) {
+            // best effort
+        }
+    }
+
+    /* default */ enum SocketBackendMode {
+        AUTO(SOCKET_BACKEND_AUTO),
+        NIO(SOCKET_BACKEND_NIO),
+        POSIX_HYBRID(SOCKET_BACKEND_POSIX_HYBRID);
+
+        private final String configValue;
+
+        SocketBackendMode(String configValue) {
+            this.configValue = configValue;
+        }
+
+        /* default */ String configValue() {
+            return configValue;
+        }
+
+        @SuppressWarnings("PMD.CyclomaticComplexity") // 4-source property/env fallback ladder is intrinsic.
+        private static SocketBackendMode resolveConfiguredMode() {
+            String configured = System.getProperty(SOCKET_BACKEND_PROPERTY);
+            if (configured == null || configured.isBlank()) {
+                configured = System.getProperty(SOCKET_BACKEND_ENV_ALIAS);
+            }
+            if (configured == null || configured.isBlank()) {
+                configured = System.getenv(SOCKET_BACKEND_ENV);
+            }
+            if (configured == null || configured.isBlank()) {
+                configured = System.getenv(SOCKET_BACKEND_ENV_ALIAS);
+            }
+            if (configured == null || configured.isBlank()) {
+                return AUTO;
+            }
+            return switch (configured.trim().toLowerCase(Locale.ROOT)) {
+                case SOCKET_BACKEND_AUTO -> AUTO;
+                case SOCKET_BACKEND_NIO -> NIO;
+                case SOCKET_BACKEND_POSIX_HYBRID -> POSIX_HYBRID;
+                default -> {
+                    String invalidMode = configured;
+                    LOG.log(System.Logger.Level.WARNING, () ->
+                            "Unknown Community socket backend mode '" + invalidMode + "'; defaulting to auto.");
+                    yield AUTO;
+                }
+            };
+        }
+    }
+
+    /* default */ record SocketBackendSelection(SocketBackendMode requestedMode,
+                                                Arena socketBackendArena,
+                                                SyscallHandles socketHandles,
+                                                boolean ffmSocketBackendArmed,
+                                                String detail) {
+
+        /* default */ static SocketBackendSelection resolve() {
+            SocketBackendMode configuredMode = SocketBackendMode.resolveConfiguredMode();
+            if (configuredMode == SocketBackendMode.NIO) {
+                return new SocketBackendSelection(
+                        configuredMode,
+                        null,
+                        null,
+                        false,
+                        "NIO backend pinned explicitly; Core syscall load skipped.");
+            }
+            if (NativeTcpSocketProbe.IS_WINDOWS_RUNTIME) {
+                String detail = configuredMode == SocketBackendMode.POSIX_HYBRID
+                        ? resolveRequestedFallbackDetail(true, true)
+                        : resolveAutoFallbackDetail(true, true);
+                return new SocketBackendSelection(configuredMode, null, null, false, detail);
+            }
+
+            //CHECKSTYLE:OFF
+            // Direct shared-arena allocation: the Community carrier is the sole owner of
+            // the socket backend seam lifetime. Shared scope is required because resolved
+            // syscall handles are used across transport threads, and the backend's
+            // close() deterministically closes this arena.
+            Arena arena = Arena.ofShared();
+            //CHECKSTYLE:ON
+            SyscallHandles handles = null;
+            try {
+                handles = CoreSyscallLoader.load(arena);
+            } catch (IllegalCallerException | IllegalStateException | UnsupportedOperationException ex) {
+                LOG.log(System.Logger.Level.DEBUG,
+                        "[NativeTcpSocketBackend] Community-owned Core socket load unavailable; "
+                                + "continuing on NIO fallback.",
+                        ex);
+            }
+
+            if (handles == null) {
+                closeQuietly(arena);
+                String detail;
+                if (configuredMode == SocketBackendMode.POSIX_HYBRID) {
+                    detail = "Core socket seam was requested explicitly but is unavailable; "
+                            + ACTIVE_NIO_FALLBACK_DETAIL;
+                } else {
+                    detail = "Core socket seam probe unavailable on this platform; "
+                            + ACTIVE_NIO_FALLBACK_DETAIL;
+                }
+                return new SocketBackendSelection(configuredMode, null, null, false, detail);
+            }
+
+            boolean plainSocketIoAvailable = handles.supportsPlainSocketIo();
+            boolean fdAccessAvailable = SocketChannelFdAccess.isRuntimeFdAccessAvailable();
+            boolean winsockModel = handles.hasIoctlsocket();
+            boolean seamArmed = plainSocketIoAvailable && fdAccessAvailable && !winsockModel;
+            String detail = resolveDetail(configuredMode, seamArmed, plainSocketIoAvailable, winsockModel);
+            return new SocketBackendSelection(configuredMode, arena, handles, seamArmed, detail);
+        }
+
+        private static String resolveDetail(SocketBackendMode configuredMode,
+                                            boolean seamArmed,
+                                            boolean plainSocketIoAvailable,
+                                            boolean winsockModel) {
+            if (seamArmed) {
+                return "Core socket seam armed for plain TCP traffic; "
+                        + "selector ownership and NIO fallback remain intact.";
+            }
+            if (configuredMode == SocketBackendMode.POSIX_HYBRID) {
+                return resolveRequestedFallbackDetail(plainSocketIoAvailable, winsockModel);
+            }
+            return resolveAutoFallbackDetail(plainSocketIoAvailable, winsockModel);
+        }
+
+        private static String resolveRequestedFallbackDetail(boolean plainSocketIoAvailable,
+                                                             boolean winsockModel) {
+            if (!plainSocketIoAvailable) {
+                return "Core socket seam was requested explicitly but is unavailable; "
+                        + ACTIVE_NIO_FALLBACK_DETAIL;
+            }
+            if (winsockModel) {
+                return "Core socket seam was requested explicitly but this platform uses the Winsock model; "
+                        + ACTIVE_NIO_FALLBACK_DETAIL;
+            }
+            return "Core socket seam was requested explicitly but "
+                    + "SocketChannel FD access is blocked by runtime openness; "
+                    + "add the required --add-opens flags or "
+                    + ACTIVE_NIO_FALLBACK_DETAIL;
+        }
+
+        private static String resolveAutoFallbackDetail(boolean plainSocketIoAvailable,
+                                                        boolean winsockModel) {
+            if (!plainSocketIoAvailable) {
+                return "Core socket seam resolved without plain socket syscall support; "
+                        + ACTIVE_NIO_FALLBACK_DETAIL;
+            }
+            if (winsockModel) {
+                return "Core socket seam resolved on a Winsock platform; "
+                        + ACTIVE_NIO_FALLBACK_DETAIL;
+            }
+            return "Core socket seam resolved but SocketChannel FD access "
+                    + "is blocked by runtime openness; "
+                    + "add the required --add-opens flags or "
+                    + ACTIVE_NIO_FALLBACK_DETAIL;
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpSocketProbe.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpSocketProbe.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import eu.exeris.kernel.core.transport.syscall.SyscallHandles;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Locale;
+
+/**
+ * Package-private static helpers for socket bootstrap validation probes.
+ *
+ * <p>Extracted from {@link NativeTcpSocketBackend} in v0.8 Sprint 1 (QA-013a)
+ * as the second-level split of the carrier's God-class suppression block.
+ * Owns the native socket FFM helpers ({@code socket()} / {@code bind()} /
+ * {@code connect()} / {@code listen()} / {@code close()}), the IPv4 sockaddr
+ * serializer, and the server/client validation probes that the backend invokes
+ * once on first server-start / first client-connect.
+ *
+ * <p>All entry points are static — no instance state lives in this class.
+ * Validation latches are held by {@link NativeTcpSocketBackend}.
+ */
+@SuppressWarnings({
+    "PMD.AvoidCatchingGenericException", // FFM downcalls throw Throwable; probes must catch defensively.
+    "PMD.LawOfDemeter"                   // probe uses NIO ServerSocketChannel.getLocalAddress for port discovery.
+})
+final class NativeTcpSocketProbe {
+
+    /* default */ static final String LOOPBACK_HOST = InetAddress.getLoopbackAddress().getHostAddress();
+    /* default */ static final boolean IS_WINDOWS_RUNTIME =
+            System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+
+    private static final System.Logger LOG = System.getLogger(NativeTcpSocketProbe.class.getName());
+    private static final byte LOOPBACK_FIRST_OCTET = 127;
+    private static final byte LOOPBACK_SECOND_OCTET = 0;
+    private static final byte LOOPBACK_THIRD_OCTET = 0;
+    private static final byte LOOPBACK_FOURTH_OCTET = 1;
+    private static final int AF_INET = 2;
+    private static final int SOCK_STREAM = 1;
+    private static final int DEFAULT_IP_PROTOCOL = 0;
+    private static final int SOCKADDR_IN_SIZE = 16;
+    private static final boolean SOCKADDR_INCLUDES_LENGTH = usesBsdSockaddrLayout();
+
+    private NativeTcpSocketProbe() {
+        // package-private static utility — never instantiated.
+    }
+
+    /* default */ static boolean validateServerSocketBootstrap(MemoryAllocator allocator, SyscallHandles handles) {
+        int socketFd = -1;
+        try (LoanedBuffer scratch = allocator.allocateInfrastructure(SOCKADDR_IN_SIZE)) {
+            socketFd = openPosixStreamSocket(handles);
+            MemorySegment sockaddr = scratch.segment().asSlice(0, SOCKADDR_IN_SIZE);
+            writeIpv4Sockaddr(sockaddr,
+                    0,
+                    LOOPBACK_FIRST_OCTET,
+                    LOOPBACK_SECOND_OCTET,
+                    LOOPBACK_THIRD_OCTET,
+                    LOOPBACK_FOURTH_OCTET);
+            return bindSocket(handles, socketFd, sockaddr) == 0
+                    && listenSocket(handles, socketFd) == 0;
+        } catch (RuntimeException _) {
+            LOG.log(System.Logger.Level.DEBUG,
+                    "Core socket server bootstrap probe failed; compatibility fallback remains active.");
+            return false;
+        } finally {
+            closePosixSocketQuietly(handles, socketFd);
+        }
+    }
+
+    /* default */ static boolean validateClientSocketConnect(MemoryAllocator allocator,
+                                                             SyscallHandles handles,
+                                                             String host,
+                                                             int port) {
+        int socketFd = -1;
+        try (ServerSocketChannel probeListener = ServerSocketChannel.open();
+             LoanedBuffer scratch = allocator.allocateInfrastructure(SOCKADDR_IN_SIZE)) {
+            probeListener.bind(new InetSocketAddress(LOOPBACK_HOST, 0));
+            int probePort = ((InetSocketAddress) probeListener.getLocalAddress()).getPort();
+
+            socketFd = openPosixStreamSocket(handles);
+            MemorySegment sockaddr = scratch.segment().asSlice(0, SOCKADDR_IN_SIZE);
+            writeIpv4Sockaddr(sockaddr,
+                    probePort,
+                    LOOPBACK_FIRST_OCTET,
+                    LOOPBACK_SECOND_OCTET,
+                    LOOPBACK_THIRD_OCTET,
+                    LOOPBACK_FOURTH_OCTET);
+            if (connectSocket(handles, socketFd, sockaddr) != 0) {
+                return false;
+            }
+
+            try (SocketChannel accepted = probeListener.accept()) {
+                return accepted != null;
+            }
+        } catch (IOException | RuntimeException _) {
+            LOG.log(System.Logger.Level.DEBUG, () ->
+                    "Core socket client probe failed for " + host + ':' + port
+                            + "; compatibility fallback remains active.");
+            return false;
+        } finally {
+            closePosixSocketQuietly(handles, socketFd);
+        }
+    }
+
+    /* default */ static void bestEffortWsaCleanup(SyscallHandles handles) {
+        if (handles == null || !handles.hasWsaCleanup()) {
+            return;
+        }
+        try {
+            handles.wsaCleanup().invokeExact();
+        } catch (Throwable _) {
+            // best effort
+        }
+    }
+
+    private static void writeIpv4Sockaddr(MemorySegment target,
+                                          int port,
+                                          byte firstOctet,
+                                          byte secondOctet,
+                                          byte thirdOctet,
+                                          byte fourthOctet) {
+        target.fill((byte) 0);
+        if (SOCKADDR_INCLUDES_LENGTH) {
+            target.set(ValueLayout.JAVA_BYTE, 0, (byte) SOCKADDR_IN_SIZE);
+            target.set(ValueLayout.JAVA_BYTE, 1, (byte) AF_INET);
+        } else {
+            target.set(ValueLayout.JAVA_SHORT, 0, (short) AF_INET);
+        }
+        target.set(ValueLayout.JAVA_BYTE, 2, (byte) ((port >>> 8) & 0xFF));
+        target.set(ValueLayout.JAVA_BYTE, 3, (byte) (port & 0xFF));
+        target.set(ValueLayout.JAVA_BYTE, 4, firstOctet);
+        target.set(ValueLayout.JAVA_BYTE, 5, secondOctet);
+        target.set(ValueLayout.JAVA_BYTE, 6, thirdOctet);
+        target.set(ValueLayout.JAVA_BYTE, 7, fourthOctet);
+    }
+
+    private static boolean usesBsdSockaddrLayout() {
+        String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return osName.contains("mac")
+                || osName.contains("darwin")
+                || osName.contains("bsd");
+    }
+
+    private static int openPosixStreamSocket(SyscallHandles handles) {
+        try {
+            return (int) handles.socket().invokeExact(AF_INET, SOCK_STREAM, DEFAULT_IP_PROTOCOL);
+        } catch (Throwable ex) {
+            throw new IllegalStateException("Core socket() probe failed", ex);
+        }
+    }
+
+    private static int bindSocket(SyscallHandles handles, int socketFd, MemorySegment sockaddr) {
+        try {
+            return (int) handles.bind().invokeExact(socketFd, sockaddr, SOCKADDR_IN_SIZE);
+        } catch (Throwable ex) {
+            throw new IllegalStateException("Core bind() probe failed", ex);
+        }
+    }
+
+    private static int connectSocket(SyscallHandles handles, int socketFd, MemorySegment sockaddr) {
+        try {
+            return (int) handles.connect().invokeExact(socketFd, sockaddr, SOCKADDR_IN_SIZE);
+        } catch (Throwable ex) {
+            throw new IllegalStateException("Core connect() probe failed", ex);
+        }
+    }
+
+    private static int listenSocket(SyscallHandles handles, int socketFd) {
+        try {
+            return (int) handles.listen().invokeExact(socketFd, 1);
+        } catch (Throwable ex) {
+            throw new IllegalStateException("Core listen() probe failed", ex);
+        }
+    }
+
+    private static void closePosixSocketQuietly(SyscallHandles handles, int socketFd) {
+        if (socketFd < 0) {
+            return;
+        }
+        try {
+            int _ = (int) handles.close().invokeExact(socketFd);
+        } catch (Throwable _) {
+            // best effort cleanup on the validation probe path
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First of a **multi-PR decomposition track** for `NativeTcpCarrier` (1381 LOC, 11 class-level PMD suppressions, HEUR-061 carry-over from v0.7 Sprint 8e). The carrier remains the `TransportEngine` implementation and composes the new helpers; future PRs will extract `ReactorLoop` (QA-013b) and client ingress/writer pumps (QA-013c).

## Two new package-private classes

### \`NativeTcpSocketBackend\` (305 LOC) — lifecycle owner

- \`SocketBackendMode\` enum (config value parsing + 4-source resolution: JVM property → ENV ALIAS property → env var → env ALIAS)
- \`SocketBackendSelection\` record (mode + arena + handles + armed flag + diagnostic detail string)
- Shared \`Arena\` ownership (deterministic \`close()\`)
- 4 \`AtomicBoolean\` validation latches (server/client × attempted/successful)
- Pkg-private getters used by \`NativeTcpCarrierBackendSelectionTest\`

### \`NativeTcpSocketProbe\` (200 LOC) — stateless probe helpers

- Server + client bootstrap probes (FFM downcalls)
- IPv4 sockaddr serialization (BSD vs SysV layout)
- Native \`socket() / bind() / connect() / listen() / close()\` wrappers
- Best-effort \`WSACleanup()\` for Windows
- Loopback constants + \`IS_WINDOWS_RUNTIME\` shared with Backend

## Carrier delegation

\`\`\`java
// Constructor
this.backend = new NativeTcpSocketBackend();

// start()
backend.validateServerSocketBootstrapOnce(allocator);

// connect()
backend.validateClientSocketBackendOnce(allocator, host, port);
new NativeTcpStream(..., backend.socketHandles());

// close()
try { stop() } finally { backend.close() }

// Test surface (proxied 1:1 to preserve NativeTcpCarrierBackendSelectionTest)
carrier.requestedSocketBackend()           → backend.requestedSocketBackend()
carrier.activeSocketBackend()              → backend.activeSocketBackend()
carrier.isFfmSocketBackendArmed()          → backend.isFfmSocketBackendArmed()
carrier.isServerSocketValidationSuccessful() → backend.isServerSocketValidationSuccessful()
carrier.isClientSocketValidationSuccessful() → backend.isClientSocketValidationSuccessful()
\`\`\`

**Public API surface unchanged.** Sprint 7 transport non-blocking client ingress refactor will be unaffected by this split (the blocking \`recv()\` on \`NativeTcpStream\` is the production-fix target, not this seam).

## Delta

| | LOC | Δ |
|---|---|---|
| NativeTcpCarrier | 1381 → 1006 | **-375 / -27%** |
| NativeTcpSocketBackend (NEW) | 305 | +305 |
| NativeTcpSocketProbe (NEW) | 200 | +200 |
| **Net** | | +130 LOC across 3 files vs 1 |

Carrier class-level suppressions: **unchanged 11** — incremental track. QA-013b (ReactorLoop, ~200 LOC) + QA-013c (client pumps, ~80 LOC) will reduce them once further responsibility blocks land in their own files. The mechanical extraction here preserves binary compatibility and test coverage for the next two PRs to land cleanly.

## Test plan

- [x] \`NativeTcpCarrierBackendSelectionTest\` 8/8 green (binary surface preserved via pkg-private proxies)
- [x] Full transport test suite 110/110 green (NativeTcpCarrierTckTest, NativeTcpStreamTckTest, MultiReactor{2,4}TckTest, CarrierPinningTckTest, IngressIntegrationTest, TransportStressTest — TLS + plaintext + FFM-armed + NIO-fallback paths)
- [x] Full reactor verify SUCCESS (SPI + TCK + Core + Community Testkit + Community + Build Config + Parent + Root)
- [x] PMD 0 violations on community module
- [x] Checkstyle 0 violations on community module

## Sprint 1 GodClass tracker after this PR

| QA-* | Class | LOC | PR |
|---|---|---|---|
| QA-010 | \`CommunityPersistenceEngine\` | 565→403 | #119 (merged) |
| QA-011 | \`CommunityHttpRequestProcessor\` | 408→258 | #122 (merged) |
| QA-012 | \`Slf4jTelemetrySink\` | 429→218 | #124 (merged) |
| **QA-013a** | **\`NativeTcpCarrier\` socket-backend extract** | **1381→1006** | **this PR** |
| QA-013b | \`NativeTcpCarrier\` ReactorLoop extract | ~1006→~800 | next |
| QA-013c | \`NativeTcpCarrier\` client pump extract | ~800→~720 | optional |
| QA-014 | \`OutboxOrchestrator\` | TBD | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)