### PR TITLE
v0.8 Sprint 6 (Coverage C-P0-02): revive 3 dead Kafka IT-tests + untag OffHeapTlsEngineLoopbackIT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -166,6 +166,71 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  kafka-integration-gate:
+    # v0.8 Sprint 6 (Coverage C-P0-02 absorption): dedicated job that runs the
+    # Kafka @Tag("integration") tests in exeris-kernel-community-kafka. The
+    # module only configures Surefire (no Failsafe), and its default
+    # <excludedGroups>integration</excludedGroups> drops the 3 IT-tests from
+    # every reactor build:
+    #   - CommunityKafkaEventEngineTckIT
+    #   - CommunityKafkaFlowChoreographyTckIT
+    #   - CommunityCrossEngineChoreographyIT
+    # All three spin Testcontainers (Kafka + Postgres) and exercise the broker
+    # path under real wire conditions. Without this gate they exist in tree
+    # but never run on CI — coverage % is ~0% on the kafka subsystem.
+    #
+    # Mirrors persistence-rls-gate exactly: override -DincludedGroups=integration
+    # and clear -DexcludedGroups= so Surefire picks them up.
+    name: Kafka Integration Gate
+    runs-on: ubuntu-latest
+    needs: build-and-verify
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache JDK tarball
+        id: jdk-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/jdk.tar.gz
+          key: ${{ env.JDK_CACHE_KEY }}
+
+      - name: Fetch JDK
+        if: steps.jdk-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          wget -q -O ${{ runner.temp }}/jdk.tar.gz ${{ env.JDK_URL }}
+          echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
+
+      - name: Inject JDK into Runner
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'jdkfile'
+          jdkFile: ${{ runner.temp }}/jdk.tar.gz
+          java-version: ${{ env.JDK_VER }}
+          architecture: x64
+          cache: maven
+
+      - name: Run kafka integration gate
+        run: |
+          mvn -pl exeris-kernel-community-kafka -am install -DskipTests -B -e
+          mvn -pl exeris-kernel-community-kafka \
+            -DincludedGroups=integration \
+            -DexcludedGroups= \
+            test -B -e
+
+      - name: Upload kafka JFR recordings
+        if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-kafka-${{ github.run_number }}
+          path: exeris-kernel-community-kafka/target/*.jfr
+          if-no-files-found: warn
+          retention-days: 14
+
   transport-stress-gate:
     # TCK-064 (v0.8 Sprint 0): dedicated job for @Tag("stress") transport tests.
     # The default `Build & TCK Verification` job excludes the stress group because the

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -126,6 +126,24 @@
                     <argLine>@{coverage.argLine} ${jvm.args}</argLine>
                     <groups>${includedGroups}</groups>
                     <excludedGroups>${excludedGroups}</excludedGroups>
+                    <!--
+                        v0.8 Sprint 6 (Coverage C-P0-02): pick up *IT.java in addition to the
+                        Surefire defaults so the kafka-integration-gate CI job (which calls
+                        `-DincludedGroups=integration -DexcludedGroups=` against this module)
+                        actually discovers CommunityKafkaEventEngineTckIT /
+                        CommunityKafkaFlowChoreographyTckIT / CommunityCrossEngineChoreographyIT.
+                        Default Surefire 3.2.5 includes only *Test.java / *Tests.java / Test*.java /
+                        *TestCase.java; the three IT files end in IT and were silently dead
+                        before this include addition. Default tag-exclusion still skips them
+                        on `mvn test` without the integration group override.
+                    -->
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
@@ -23,7 +23,6 @@ import eu.exeris.kernel.spi.memory.MemoryStats;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -75,7 +74,13 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @since 0.5.0
  */
-@Tag("integration")
+// v0.8 Sprint 6 (Coverage C-P0-02): @Tag("integration") removed — the class
+// name ends in "IT" so Maven Failsafe picks it up automatically on `mvn verify`
+// regardless of tags. The tag was misleading because it suggested the IT was
+// dead from CI (it ran via Failsafe all along). Keeping the JUnit tag would
+// still cause `mvn -DexcludedGroups=integration ...` opt-outs to drop the test
+// on Surefire-only paths even though Failsafe runs it; removing the tag aligns
+// observable behavior with the Failsafe-based execution model.
 @EnabledOnOs(OS.LINUX)
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 @DisplayName("IT: OffHeapTlsEngine — TLS 1.3 loopback handshake + round-trip")


### PR DESCRIPTION
## Summary

Two of the three "cheapest wins" from the v0.8 Coverage audit, absorbed into Sprint 6:

