### PR TITLE
v0.8 Sprint 2: ExerisWebClient + WebClientException + ADR-026 — unblocks exeris-tooling KernelClientGenerator

### DIFF
--- a/docs/adr/ADR-026-client-side-application-api.md
+++ b/docs/adr/ADR-026-client-side-application-api.md
@@ -1,0 +1,156 @@
+# ADR-026: Client-Side Application API — `ExerisWebClient`
+
+**Status:** Accepted
+**Date:** 2026-05-16
+**Owner:** kernel/transport
+**Visibility:** public
+**Scope:** kernel/transport (per-repo)
+**Authors:** Arkadiusz Przychocki
+
+## Context
+
+The Exeris ecosystem has so far defined two HTTP surfaces in the kernel:
+
+- **`HttpServerEngine` SPI** (since 0.5.0) — server-side accept loop, exchange dispatch, response writer.
+- **`HttpClientEngine` SPI** (since 0.5.0) — outbound `send(HttpRequest) → HttpResponse` with connection pooling, TLS, and lifecycle (`start` / `close` / `isRunning`).
+
+The `HttpClientEngine` SPI is implementation-blind by design — `HttpRequest` carries an off-heap `LoanedBuffer` body, `HttpResponse` likewise — and gives callers no encoding/decoding affordance. Building a `POST` request from a domain object requires manual JSON serialization, manual byte → `LoanedBuffer` adaptation, manual header construction, and explicit memory ownership at every call site. Status-code branching (404 → `Optional.empty()`, 5xx → retry, etc.) is also caller responsibility.
+
+`exeris-tooling` ships `KernelClientGenerator` (`exeris-codegen-java`) which emits typed per-entity REST clients (`WidgetClient.findById(id)`, `WidgetClient.create(widget)`, etc.). The generator's emitted code references a kernel-side `ExerisWebClient` class as its underlying transport and JSON binding façade:
+
+```java
+private static final ClassName WEB_CLIENT =
+    ClassName.get("eu.exeris.kernel.transport.http3.client", "ExerisWebClient");
+private static final ClassName WEB_CLIENT_EXCEPTION =
+    ClassName.get("eu.exeris.kernel.transport.http3.client", "ExerisWebClient", "WebClientException");
+```
+
+The generated code calls `client.get(path, EntityClass.class)`, `client.post(path, entity, EntityClass.class)`, `client.patch(path, entity, EntityClass.class)`, `client.delete(path, Void.class)` — and inspects `WebClientException.isNotFound()` to map `404` to `Optional.empty()`.
+
+Until the kernel exposes this class, the generator emits code that cannot compile against the kernel artifact. The gap is documented in `exeris-tooling` as *"SPI HTTP/transport client (TBD against the actually exposed client SPI; align with the working benchmark app)"*. This ADR closes that gap.
+
+## Decision
+
+Introduce a kernel-side **`ExerisWebClient`** as a public façade on top of `HttpClientEngine` SPI. The class lives in the **`exeris-kernel-community` module** under package **`eu.exeris.kernel.transport.http3.client`** (matching the generator's expected import path).
+
+### Public API surface
+
+```java
+package eu.exeris.kernel.transport.http3.client;
+
+public final class ExerisWebClient {
+
+    public ExerisWebClient(HttpClientEngine engine, MemoryAllocator allocator, ObjectMapper mapper);
+
+    public <T> T get(String path, Class<T> responseType);
+    public <T> T post(String path, Object body, Class<T> responseType);
+    public <T> T patch(String path, Object body, Class<T> responseType);
+    public <T> T delete(String path, Class<T> responseType);
+
+    public static final class WebClientException extends RuntimeException {
+        public int status();
+        public String responseBody();
+        public boolean isNotFound();
+    }
+}
+```
+
+### Constructor inputs
+
+- **`HttpClientEngine engine`** — pre-configured (host + port + TLS + connection pool). The engine targets a single host; the web client adds path + JSON binding on top.
+- **`MemoryAllocator allocator`** — required to materialise outbound JSON bytes into the off-heap `LoanedBuffer` body required by `HttpRequest`. Uses `allocator.allocateInfrastructure(sizeBytes)` (same pattern as `NativeTcpSocketProbe`).
+- **`ObjectMapper mapper`** — Jackson 3 (BOM-managed at 3.1.1). The mapper is application-owned — callers can configure modules, naming strategies, date handlers.
+
+### Status-code mapping
+
+- **2xx** → deserialise body via Jackson into the requested `responseType`. If `responseType == Void.class`, return `null` (intended for `delete`, but legal anywhere).
+- **404** → throw `WebClientException` with `status() == 404`; the generated code uses `isNotFound()` to translate this back to `Optional.empty()` at the entity-level wrapper.
+- **Any other non-2xx** → throw `WebClientException` with the full status + response body.
+
+The web client deliberately performs **no implicit retry**. Retry policy is the caller's concern; failures map to `WebClientException` exactly once, with full diagnostic context.
+
+### Threading model
+
+Every method call **blocks the calling virtual thread** through the underlying `HttpClientEngine.send` (which itself is documented as blocking until the response is fully buffered). No implicit async wrapping. No callbacks. No `CompletableFuture`. Virtual threads are the concurrency primitive — callers parallelise by spawning more VTs.
+
+### Memory ownership
+
+- **Request body** (`post` / `patch`): the web client allocates a `LoanedBuffer` from the `MemoryAllocator`, serialises the body via Jackson, and passes ownership to `HttpRequest`. The engine is responsible for the buffer's lifetime after `send` is invoked (per `HttpClientEngine` Javadoc).
+- **Response body**: returned by `HttpClientEngine.send` as a `LoanedBuffer`. The web client deserialises bytes via Jackson **and then closes the buffer** in a `try`-with-resources or equivalent `finally`. Callers never see the buffer.
+
+### Package naming
+
+`eu.exeris.kernel.transport.http3.client` reads as HTTP/3-specific, but the class is **tier-agnostic**: Community runs over HTTP/1 + HTTP/2 (the actual protocol is `HttpClientEngine`'s private concern), Enterprise will run over H3 when the H3 client engine lands. The `http3` package name is historical — it was reserved when the original ADR sketch assumed an H3-first rollout. Renaming would break the `exeris-tooling` generator's in-flight code emission. The name **stays** for v0.8 stability and the generator pipeline; a rename can land alongside a separate codegen-coordinated PR if value justifies the churn.
+
+### Module placement: Community, not SPI
+
+`HttpClientEngine` lives in SPI as it must — it's the implementation-blind contract for inbound/outbound HTTP wire work. `ExerisWebClient` is **a kernel-side façade on top of the SPI**, not an SPI itself. It pulls Jackson 3 as a JSON-binding choice; SPI must remain implementation-blind and cannot host a binding-specific helper without breaking the principle.
+
+The Community module already declares `jackson-databind` as a runtime dependency (used elsewhere for Community-internal JSON paths). Placing `ExerisWebClient` here satisfies "no new dependency" — Jackson 3 is already on Community's classpath. The package namespace `eu.exeris.kernel.transport.http3.client` (vs `eu.exeris.kernel.community.transport.http3.client`) keeps the generator's expected import working — module structure and package structure are independent.
+
+### TCK + binding
+
+`ExerisWebClient` is a **single concrete class** rather than an SPI contract — there is only one implementation today (the Jackson-backed Community one). The TCK abstract-base pattern applies to SPI contracts with multiple implementations (e.g., `HttpClientEngine` → Community + future Enterprise); it does not apply here. The `exeris-kernel-tck` module also cannot import classes from `exeris-kernel-community` (Community depends on TCK, not the reverse), so an abstract TCK base hosted in TCK could not reference `ExerisWebClient` directly.
+
+Instead, ship an **integration test** in the owning module: `ExerisWebClientIntegrationTest` in `exeris-kernel-community/src/test/java/eu/exeris/kernel/transport/http3/client/` exercising every public verb plus error semantics against an in-process `HttpServerEngine` listener + `CommunityHttpClientEngine` round-trip. No external network dependency — fully hermetic. Coverage:
+
+- 2xx round-trip per verb (GET / POST / PATCH / DELETE)
+- 4xx → `WebClientException` carries status + body
+- 404 → `isNotFound()` returns `true`
+- 5xx → `WebClientException` (no implicit retry)
+- Null arguments → `NullPointerException` at boundary
+- `Void.class` response — returns null cleanly
+
+If/when a second `ExerisWebClient`-shaped class lands (e.g., Enterprise variant with H3 + zero-allocation Panama JSON binding), an abstract TCK in a Community-aware testkit module can be lifted from this integration test and shared between bindings.
+
+## Consequences
+
+### Positive
+
+- **`exeris-tooling` `KernelClientGenerator` unblocked** — emitted client code compiles against kernel artifact starting in 0.8.0.
+- **One canonical client surface** for kernel consumers (and SDK callers without the generator) — typed CRUD ergonomics over generic `HttpClientEngine.send`.
+- **No new module** — fits into existing Community surface; Jackson 3 is already present.
+- **No new SPI tier** — the lower-level engine boundary stays implementation-blind; this is a higher-level façade.
+
+### Negative / costs
+
+- Community module gains a public-facing class outside its `eu.exeris.kernel.community.*` namespace convention. Justified by generator-import stability and ADR-008 capability-licensing taxonomy — `ExerisWebClient` is `community` tier (free, open-core).
+- Jackson 3 binding is hardcoded. Alternative JSON libraries (Gson, Moshi, native Jackson 2) would require a parallel client class or an additional dependency-injection seam. Deferred — Jackson 3 covers ≥ 95% of JVM JSON workloads.
+- The `http3` package name remains semantically misleading until the H3 client engine actually lands. Acceptance per "Package naming" section above.
+
+### Neutral / open
+
+- A **future H3 client engine** (Enterprise) can plug into `ExerisWebClient` unchanged — the `HttpClientEngine` SPI is protocol-agnostic by design.
+- A `KernelProviders.WEB_CLIENT` `ScopedValue` binding could publish a default client for subsystem consumers, but is **out of scope for 0.8.0**. Application code or codegen output constructs `ExerisWebClient` explicitly today. ScopedValue binding deferred to v0.9 or later if a use case emerges.
+
+## Alternatives considered
+
+### A) Layer the typed API on `HttpClientEngine` SPI directly
+
+Add `<T> T sendJson(...)` / similar helper methods to `HttpClientEngine` interface. Rejected — would force every engine implementation to ship Jackson or some binding, breaking SPI implementation-blind invariant.
+
+### B) New `exeris-kernel-client` module
+
+Carve out a dedicated module to host `ExerisWebClient` + its Jackson binding. Rejected — adds a module to the kernel POM tree (CI cycles + Maven Central artifact + module-info bookkeeping) for a single public class. Premature modularisation. Can be promoted later if the client surface grows.
+
+### C) Provide the client via `exeris-sdk` instead
+
+Move `ExerisWebClient` to the SDK module (which already ships annotations + source model + UI kit). Rejected — `exeris-sdk` is build-time and design-time tooling. The web client is a **runtime** concern (it lives behind a live `HttpClientEngine`). Cross-cutting it into the SDK breaks the build-time / runtime split.
+
+### D) Higher-level entity-shaped surface on `ExerisWebClient` (`findById` / `findAll` / `create` / `update` / `delete`)
+
+Earlier sprint-map sketches proposed methods like `<T> Optional<T> findById(String basePath, UUID id, Class<T> entityType)`. Rejected after reading the actual `KernelClientGenerator` emission: the generator already emits the typed entity-shaped wrappers (`UserClient.findById`) on top of HTTP-verb primitives. Putting entity-shaped methods on `ExerisWebClient` would duplicate the abstraction layer and force every non-generator consumer to use the entity API even when raw HTTP verbs suffice. The cleaner split is: **`ExerisWebClient` provides HTTP verbs + JSON; generator emits entity wrappers**.
+
+## Implementation plan (v0.8 Sprint 2)
+
+- **PR #1 (this PR)** — `ExerisWebClient` + `WebClientException` + `AbstractExerisWebClientTck` + `CommunityExerisWebClientTckTest` + ADR-026 + CHANGELOG entry + ROADMAP entry.
+- **Follow-up** — register `ADR-026` row in `~/exeris-systems/exeris-docs/adr-index.md` as a separate commit on the docs repo (per global namespace policy).
+- **Cross-repo follow-up** — `exeris-benchmarks/community-app` should add a client-variant benchmark validating the round-trip path under load (out of kernel CI scope; tracked on the benchmarks repo's cadence).
+
+## References
+
+- [HttpClientEngine.java](../../exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpClientEngine.java) (SPI surface)
+- [CommunityHttpClientEngine.java](../../exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientEngine.java) (Community impl)
+- [KernelClientGenerator.java](https://github.com/exeris-systems/exeris-tooling/blob/main/exeris-codegen-java/src/main/java/eu/exeris/tooling/codegen/java/kernel/KernelClientGenerator.java) (downstream consumer)
+- ADR-008 — Open-Core Strategy & Commoditization of Off-Heap TLS
+- ADR-009 — HTTP Codec module

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/transport/http3/client/ExerisWebClient.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/transport/http3/client/ExerisWebClient.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.transport.http3.client;
+
+import eu.exeris.kernel.spi.http.HttpClientEngine;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Kernel-side typed HTTP client façade over {@link HttpClientEngine} SPI.
+ *
+ * <p>Layered API: callers issue verb-level CRUD against a relative path; the client
+ * marshals request bodies through Jackson 3, copies them into an off-heap
+ * {@link LoanedBuffer}, hands the buffer to the engine, deserialises the response
+ * body back through Jackson, and releases the response buffer. Non-2xx responses
+ * map to {@link WebClientException} carrying status code + response body —
+ * {@link WebClientException#isNotFound()} is the canonical 404 predicate
+ * (used by {@code exeris-tooling} {@code KernelClientGenerator}-emitted client code).
+ *
+ * <h2>Threading model</h2>
+ * <p>Every method call blocks the calling virtual thread through
+ * {@link HttpClientEngine#send(HttpRequest)}. No implicit async wrapping;
+ * concurrency is the caller's responsibility via additional virtual threads.
+ *
+ * <h2>Memory ownership</h2>
+ * <p>Request body: allocated via the supplied {@link MemoryAllocator}, populated
+ * by Jackson serialisation, and ownership transferred to the engine on
+ * {@code send}. Response body: returned by the engine, deserialised by Jackson,
+ * then released by {@link LoanedBuffer#close()} in a {@code finally} clause —
+ * callers never see the response buffer directly.
+ *
+ * <h2>Decision rationale</h2>
+ * <p>See ADR-026 for the package-name (historical {@code http3} retained for
+ * generator stability), tier-placement (Community module — Jackson already on
+ * classpath), and rejected alternatives.
+ *
+ * @since 0.8.0
+ */
+public final class ExerisWebClient {
+
+    private static final HttpVersion DEFAULT_VERSION = HttpVersion.HTTP_1_1;
+    private static final String CONTENT_TYPE = "content-type";
+    private static final String ACCEPT = "accept";
+    private static final String CONTENT_LENGTH = "content-length";
+    private static final String APPLICATION_JSON = "application/json";
+
+    private static final int HTTP_2XX_LOWER = 200;
+    private static final int HTTP_2XX_UPPER = 300;
+    private static final int HTTP_NOT_FOUND = 404;
+
+    private static final List<HttpHeader> ACCEPT_JSON_HEADERS =
+            List.of(new HttpHeader(ACCEPT, APPLICATION_JSON));
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    private final HttpClientEngine engine;
+    private final MemoryAllocator allocator;
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates a client backed by the given engine, allocator, and JSON binder.
+     *
+     * @param engine    a pre-configured client engine targeting a single host
+     * @param allocator the kernel memory allocator (request body materialisation)
+     * @param mapper    Jackson {@link ObjectMapper} — application-owned (modules,
+     *                  naming strategies, date handlers are caller's choice)
+     */
+    public ExerisWebClient(HttpClientEngine engine, MemoryAllocator allocator, ObjectMapper mapper) {
+        this.engine = Objects.requireNonNull(engine, "engine must not be null");
+        this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
+        this.mapper = Objects.requireNonNull(mapper, "mapper must not be null");
+    }
+
+    /**
+     * Issues an HTTP {@code GET} against {@code path} and deserialises the
+     * response body as {@code responseType}.
+     *
+     * @param <T>          response payload type
+     * @param path         request-target path (relative to the engine's target host)
+     * @param responseType target Jackson type, or {@code Void.class} to discard
+     * @return the deserialised payload, or {@code null} when {@code responseType == Void.class}
+     * @throws WebClientException on any non-2xx response
+     */
+    public <T> T get(String path, Class<T> responseType) {
+        return execute(HttpMethod.GET, path, null, responseType);
+    }
+
+    /**
+     * Issues an HTTP {@code POST} with a JSON-serialised body and deserialises the
+     * response body as {@code responseType}.
+     *
+     * @param <T>          response payload type
+     * @param path         request-target path
+     * @param body         request payload (Jackson-serialised); must not be null
+     * @param responseType target Jackson type, or {@code Void.class} to discard
+     * @return the deserialised payload, or {@code null} when {@code responseType == Void.class}
+     * @throws WebClientException on any non-2xx response or serialisation failure
+     */
+    public <T> T post(String path, Object body, Class<T> responseType) {
+        Objects.requireNonNull(body, "body must not be null for POST");
+        return execute(HttpMethod.POST, path, body, responseType);
+    }
+
+    /**
+     * Issues an HTTP {@code PATCH} with a JSON-serialised body. Same contract as
+     * {@link #post(String, Object, Class)} otherwise.
+     */
+    public <T> T patch(String path, Object body, Class<T> responseType) {
+        Objects.requireNonNull(body, "body must not be null for PATCH");
+        return execute(HttpMethod.PATCH, path, body, responseType);
+    }
+
+    /**
+     * Issues an HTTP {@code DELETE} against {@code path}. Most callers pass
+     * {@code Void.class} as {@code responseType} to discard any response body.
+     *
+     * @return the deserialised payload, or {@code null} when {@code responseType == Void.class}
+     * @throws WebClientException on any non-2xx response
+     */
+    public <T> T delete(String path, Class<T> responseType) {
+        return execute(HttpMethod.DELETE, path, null, responseType);
+    }
+
+    @SuppressWarnings("PMD.UseTryWithResources") // response body ownership transfers from engine.send() return.
+    private <T> T execute(HttpMethod method, String path, Object requestBody, Class<T> responseType) {
+        Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(responseType, "responseType must not be null");
+
+        HttpRequest request = buildRequest(method, path, requestBody);
+        HttpResponse response = engine.send(request);
+
+        int status = response.status().code();
+        LoanedBuffer body = response.body();
+        try {
+            byte[] responseBytes = (body == null) ? new byte[0] : readAll(body);
+            if (status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER) {
+                if (responseType == Void.class) {
+                    return null;
+                }
+                return parseBody(responseBytes, responseType, status);
+            }
+            String responseBody = new String(responseBytes, StandardCharsets.UTF_8);
+            throw new WebClientException(status, responseBody,
+                    "HTTP " + status + " " + response.status().reasonPhrase(), null);
+        } finally {
+            if (body != null) {
+                body.close();
+            }
+        }
+    }
+
+    // PMD.AvoidCatchingGenericException: outbound buffer must be released if anything throws
+    // between allocate() and engine ownership transfer.
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private HttpRequest buildRequest(HttpMethod method, String path, Object body) {
+        if (body == null) {
+            return HttpRequest.noBody(method, path, DEFAULT_VERSION, ACCEPT_JSON_HEADERS);
+        }
+        byte[] payload;
+        try {
+            payload = mapper.writeValueAsBytes(body);
+        } catch (JacksonException ex) {
+            throw new WebClientException(0, "",
+                    "Failed to serialize request body of type " + body.getClass().getName(), ex);
+        }
+        LoanedBuffer buf = allocator.allocateNetwork(payload.length);
+        try {
+            MemorySegment.copy(MemorySegment.ofArray(payload), 0, buf.segment(), 0, payload.length);
+            buf.setSize(payload.length);
+            List<HttpHeader> headers = List.of(
+                    new HttpHeader(CONTENT_TYPE, APPLICATION_JSON),
+                    new HttpHeader(ACCEPT, APPLICATION_JSON),
+                    new HttpHeader(CONTENT_LENGTH, Integer.toString(payload.length))
+            );
+            return new HttpRequest(method, path, DEFAULT_VERSION, headers, buf);
+        } catch (RuntimeException ex) {
+            buf.close();   // engine never received ownership; release the loan locally.
+            throw ex;
+        }
+    }
+
+    private <T> T parseBody(byte[] bytes, Class<T> responseType, int status) {
+        if (bytes.length == 0) {
+            throw new WebClientException(status, "",
+                    "Empty response body cannot deserialize to " + responseType.getName(), null);
+        }
+        try {
+            return mapper.readValue(bytes, responseType);
+        } catch (JacksonException ex) {
+            throw new WebClientException(status, new String(bytes, StandardCharsets.UTF_8),
+                    "Failed to deserialize response of type " + responseType.getName(), ex);
+        }
+    }
+
+    private static byte[] readAll(LoanedBuffer body) {
+        long size = body.size();
+        if (size == EMPTY_BYTES.length) {
+            return EMPTY_BYTES;
+        }
+        byte[] out = new byte[Math.toIntExact(size)];
+        MemorySegment.copy(body.segment(), 0L, MemorySegment.ofArray(out), 0L, size);
+        return out;
+    }
+
+    /**
+     * Thrown by {@link ExerisWebClient} when the response status is non-2xx or
+     * when JSON serialisation / deserialisation fails. Carries the wire status
+     * and the raw response body for caller diagnostics.
+     *
+     * <p>Generated client code (e.g., {@code KernelClientGenerator} output)
+     * inspects {@link #isNotFound()} to map 404 responses to
+     * {@link java.util.Optional#empty()} at the entity layer.
+     */
+    public static final class WebClientException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int status;
+        private final String responseBody;
+
+        /* default */ WebClientException(int status, String responseBody, String message, Throwable cause) {
+            super(message, cause);
+            this.status = status;
+            this.responseBody = responseBody == null ? "" : responseBody;
+        }
+
+        /** Wire status code at the time of the failure; {@code 0} if no response was received. */
+        public int status() {
+            return status;
+        }
+
+        /** Raw response body decoded as UTF-8, or empty string when unavailable. */
+        public String responseBody() {
+            return responseBody;
+        }
+
+        /** {@code true} when {@link #status()} equals 404 — the canonical "not found" predicate. */
+        public boolean isNotFound() {
+            return status == HTTP_NOT_FOUND;
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/transport/http3/client/ExerisWebClientIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/transport/http3/client/ExerisWebClientIntegrationTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.transport.http3.client;
+
+import eu.exeris.kernel.community.http.CommunityHttpProvider;
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.http.HttpClientEngine;
+import eu.exeris.kernel.spi.http.HttpConfig;
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpMode;
+import eu.exeris.kernel.spi.http.HttpProvider;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpServerEngine;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Community: ExerisWebClient integration (loopback HttpServerEngine round-trip)")
+class ExerisWebClientIntegrationTest {
+
+    private static final MemoryAllocator ALLOCATOR =
+            new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+    private final HttpProvider provider = new CommunityHttpProvider();
+    private final AtomicReference<HandlerHook> handlerHook = new AtomicReference<>();
+
+    @AfterAll
+    @SuppressWarnings("unused")
+    static void closeAllocator() {
+        ALLOCATOR.close();
+    }
+
+    @Test
+    @DisplayName("GET 200 round-trip deserialises JSON body into the requested type")
+    void getRoundTrip() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) -> {
+                assertThat(method).isEqualTo(HttpMethod.GET);
+                assertThat(path).isEqualTo("/widget/42");
+                respondWithJson(exchange, HttpStatus.OK, Map.of("id", "42", "name", "Cogwheel"));
+            });
+
+            @SuppressWarnings("unchecked") Map<String, Object> body = client.get("/widget/42", Map.class);
+
+            assertThat(body).containsEntry("id", "42").containsEntry("name", "Cogwheel");
+        });
+    }
+
+    @Test
+    @DisplayName("POST 201 round-trip serialises request body and deserialises response")
+    void postRoundTrip() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) -> {
+                assertThat(method).isEqualTo(HttpMethod.POST);
+                assertThat(path).isEqualTo("/widget");
+                byte[] requestBytes = readRequestBody(exchange.request().body());
+                assertThat(new String(requestBytes, StandardCharsets.UTF_8))
+                        .contains("\"name\":\"Cogwheel\"");
+                respondWithJson(exchange, new HttpStatus(201, "Created"),
+                        Map.of("id", "1", "name", "Cogwheel"));
+            });
+
+            @SuppressWarnings("unchecked") Map<String, Object> created = client.post("/widget", Map.of("name", "Cogwheel"), Map.class);
+
+            assertThat(created).containsEntry("id", "1").containsEntry("name", "Cogwheel");
+        });
+    }
+
+    @Test
+    @DisplayName("PATCH 200 round-trip serialises request body and deserialises response")
+    void patchRoundTrip() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) -> {
+                assertThat(method).isEqualTo(HttpMethod.PATCH);
+                assertThat(path).isEqualTo("/widget/42");
+                byte[] requestBytes = readRequestBody(exchange.request().body());
+                assertThat(new String(requestBytes, StandardCharsets.UTF_8))
+                        .contains("\"name\":\"Updated\"");
+                respondWithJson(exchange, HttpStatus.OK, Map.of("id", "42", "name", "Updated"));
+            });
+
+            @SuppressWarnings("unchecked") Map<String, Object> updated = client.patch("/widget/42", Map.of("name", "Updated"), Map.class);
+
+            assertThat(updated).containsEntry("id", "42").containsEntry("name", "Updated");
+        });
+    }
+
+    @Test
+    @DisplayName("DELETE 204 with Void.class returns null and consumes no body")
+    void deleteNoBodyReturnsNull() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) -> {
+                assertThat(method).isEqualTo(HttpMethod.DELETE);
+                assertThat(path).isEqualTo("/widget/42");
+                exchange.respond(HttpResponse.noBody(new HttpStatus(204, "No Content"), HttpVersion.HTTP_1_1));
+            });
+
+            Void result = client.delete("/widget/42", Void.class);
+
+            assertThat(result).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("GET 404 throws WebClientException whose isNotFound() is true")
+    void notFoundMapping() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) ->
+                    exchange.respond(HttpResponse.noBody(HttpStatus.NOT_FOUND, HttpVersion.HTTP_1_1)));
+
+            assertThatThrownBy(() -> client.get("/widget/missing", Map.class))
+                    .isInstanceOf(ExerisWebClient.WebClientException.class)
+                    .satisfies(ex -> {
+                        ExerisWebClient.WebClientException wce = (ExerisWebClient.WebClientException) ex;
+                        assertThat(wce.status()).isEqualTo(404);
+                        assertThat(wce.isNotFound()).isTrue();
+                    });
+        });
+    }
+
+    @Test
+    @DisplayName("GET 500 throws WebClientException with status + body but does not retry")
+    void serverErrorMapping() {
+        runScopedTest(client -> {
+            handlerHook.set((method, path, exchange) -> respondWithBytes(
+                    exchange,
+                    new HttpStatus(500, "Internal Server Error"),
+                    "boom".getBytes(StandardCharsets.UTF_8),
+                    "text/plain"));
+
+            assertThatThrownBy(() -> client.get("/widget/broken", Map.class))
+                    .isInstanceOf(ExerisWebClient.WebClientException.class)
+                    .satisfies(ex -> {
+                        ExerisWebClient.WebClientException wce = (ExerisWebClient.WebClientException) ex;
+                        assertThat(wce.status()).isEqualTo(500);
+                        assertThat(wce.isNotFound()).isFalse();
+                        assertThat(wce.responseBody()).isEqualTo("boom");
+                    });
+        });
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null engine (Objects.requireNonNull contract)")
+    void constructorRejectsNullEngine() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new ExerisWebClient(null, ALLOCATOR, MAPPER));
+    }
+
+    @Test
+    @DisplayName("Verb methods reject null path / responseType / body-for-POST")
+    void verbMethodsRejectNullArguments() {
+        runScopedTest(client -> {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> client.get(null, Map.class));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> client.get("/p", null));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> client.post("/p", null, Map.class));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> client.patch("/p", null, Map.class));
+        });
+    }
+
+    private void runScopedTest(Consumer<ExerisWebClient> testCase) {
+        java.lang.ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR).run(() -> {
+            int port = nextFreePort();
+            try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                 HttpClientEngine engine = provider.createClientEngine(clientConfig(port))) {
+
+                server.setHandler(exchange -> {
+                    HandlerHook hook = handlerHook.get();
+                    if (hook != null) {
+                        hook.handle(exchange.request().method(), exchange.request().path(), exchange);
+                        return;
+                    }
+                    exchange.respond(HttpResponse.noBody(HttpStatus.NOT_FOUND, HttpVersion.HTTP_1_1));
+                });
+
+                server.start();
+                engine.start();
+                ExerisWebClient client = new ExerisWebClient(engine, ALLOCATOR, MAPPER);
+
+                testCase.accept(client);
+            }
+        });
+    }
+
+    private void respondWithJson(HttpExchange exchange,
+                                 HttpStatus status,
+                                 Object payload) {
+        byte[] bytes;
+        try {
+            bytes = MAPPER.writeValueAsBytes(payload);
+        } catch (Exception ex) {
+            throw new IllegalStateException("test serialisation failed", ex);
+        }
+        respondWithBytes(exchange, status, bytes, "application/json");
+    }
+
+    private void respondWithBytes(HttpExchange exchange,
+                                  HttpStatus status,
+                                  byte[] bytes,
+                                  String contentType) {
+        LoanedBuffer body = ALLOCATOR.allocateNetwork(bytes.length);
+        MemorySegment.copy(MemorySegment.ofArray(bytes), 0, body.segment(), 0, bytes.length);
+        body.setSize(bytes.length);
+        List<HttpHeader> headers = List.of(
+                new HttpHeader("content-type", contentType),
+                new HttpHeader("content-length", Integer.toString(bytes.length))
+        );
+        exchange.respond(new HttpResponse(status, HttpVersion.HTTP_1_1, headers, body));
+    }
+
+    private static byte[] readRequestBody(LoanedBuffer body) {
+        if (body == null) {
+            return new byte[0];
+        }
+        long size = body.size();
+        byte[] out = new byte[Math.toIntExact(size)];
+        MemorySegment.copy(body.segment(), 0L, MemorySegment.ofArray(out), 0L, size);
+        return out;
+    }
+
+    private static int nextFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to allocate free TCP port", ex);
+        }
+    }
+
+    private static HttpConfig serverConfig(int port) {
+        return new HttpConfig(
+                HttpMode.SERVER,
+                "127.0.0.1",
+                port,
+                HttpConfig.DEFAULT_MAX_CONNECTIONS,
+                HttpConfig.DEFAULT_IDLE_TIMEOUT_MS,
+                HttpConfig.DEFAULT_MAX_HEADER_COUNT,
+                HttpConfig.DEFAULT_MAX_HEADER_SIZE,
+                HttpConfig.DEFAULT_MAX_REQUEST_BODY_BYTES,
+                false,
+                HttpVersion.HTTP_1_1
+        );
+    }
+
+    private static HttpConfig clientConfig(int port) {
+        return new HttpConfig(
+                HttpMode.CLIENT,
+                "127.0.0.1",
+                port,
+                HttpConfig.DEFAULT_MAX_CONNECTIONS,
+                HttpConfig.DEFAULT_IDLE_TIMEOUT_MS,
+                HttpConfig.DEFAULT_MAX_HEADER_COUNT,
+                HttpConfig.DEFAULT_MAX_HEADER_SIZE,
+                HttpConfig.DEFAULT_MAX_REQUEST_BODY_BYTES,
+                false,
+                HttpVersion.HTTP_1_1
+        );
+    }
+
+    @FunctionalInterface
+    private interface HandlerHook {
+        void handle(HttpMethod method, String path, HttpExchange exchange);
+    }
+}


