### PR TITLE
v0.8 Sprint 1 (QA-014): decompose OutboxOrchestrator — close GodClass + TooManyMethods + CyclomaticComplexity + AvoidCatchingGenericException

### DIFF
--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxBatchFlusher.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxBatchFlusher.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.events.outbox;
+
+import eu.exeris.kernel.core.events.jfr.OutboxBatchFlushedEvent;
+import eu.exeris.kernel.core.events.jfr.OutboxDlqEvent;
+import eu.exeris.kernel.spi.events.EventDescriptor;
+import eu.exeris.kernel.spi.events.EventPayload;
+import jdk.jfr.FlightRecorder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Batch flush + retry + DLQ delivery for {@link OutboxOrchestrator}.
+ *
+ * <p>Extracted from {@link OutboxOrchestrator} in v0.8 Sprint 1 (QA-014) to close
+ * the orchestrator's God-class suppression block. Owns:
+ *
+ * <ul>
+ *   <li>{@link #flush(List)} — publishes a batch via the broker port, marks
+ *       delivered descriptors in the store, and routes partial failures to
+ *       per-event retries.</li>
+ *   <li>Per-event retry loop with linear backoff ({@code pollIntervalNanos *
+ *       attempt}).</li>
+ *   <li>DLQ delivery + {@link OutboxDlqEvent} JFR emission on retry
+ *       exhaustion or unhandled retry exception.</li>
+ *   <li>{@link OutboxBatchFlushedEvent} JFR emission summarising every flush
+ *       cycle (size, duration nanos, failed count).</li>
+ *   <li>Payload close after flush — release {@link EventPayload} loans
+ *       regardless of outcome.</li>
+ * </ul>
+ *
+ * <p>State transitions during partial failure are routed through the supplied
+ * {@link OutboxStateMachine}; this class does not own state itself.
+ */
+@SuppressWarnings({
+    "PMD.AvoidCatchingGenericException", // broker.publish() and retry path catch RuntimeException by contract.
+    "PMD.CloseResource"                  // payload close is intentional and routed through closeEntryPayloads.
+})
+final class OutboxBatchFlusher {
+
+    private static final int SINGLE_EVENT_PUBLISHED = 1;
+
+    private final OutboxEventStore eventStore;
+    private final OutboxBrokerPort brokerPort;
+    private final OutboxStateMachine stateMachine;
+    private final int maxRetries;
+    private final long pollIntervalNanos;
+
+    /* default */ OutboxBatchFlusher(OutboxEventStore eventStore,
+                                     OutboxBrokerPort brokerPort,
+                                     OutboxStateMachine stateMachine,
+                                     int maxRetries,
+                                     long pollIntervalNanos) {
+        this.eventStore = eventStore;
+        this.brokerPort = brokerPort;
+        this.stateMachine = stateMachine;
+        this.maxRetries = maxRetries;
+        this.pollIntervalNanos = pollIntervalNanos;
+    }
+
+    /* default */ void flush(List<OutboxBrokerPort.OutboxEntry> batch) {
+        long startNanos = System.nanoTime();
+        int  failed     = batch.size(); // assume all failed until broker confirms
+
+        List<EventDescriptor> toDeliver = new ArrayList<>(batch.size());
+        try {
+            int rawPublished = brokerPort.publish(batch);
+            int published = Math.clamp(rawPublished, 0, batch.size());
+            failed = batch.size() - published;
+
+            for (int i = 0; i < published; i++) {
+                toDeliver.add(batch.get(i).descriptor());
+            }
+            if (!toDeliver.isEmpty()) {
+                eventStore.markDelivered(toDeliver);
+            }
+
+            if (failed > 0) {
+                handlePartialFailure(batch, published);
+            }
+        } catch (RuntimeException ex) {
+            // broker.publish() threw — entire batch failed; failed is already batch.size()
+            handlePartialFailure(batch, 0);
+            throw ex;
+        } finally {
+            closeEntryPayloads(batch);
+            emitBatchFlushed(batch.size() - failed, System.nanoTime() - startNanos, failed);
+        }
+    }
+
+    private void handlePartialFailure(List<OutboxBrokerPort.OutboxEntry> batch, int successCount) {
+        stateMachine.transitionTo(OutboxStateMachine.RETRYING, 0);
+        for (int i = successCount; i < batch.size(); i++) {
+            OutboxBrokerPort.OutboxEntry entry = batch.get(i);
+            try {
+                boolean recovered = retryEntry(entry);
+                if (!recovered) {
+                    emitDlqTransition(entry, "max retries exhausted");
+                    eventStore.moveToDlq(entry.descriptor(), entry.payload(), "max retries exhausted");
+                }
+            } catch (RuntimeException ex) {
+                String message = ex.getMessage();
+                String reason = (message == null || message.isBlank()) ? "exception" : message;
+                emitDlqTransition(entry, reason);
+                eventStore.moveToDlq(entry.descriptor(), entry.payload(), reason);
+            }
+        }
+    }
+
+    private boolean retryEntry(OutboxBrokerPort.OutboxEntry entry) {
+        List<OutboxBrokerPort.OutboxEntry> single = List.of(entry);
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                if (brokerPort.publish(single) == SINGLE_EVENT_PUBLISHED) {
+                    eventStore.markDelivered(List.of(entry.descriptor()));
+                    return true;
+                }
+            } catch (RuntimeException _) {
+                // retry on next attempt
+            }
+            LockSupport.parkNanos(pollIntervalNanos * attempt);
+        }
+        return false;
+    }
+
+    private void emitDlqTransition(OutboxBrokerPort.OutboxEntry entry, String reason) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        OutboxDlqEvent dlqEvt = new OutboxDlqEvent();
+        if (dlqEvt.isEnabled()) {
+            dlqEvt.eventType    = String.valueOf(entry.descriptor().eventTypeOrdinal());
+            dlqEvt.streamIdHigh = entry.descriptor().streamIdHigh();
+            dlqEvt.streamIdLow  = entry.descriptor().streamIdLow();
+            dlqEvt.reason       = reason;
+            dlqEvt.retryCount   = maxRetries;
+            dlqEvt.commit();
+        }
+    }
+
+    private static void closeEntryPayloads(List<OutboxBrokerPort.OutboxEntry> batch) {
+        for (OutboxBrokerPort.OutboxEntry entry : batch) {
+            EventPayload payload = entry.payload();
+            if (payload != null && payload.isAlive()) {
+                payload.close();
+            }
+        }
+    }
+
+    private static void emitBatchFlushed(int size, long durationNanos, int failed) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        OutboxBatchFlushedEvent evt = new OutboxBatchFlushedEvent();
+        if (evt.isEnabled()) {
+            evt.batchSize          = size;
+            evt.flushDurationNanos = durationNanos;
+            evt.failedCount        = failed;
+            evt.commit();
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxOrchestrator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxOrchestrator.java
@@ -8,16 +8,6 @@
  */
 package eu.exeris.kernel.core.events.outbox;
 
-import eu.exeris.kernel.core.events.jfr.OutboxBatchFlushedEvent;
-import eu.exeris.kernel.core.events.jfr.OutboxDlqEvent;
-import eu.exeris.kernel.core.events.jfr.OutboxStateTransitionEvent;
-import eu.exeris.kernel.spi.events.EventDescriptor;
-import eu.exeris.kernel.spi.events.EventPayload;
-import jdk.jfr.FlightRecorder;
-
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.StructuredTaskScope;
@@ -54,72 +44,39 @@ import java.util.concurrent.locks.LockSupport;
  * {@code join()}, and {@code close()} are all invoked by that same internal owner
  * thread, satisfying the Java 26 owner-thread rule.
  *
- * <h2>VarHandle State Transitions</h2>
- * <p>State is stored in a {@code volatile int} field. All transitions use
- * {@link VarHandle#compareAndSet} or {@link VarHandle#getAndSet} — O(1), lock-free,
- * no {@code synchronized}.
+ * <h2>Decomposition (v0.8 Sprint 1 QA-014)</h2>
+ * <p>State transitions and the {@link java.lang.invoke.VarHandle} CAS primitive
+ * live in {@link OutboxStateMachine}; batch flush + retry + DLQ delivery live in
+ * {@link OutboxBatchFlusher}. This orchestrator owns only lifecycle (start/stop/
+ * close), the owner virtual thread and {@code StructuredTaskScope} wiring,
+ * the poll-flush tick loop, and the fluent builder.
  *
  * @since 0.5.0
  */
-// TooManyMethods, CyclomaticComplexity, GodClass: state machine + outbox lifecycle + builder
-// cannot be split without introducing artificial coordination abstractions.
-// ATFD driven by necessary port interfaces (eventStore, brokerPort) + VarHandle state access.
-@SuppressWarnings({
-    "PMD.TooManyMethods",
-    "PMD.AvoidCatchingGenericException", 
-    "PMD.CyclomaticComplexity", 
-    "PMD.GodClass"
-})
 public final class OutboxOrchestrator implements AutoCloseable {
 
-    // ── State machine ordinals ────────────────────────────────────────────────
-    private static final int STATE_IDLE     = 0;
-    private static final int STATE_POLLING  = 1;
-    private static final int STATE_FLUSHING = 2;
-    private static final int STATE_WAITING  = 3;
-    private static final int STATE_RETRYING = 4;
-    private static final int STATE_STOPPED  = 5;
-
-    private static final int SINGLE_EVENT_PUBLISHED = 1;
-
-    private static final String[] STATE_NAMES =
-            {"IDLE", "POLLING", "FLUSHING", "WAITING", "RETRYING", "STOPPED"};
-
-    private static final VarHandle STATE_VH;
-
-    static {
-        try {
-            STATE_VH = MethodHandles.lookup()
-                    .findVarHandle(OutboxOrchestrator.class, "state", int.class);
-        } catch (ReflectiveOperationException ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
-
-    // ── Configuration ─────────────────────────────────────────────────────────
     private final OutboxEventStore eventStore;
-    private final OutboxBrokerPort brokerPort;
     private final int              batchSize;
     private final long             pollIntervalNanos;
-    private final int              maxRetries;
 
-    // ── Mutable state — all access via VarHandle or AtomicBoolean ─────────────
-    @SuppressWarnings("PMD.UnusedPrivateField")
-    private volatile int        state   = STATE_IDLE;
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final OutboxStateMachine stateMachine;
+    private final OutboxBatchFlusher batchFlusher;
 
-    // ── Loop scope (owned by the thread that called start()) ──────────────────
     private volatile Thread ownerThread;
 
-    @SuppressWarnings("PMD.LawOfDemeter")
+    @SuppressWarnings("PMD.LawOfDemeter") // builder field access is the canonical Builder pattern.
     private OutboxOrchestrator(Builder builder) {
-        OutboxEventStore store = builder.eventStore;
-        OutboxBrokerPort port  = builder.brokerPort;
-        this.eventStore        = store;
-        this.brokerPort        = port;
+        this.eventStore        = builder.eventStore;
         this.batchSize         = builder.batchSize;
         this.pollIntervalNanos = builder.pollIntervalNanos;
-        this.maxRetries        = builder.maxRetries;
+        this.stateMachine      = new OutboxStateMachine(running::get);
+        this.batchFlusher      = new OutboxBatchFlusher(
+                builder.eventStore,
+                builder.brokerPort,
+                stateMachine,
+                builder.maxRetries,
+                builder.pollIntervalNanos);
     }
 
     // =========================================================================
@@ -141,12 +98,12 @@ public final class OutboxOrchestrator implements AutoCloseable {
         if (!running.compareAndSet(false, true)) {
             return;
         }
-        if ((int) STATE_VH.getVolatile(this) == STATE_STOPPED) {
+        if (stateMachine.isStopped()) {
             running.set(false);
             throw new IllegalStateException(
                     "OutboxOrchestrator cannot be restarted after stop(); create a new instance.");
         }
-        transitionTo(STATE_POLLING, 0);
+        stateMachine.transitionTo(OutboxStateMachine.POLLING, 0);
 
         // Owner VT — the sole thread that may call fork/join/close on the scope.
         // Exempt from StructuredTaskScope rule per docs/modules/02-core.md §3(b):
@@ -161,15 +118,14 @@ public final class OutboxOrchestrator implements AutoCloseable {
         if (!running.compareAndSet(true, false)) {
             return;
         }
-        int prev = (int) STATE_VH.getAndSet(this, STATE_STOPPED);
-        emitTransition(STATE_NAMES[prev], STATE_NAMES[STATE_STOPPED], 0);
+        stateMachine.forceTransitionToStopped();
 
         Thread owner = this.ownerThread;
         if (owner != null) {
             owner.interrupt();
             try {
                 owner.join();
-            } catch (InterruptedException ex) {
+            } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
             }
         }
@@ -186,7 +142,7 @@ public final class OutboxOrchestrator implements AutoCloseable {
      * @return one of: IDLE, POLLING, FLUSHING, WAITING, RETRYING, STOPPED
      */
     public String currentState() {
-        return STATE_NAMES[(int) STATE_VH.getVolatile(this)];
+        return stateMachine.currentStateName();
     }
 
     // =========================================================================
@@ -209,186 +165,45 @@ public final class OutboxOrchestrator implements AutoCloseable {
             });
             try {
                 scope.join();
-            } catch (InterruptedException ex) {
+            } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
             }
         }
     }
 
-    // =========================================================================
-    // Internal — loop body
-    // =========================================================================
-
     private void runLoop() {
         while (running.get()) {
-            if ((int) STATE_VH.getVolatile(this) == STATE_STOPPED) {
+            if (stateMachine.isStopped()) {
                 break;
             }
             executeTick();
         }
     }
 
-    @SuppressWarnings("PMD.LawOfDemeter")
+    @SuppressWarnings({
+        "PMD.AvoidCatchingGenericException", // tick body must wrap broker/store RuntimeException defensively.
+        "PMD.LawOfDemeter"                   // batch.size() on List parameter is the canonical pattern.
+    })
     private void executeTick() {
         try {
             List<OutboxBrokerPort.OutboxEntry> batch = eventStore.pollPending(batchSize);
             int batchCount = batch.size();
 
             if (batchCount == 0) {
-                transitionTo(STATE_WAITING, 0);
+                stateMachine.transitionTo(OutboxStateMachine.WAITING, 0);
                 LockSupport.parkNanos(pollIntervalNanos);
-                transitionTo(STATE_POLLING, 0);
+                stateMachine.transitionTo(OutboxStateMachine.POLLING, 0);
                 return;
             }
 
-            transitionTo(STATE_FLUSHING, batchCount);
-            flushBatch(batch);
-            transitionTo(STATE_POLLING, 0);
+            stateMachine.transitionTo(OutboxStateMachine.FLUSHING, batchCount);
+            batchFlusher.flush(batch);
+            stateMachine.transitionTo(OutboxStateMachine.POLLING, 0);
 
-        } catch (RuntimeException ex) {
-            transitionTo(STATE_WAITING, 0);
+        } catch (RuntimeException _) {
+            stateMachine.transitionTo(OutboxStateMachine.WAITING, 0);
             LockSupport.parkNanos(pollIntervalNanos);
-            transitionTo(STATE_POLLING, 0);
-        }
-    }
-
-    private void flushBatch(List<OutboxBrokerPort.OutboxEntry> batch) {
-        long startNanos = System.nanoTime();
-        int  failed     = batch.size(); // assume all failed until broker confirms
-
-        List<EventDescriptor> toDeliver = new ArrayList<>(batch.size());
-        try {
-            int rawPublished = brokerPort.publish(batch);
-            int published = Math.clamp(rawPublished, 0, batch.size());
-            failed = batch.size() - published;
-
-            for (int i = 0; i < published; i++) {
-                toDeliver.add(batch.get(i).descriptor());
-            }
-            if (!toDeliver.isEmpty()) {
-                eventStore.markDelivered(toDeliver);
-            }
-
-            if (failed > 0) {
-                handlePartialFailure(batch, published);
-            }
-        } catch (RuntimeException ex) {
-            // broker.publish() threw — entire batch failed; failed is already batch.size()
-            handlePartialFailure(batch, 0);
-            throw ex;
-        } finally {
-            closeEntryPayloads(batch);
-            emitBatchFlushed(batch.size() - failed, System.nanoTime() - startNanos, failed);
-        }
-    }
-
-    private void handlePartialFailure(List<OutboxBrokerPort.OutboxEntry> batch, int successCount) {
-        transitionTo(STATE_RETRYING, 0);
-        for (int i = successCount; i < batch.size(); i++) {
-            OutboxBrokerPort.OutboxEntry entry = batch.get(i);
-            try {
-                boolean recovered = retryEntry(entry);
-                if (!recovered) {
-                    emitDlqTransition(entry, "max retries exhausted");
-                    eventStore.moveToDlq(entry.descriptor(), entry.payload(), "max retries exhausted");
-                }
-            } catch (RuntimeException ex) {
-                String message = ex.getMessage();
-                String reason = (message == null || message.isBlank()) ? "exception" : message;
-                emitDlqTransition(entry, reason);
-                eventStore.moveToDlq(entry.descriptor(), entry.payload(), reason);
-            }
-        }
-    }
-
-    private void emitDlqTransition(OutboxBrokerPort.OutboxEntry entry, String reason) {
-        if (!FlightRecorder.isInitialized()) {
-            return;
-        }
-        OutboxDlqEvent dlqEvt = new OutboxDlqEvent();
-        if (dlqEvt.isEnabled()) {
-            dlqEvt.eventType    = String.valueOf(entry.descriptor().eventTypeOrdinal());
-            dlqEvt.streamIdHigh = entry.descriptor().streamIdHigh();
-            dlqEvt.streamIdLow  = entry.descriptor().streamIdLow();
-            dlqEvt.reason       = reason;
-            dlqEvt.retryCount   = maxRetries;
-            dlqEvt.commit();
-        }
-    }
-
-    private boolean retryEntry(OutboxBrokerPort.OutboxEntry entry) {
-        List<OutboxBrokerPort.OutboxEntry> single = List.of(entry);
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            try {
-                if (brokerPort.publish(single) == SINGLE_EVENT_PUBLISHED) {
-                    eventStore.markDelivered(List.of(entry.descriptor()));
-                    return true;
-                }
-            } catch (RuntimeException ex) {
-                // retry on next attempt
-            }
-            LockSupport.parkNanos(pollIntervalNanos * attempt);
-        }
-        return false;
-    }
-
-    @SuppressWarnings("PMD.CloseResource")
-    private static void closeEntryPayloads(List<OutboxBrokerPort.OutboxEntry> batch) {
-        for (OutboxBrokerPort.OutboxEntry entry : batch) {
-            EventPayload payload = entry.payload();
-            if (payload != null && payload.isAlive()) {
-                payload.close();
-            }
-        }
-    }
-
-    // ── State transitions ─────────────────────────────────────────────────────
-
-    private void transitionTo(int next, int polledCount) {
-        if (next != STATE_STOPPED && !running.get()) {
-            return;
-        }
-
-        while (true) {
-            int prev = (int) STATE_VH.getVolatile(this);
-            if (next != STATE_STOPPED && prev == STATE_STOPPED) {
-                return;
-            }
-            if (prev == next) {
-                return;
-            }
-            if (STATE_VH.compareAndSet(this, prev, next)) {
-                emitTransition(STATE_NAMES[prev], STATE_NAMES[next], polledCount);
-                return;
-            }
-        }
-    }
-
-    // ── JFR helpers ──────────────────────────────────────────────────────────
-
-    private static void emitTransition(String prev, String next, int polled) {
-        if (!FlightRecorder.isInitialized()) {
-            return;
-        }
-        OutboxStateTransitionEvent evt = new OutboxStateTransitionEvent();
-        if (evt.isEnabled()) {
-            evt.previousState = prev;
-            evt.nextState     = next;
-            evt.polledCount   = polled;
-            evt.commit();
-        }
-    }
-
-    private static void emitBatchFlushed(int size, long durationNanos, int failed) {
-        if (!FlightRecorder.isInitialized()) {
-            return;
-        }
-        OutboxBatchFlushedEvent evt = new OutboxBatchFlushedEvent();
-        if (evt.isEnabled()) {
-            evt.batchSize          = size;
-            evt.flushDurationNanos = durationNanos;
-            evt.failedCount        = failed;
-            evt.commit();
+            stateMachine.transitionTo(OutboxStateMachine.POLLING, 0);
         }
     }
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxStateMachine.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/outbox/OutboxStateMachine.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.events.outbox;
+
+import eu.exeris.kernel.core.events.jfr.OutboxStateTransitionEvent;
+import jdk.jfr.FlightRecorder;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Lock-free state machine for {@link OutboxOrchestrator}.
+ *
+ * <p>Extracted from {@link OutboxOrchestrator} in v0.8 Sprint 1 (QA-014) to close
+ * the orchestrator's God-class suppression block. Owns the six-state ordinal
+ * encoding, the {@link VarHandle} CAS transition primitive, and the JFR
+ * {@link OutboxStateTransitionEvent} emit on every successful transition.
+ *
+ * <p>All transitions are lock-free O(1) — no {@code synchronized} block.
+ * Reads use {@code getVolatile}; writes use {@code compareAndSet} or
+ * {@code getAndSet}. STOPPED is a terminal absorbing state.
+ *
+ * <h2>State transitions</h2>
+ * <pre>
+ *   IDLE ──► POLLING ──► FLUSHING ──► POLLING
+ *               │           │
+ *               ▼           ▼
+ *            WAITING     RETRYING ──► POLLING
+ *               │
+ *           parkNanos
+ *               └──► POLLING
+ *
+ *   Any state ──► STOPPED  (terminal — set only by forceTransitionToStopped)
+ * </pre>
+ */
+final class OutboxStateMachine {
+
+    /* default */ static final int IDLE     = 0;
+    /* default */ static final int POLLING  = 1;
+    /* default */ static final int FLUSHING = 2;
+    /* default */ static final int WAITING  = 3;
+    /* default */ static final int RETRYING = 4;
+    /* default */ static final int STOPPED  = 5;
+
+    private static final String[] STATE_NAMES =
+            {"IDLE", "POLLING", "FLUSHING", "WAITING", "RETRYING", "STOPPED"};
+
+    private static final VarHandle STATE_VH;
+
+    static {
+        try {
+            STATE_VH = MethodHandles.lookup()
+                    .findVarHandle(OutboxStateMachine.class, "state", int.class);
+        } catch (ReflectiveOperationException ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateField") // accessed via STATE_VH (VarHandle).
+    private volatile int state = IDLE;
+
+    private final BooleanSupplier runningCheck;
+
+    /* default */ OutboxStateMachine(BooleanSupplier runningCheck) {
+        this.runningCheck = runningCheck;
+    }
+
+    /* default */ String currentStateName() {
+        return STATE_NAMES[(int) STATE_VH.getVolatile(this)];
+    }
+
+    /* default */ int currentOrdinal() {
+        return (int) STATE_VH.getVolatile(this);
+    }
+
+    /* default */ boolean isStopped() {
+        return currentOrdinal() == STOPPED;
+    }
+
+    /**
+     * Attempts a CAS transition to {@code next}. No-op if already stopped (except
+     * the transition to STOPPED itself) or if the running check returns false.
+     * Emits an {@link OutboxStateTransitionEvent} on successful transition.
+     */
+    /* default */ void transitionTo(int next, int polledCount) {
+        if (next != STOPPED && !runningCheck.getAsBoolean()) {
+            return;
+        }
+
+        while (true) {
+            int prev = currentOrdinal();
+            if (next != STOPPED && prev == STOPPED) {
+                return;
+            }
+            if (prev == next) {
+                return;
+            }
+            if (STATE_VH.compareAndSet(this, prev, next)) {
+                emitTransitionEvent(STATE_NAMES[prev], STATE_NAMES[next], polledCount);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Force-transitions to STOPPED via {@code getAndSet}, returning the previous
+     * ordinal. Used by {@code stop()} to bypass the running check.
+     */
+    /* default */ void forceTransitionToStopped() {
+        int prev = (int) STATE_VH.getAndSet(this, STOPPED);
+        emitTransitionEvent(STATE_NAMES[prev], STATE_NAMES[STOPPED], 0);
+    }
+
+    private static void emitTransitionEvent(String prev, String next, int polled) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        OutboxStateTransitionEvent evt = new OutboxStateTransitionEvent();
+        if (evt.isEnabled()) {
+            evt.previousState = prev;
+            evt.nextState     = next;
+            evt.polledCount   = polled;
+            evt.commit();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 1 GodClass closure track continues. `OutboxOrchestrator` (461 LOC, 4 class-level PMD suppressions) splits along **two cohesive seams** into three files, achieving **full class-level suppression closure** (4 → 0) and **-40% LOC** on the orchestrator.

## Three files now

### \`OutboxStateMachine\` (133 LOC, pkg-private) — state primitive

- \`STATE_*\` ordinal constants (IDLE/POLLING/FLUSHING/WAITING/RETRYING/STOPPED)
- \`VarHandle STATE_VH\` + volatile int state field
- \`transitionTo(next, polledCount)\` — CAS guarded by \`BooleanSupplier runningCheck\`
- \`forceTransitionToStopped()\` — \`getAndSet\` for terminal transition from \`stop()\`
- \`currentStateName()\` / \`currentOrdinal()\` / \`isStopped()\` accessors
- Internal JFR emit on every successful transition (\`OutboxStateTransitionEvent\`)

### \`OutboxBatchFlusher\` (171 LOC, pkg-private) — flush + retry + DLQ

- \`flush(batch)\` — broker.publish + markDelivered + partial-failure routing
- \`handlePartialFailure\` — per-event retry loop, DLQ on exhaustion
- \`retryEntry\` — single-event retry with linear backoff (\`pollIntervalNanos * attempt\`)
- Internal \`closeEntryPayloads\` + JFR \`OutboxBatchFlushedEvent\` + \`OutboxDlqEvent\`

### \`OutboxOrchestrator\` (276 LOC, public — refactored)

- **Public surface UNCHANGED:** \`builder()\`, \`start()\`, \`stop()\`, \`close()\`, \`currentState()\` string + Builder fluent setters all preserved
- \`ownerLoop\` — \`StructuredTaskScope\` owner VT (Java 26 owner-thread rule)
- \`runLoop\` + \`executeTick\` — drives the state machine through the flusher
- Builder static inner class — verbatim

## Suppression delta — full class-level closure

**Closed (4 class-level on \`OutboxOrchestrator\`):**

- \`PMD.TooManyMethods\` ✅
- \`PMD.AvoidCatchingGenericException\` ✅ (one residual per-method on \`executeTick\` with inline rationale)
- \`PMD.CyclomaticComplexity\` ✅
- \`PMD.GodClass\` ✅

**Net effect:**

| | Before | After | Δ |
|---|---|---|---|
| Class-level suppressions on Orchestrator | 4 | **0** | **-4 (full closure)** |
| Class-level suppressions on Flusher (new) | — | 2 (with rationale) | +2 |
| Method-level suppressions on Orchestrator | 2 | 2 | unchanged |

The new class-level suppressions on \`OutboxBatchFlusher\` are narrowly scoped to that helper's responsibility (broker.publish RuntimeException contract + payload close routing) vs the original 4 covering the entire 461-LOC orchestrator.

## Delta

| File | LOC | Δ |
|---|---|---|
| OutboxOrchestrator | 461 → 276 | **-185 / -40%** |
| OutboxStateMachine (NEW) | 133 | +133 |
| OutboxBatchFlusher (NEW) | 171 | +171 |

## Test plan

- [x] \`OutboxOrchestratorTest\` 6/6 green (state lifecycle + currentState semantics)
- [x] \`OutboxOrchestratorIntegrationTest\` 1/1 green (start → poll → stop sequence)
- [x] \`CommunityOutboxOrchestratorTckTest\` 4/4 green (community TCK binding)
- [x] \`CommunityOutboxGuaranteeTckTest\` 2/2 green (at-least-once + replay idempotency)
- [x] Full reactor verify SUCCESS (SPI + TCK + Core + Community Testkit + Community + Build Config + Parent + Root)
- [x] PMD 0 violations on core module
- [x] Checkstyle 0 violations on core module
- [x] Local JDK 26+35 G1 crash worked around with \`-XX:+UseSerialGC\` (pre-existing memory note; unrelated to this refactor)

## Sprint 1 GodClass tracker after this PR

| QA-* | Class | LOC | Class-suppressions Δ | PR |
|---|---|---|---|---|
| QA-010 | \`CommunityPersistenceEngine\` | 565→403 | partial | #119 merged |
| QA-011 | \`CommunityHttpRequestProcessor\` | 408→258 | partial | #122 merged |
| QA-012 | \`Slf4jTelemetrySink\` | 429→218 | 8→2 (-6) | #124 merged |
| QA-013a | \`NativeTcpCarrier\` socket-backend | 1381→1006 | unchanged | #126 merged |
| QA-013b | \`NativeTcpCarrier\` reactor extract | 1006→803 | 11→10 (-1) | #127 merged |
| **QA-014** | **\`OutboxOrchestrator\`** | **461→276** | **4→0 (full closure)** | **this PR** |
| QA-013c | \`NativeTcpCarrier\` client pumps | optional | TBD | skip-or-later |

**Sprint 1 GodClass closure target was -5 cumulative.** After QA-014: **6 GodClass markers closed cumulatively** (QA-010 + QA-011 + QA-012 + QA-013b CognitiveComplexity + QA-014's 4-of-4). Target reached + 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)