1. **kafka-integration-gate CI job** (mirror \`persistence-rls-gate\`) — 0.5d
2. **OffHeapTlsEngineLoopbackIT** untag — 0.5d (already runs via Failsafe; remove misleading \`@Tag\`)

Third item (JaCoCo \`<check>\` rule + \`-Pcoverage\` in default CI, ~2d) is a separate larger PR landing next.

## Kafka IT-tests revival

Three integration tests in \`exeris-kernel-community-kafka\` have been **silently dead since v0.7.0**:

- \`CommunityKafkaEventEngineTckIT\` (5 tests)
- \`CommunityKafkaFlowChoreographyTckIT\` (4 tests)
- \`CommunityCrossEngineChoreographyIT\` (1 test)

**Root cause:** the module configures only Surefire (no Failsafe) and Surefire 3.2.5 default \`<includes>\` matches only \`*Test.java\` / \`*Tests.java\` / \`Test*.java\` / \`*TestCase.java\` patterns. None of the three IT files ends in \`Test\`, so Surefire silently skipped them across every reactor build. Same dormant pattern explains why the audit flagged the kafka subsystem coverage as ~0%.

**Two-part fix:**

| Component | Change |
|---|---|
| \`exeris-kernel-community-kafka/pom.xml\` | Add \`**/*IT.java\` to Surefire \`<includes>\` alongside the defaults. \`<excludedGroups>integration</excludedGroups>\` still keeps them out of \`mvn test\` (default unit suite stays fast and Docker-free). |
| \`.github/workflows/maven.yml\` | New \`kafka-integration-gate\` CI job mirroring \`persistence-rls-gate\` (parallel to main build-and-verify, depends on it). Override: \`-DincludedGroups=integration -DexcludedGroups=\` so Surefire picks up the 3 ITs. |

**Local verification:** all 10 kafka IT tests now run + green (~24s including Testcontainers Kafka + Postgres container startup).

## OffHeapTlsEngineLoopbackIT untag

The test was tagged \`@Tag("integration")\` but Maven Failsafe picks it up automatically (class name ends in \`IT\`) on \`mvn verify\`. Default CI already ran it via Failsafe — the tag was misleading, suggesting "dead from CI" when it has been running all along (the audit flagged it before this was understood).

Removing the \`@Tag\` (plus its no-longer-needed import) aligns observable behavior with the Failsafe-based execution model. Class header gets a Sprint 6 comment explaining the historical confusion so future readers don't reintroduce the tag.

**Local verification:** 3 tests in \`OffHeapTlsEngineLoopbackIT\` continue to run + green via Failsafe (0.4s, unchanged).

## Net effect on coverage measurability

| | Before | After |
|---|---|---|
| Kafka subsystem IT tests in CI | 0 / 10 | **10 / 10** |
| OffHeapTlsEngineLoopbackIT discoverability | Failsafe (correct) + misleading tag | Failsafe (correct) — tag removed |
| Kafka subsystem integration coverage | unmeasured (no tests ran) | measurable |

This is the **gate that JaCoCo's measurement depends on** — the follow-up JaCoCo PR can then enforce \`<check>\` rules with real coverage numbers, not 0% baselines.

## Test plan

- [x] kafka-integration-gate command verified locally: 10/10 green
  - CommunityCrossEngineChoreographyIT 1/1
  - CommunityKafkaEventEngineTckIT 5/5
  - CommunityKafkaFlowChoreographyTckIT 4/4
- [x] OffHeapTlsEngineLoopbackIT continues to run via Failsafe: 3/3 green
- [x] PMD 0 violations on core + community-kafka modules
- [x] Checkstyle 0 violations on core + community-kafka modules
- [ ] CI: kafka-integration-gate job green on this PR

## Sprint 6 audit-absorption tracker (cumulative)

| Item | Status |
|---|---|
| A3 D-CR-01..05 doc drift fixes | ✅ earlier |
| B4 KernelErrorCodes per-constant audit | ✅ earlier |
| BUILD-107 kernel-legacy archive | ✅ earlier |
| ARCH-108 ArchTest unblock | ✅ earlier |
| DOC-109 N3 30 orphan-code config knobs | ✅ earlier |
| **Coverage C-P0-02a kafka-integration-gate** | **✅ this PR** |
| **Coverage C-P0-02b OffHeapTlsEngineLoopbackIT untag** | **✅ this PR** |
| Coverage C-P0-01 JaCoCo \`<check>\` + \`-Pcoverage\` in CI | ⏳ next PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)