### PR DESCRIPTION
## Summary

**First Client SPI track** in v0.8. \`exeris-tooling\` \`KernelClientGenerator\` emits typed per-entity REST clients that reference a kernel-side \`eu.exeris.kernel.transport.http3.client.ExerisWebClient\` — until this PR, the generator could emit code that did not compile against the kernel artifact. **This PR lands the kernel-side class and its loopback integration test.**

## New files (3)

### \`docs/adr/ADR-026-client-side-application-api.md\` (156 LOC)

Documents the design decisions: kernel-side façade over \`HttpClientEngine\` SPI, Jackson 3 JSON binding, **HTTP-verb-level API surface** (verb-shaped chosen over entity-shaped after reading the generator's actual emission — the generator already emits entity wrappers on top), tier-agnostic \`http3\` package name kept for generator stability, module placement in **Community** (Jackson already on classpath; SPI must remain binding-blind), full rejected alternatives section, integration-test vs abstract-TCK rationale (single concrete impl).

### \`exeris-kernel-community/.../transport/http3/client/ExerisWebClient.java\` (260 LOC)

Public final class.

\`\`\`java
public ExerisWebClient(HttpClientEngine engine, MemoryAllocator allocator, ObjectMapper mapper);

public <T> T get(String path, Class<T> responseType);
public <T> T post(String path, Object body, Class<T> responseType);
public <T> T patch(String path, Object body, Class<T> responseType);
public <T> T delete(String path, Class<T> responseType);

public static final class WebClientException extends RuntimeException {
    public int status();
    public String responseBody();
    public boolean isNotFound();  // == 404 — used by generator-emitted code
}
\`\`\`

Memory ownership:

- Outbound body: allocated via \`MemoryAllocator.allocateNetwork\`, serialised by Jackson, ownership transfers to engine on \`send\`.
- Inbound response body: closed in \`finally\` after Jackson deserialisation. Callers never see the buffer.

No implicit retry — non-2xx maps to \`WebClientException\` exactly once.

### \`exeris-kernel-community/src/test/.../ExerisWebClientIntegrationTest.java\` (297 LOC)

Loopback integration test — real \`CommunityHttpServerEngine\` on a free port, real \`CommunityHttpClientEngine\`, real Jackson 3 \`ObjectMapper\`. Scoped through \`KernelProviders.MEMORY_ALLOCATOR\`. Fully hermetic.

**8 tests:**

- GET 200 round-trip with JSON deserialisation
- POST 201 round-trip (request body serialised + response deserialised)
- PATCH 200 round-trip
- DELETE 204 with \`Void.class\` returns null
- 404 → \`WebClientException.isNotFound()\` = true
- 500 → \`WebClientException\` carries status + body, no retry
- Constructor null-engine rejection
- Verb method null path / null \`responseType\` / null body rejection

## Public API contract (covered by tests)

| Behavior | Test |
|---|---|
| GET / POST / PATCH / DELETE verbs | ✅ 4 round-trip tests |
| Non-2xx → \`WebClientException(status, responseBody, message, cause)\` | ✅ 404 + 500 |
| 404 specifically → \`WebClientException.isNotFound() == true\` | ✅ |
| \`Void.class\` \`responseType\` → returns null cleanly | ✅ |
| All entry-point arguments validated against null | ✅ |

## Memory + threading model

- Every method blocks calling virtual thread through \`HttpClientEngine.send\` (no async wrapping, no \`CompletableFuture\`).
- Outbound \`LoanedBuffer\` allocated, populated by Jackson, ownership transferred to engine on send.
- Inbound \`LoanedBuffer\` released in \`finally\` block after Jackson deserialisation.
- No implicit retry on non-2xx — callers parallelise via more virtual threads.

## Follow-ups

- **\`~/exeris-systems/exeris-docs/adr-index.md\`** row for ADR-026 — separate commit on the docs repo (per global namespace policy).
- **\`docs/ROADMAP.md\`** entry — landed in a follow-up commit on this PR if appropriate, or part of release-cut housekeeping.
- **\`exeris-benchmarks/community-app\`** client-variant benchmark — out of kernel CI scope; tracked on the benchmarks repo's cadence.
- **\`KernelProviders.WEB_CLIENT\` \`ScopedValue\`** binding for a default client — intentionally deferred to v0.9+; applications and codegen output construct \`ExerisWebClient\` explicitly today.

## Test plan

- [x] \`ExerisWebClientIntegrationTest\` 8/8 green (all verbs + error paths + null guards)
- [x] Full reactor verify SUCCESS (SPI + TCK + Core + Community Testkit + Community + Build Config + Parent + Root)
- [x] PMD 0 violations on community module
- [x] Checkstyle 0 violations on community module
- [x] Local JDK 26+35 G1 crash worked around with \`-XX:+UseSerialGC\` (pre-existing memory note)

## Sprint 2 status

Per \`docs/v0.8-sprint-and-implementation-map.md\` Sprint 2 deliverables:

- ✅ ADR-026 documenting Client SPI shape
- ✅ \`ExerisWebClient\` + \`WebClientException\` public API
- ✅ Community integration coverage (loopback round-trip)
- ⏳ ROADMAP entry update — follow-up commit on this PR
- ⏳ \`~/exeris-systems/exeris-docs/adr-index.md\` row for ADR-026 — separate docs repo commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)