### PR TITLE
v0.8 Sprint 6 (Coverage C-P0-01): JaCoCo <check> per-module + -Pcoverage in default CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -76,8 +76,14 @@ jobs:
         #     not transient flake). 90 s is ~3× the prior bump to absorb the JDK
         #     26+35 schedule pressure tail; happy path drain is sub-second so the
         #     widened budget only kicks in under worst-case CI contention.
+        #
+        # v0.8 Sprint 6 (Coverage C-P0-01): -Pcoverage activates JaCoCo agent +
+        # report + per-module <check> rule enforcement. Per-module LINE coverage
+        # floors live in each module's <jacoco.line.minimum> property
+        # (ratcheted ~5-9 pp below current baseline).
         run: |
           mvn clean verify -B -e \
+            -P coverage \
             -Djdk.virtualThreadScheduler.parallelism=16 \
             -Djdk.virtualThreadScheduler.maxPoolSize=64 \
             -Dexeris.tck.transport.drainTimeoutSeconds=90

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -20,6 +20,13 @@
 		<maven.deploy.skip>false</maven.deploy.skip>
 		<pmd.skip>true</pmd.skip>
 		<maven.compiler.release>26</maven.compiler.release>
+
+		<!--
+			v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the
+			build-config bundle. Current measurement: ~91% (small module,
+			high coverage). Ratchet at 0.80.
+		-->
+		<jacoco.line.minimum>0.80</jacoco.line.minimum>
 	</properties>
 
 	<dependencyManagement>

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -29,6 +29,16 @@
             Default Surefire runs exclude them so the unit suite stays fast and Docker-free.
         -->
         <excludedGroups>integration</excludedGroups>
+
+        <!--
+            v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Kafka bundle.
+            Current measurement: ~28% from unit suite only. The 10 Testcontainers
+            IT-tests revived in this same Sprint (kafka-integration-gate) run in a
+            separate CI job with their own jacoco.exec — IT coverage is not merged
+            into this floor. Ratchet at 0.20 — blocks unit-suite regressions while
+            the IT-merge follow-up is pending.
+        -->
+        <jacoco.line.minimum>0.20</jacoco.line.minimum>
     </properties>
 
     <dependencies>

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -34,6 +34,16 @@
               mvn test -Dtest=NativeTcpTransportStressTest (targeted-test-run profile)
         -->
         <excludedGroups>flamegraph,integration,stress</excludedGroups>
+
+        <!--
+            v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Community bundle.
+            Current measurement: ~69% from unit suite + IntegrationTest-named tests.
+            Several @Tag("integration") tests live in this module but only the
+            persistence-rls-gate CI job runs them (separate jacoco.exec). Ratchet at
+            0.55 — keeps headroom for the IT-coverage-not-merged gap, but blocks
+            unit-suite regressions.
+        -->
+        <jacoco.line.minimum>0.55</jacoco.line.minimum>
     </properties>
 
     <dependencies>

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -19,6 +19,15 @@
         WatermarkManager, ResourceArbiter. Depends only on exeris-kernel-spi.
     </description>
 
+    <properties>
+        <!--
+            v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Core bundle.
+            Current measurement: ~74% (deepest test coverage in the reactor — TCK
+            backing + JFR event sites). Ratchet at 0.65 — regressions blocked.
+        -->
+        <jacoco.line.minimum>0.65</jacoco.line.minimum>
+    </properties>
+
     <dependencies>
         <!-- SPI contracts — The Wall -->
         <dependency>

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -15,6 +15,16 @@
     <name>Exeris Kernel :: SPI</name>
     <description>The "Invisible Wall" — agnostic L0/L1/L2 contracts and RAII memory protocols.</description>
 
+    <properties>
+        <!--
+            v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the SPI bundle.
+            Current measurement: ~36% (records / enums / interface skeletons inflate
+            the denominator). Ratchet at 0.30 — regressions blocked, headroom for
+            organic improvement.
+        -->
+        <jacoco.line.minimum>0.30</jacoco.line.minimum>
+    </properties>
+
     <dependencies>
         <!--
             Zero-Magic Test Guard (Architectural Mandate):

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,16 @@
 
         <jdk.preview.enable>--enable-preview</jdk.preview.enable>
         <coverage.argLine/>
+
+        <!--
+            v0.8 Sprint 6 (Coverage C-P0-01): default JaCoCo LINE coverage floor
+            applied to every module that produces a jacoco.exec. Per-module
+            overrides live in each module's <properties>. Default (0.20) is a
+            floor that any module with source must meet; modules without their
+            own tests (tck, community-testkit) skip the check naturally because
+            no jacoco.exec is produced.
+        -->
+        <jacoco.line.minimum>0.20</jacoco.line.minimum>
         <jvm.args>
             -XX:+UnlockExperimentalVMOptions
             -XX:+UseZGC
@@ -103,6 +113,38 @@
                                         <format>XML</format>
                                         <format>HTML</format>
                                     </formats>
+                                </configuration>
+                            </execution>
+                            <!--
+                                v0.8 Sprint 6 (Coverage C-P0-01 absorption): enforce LINE
+                                coverage floor per module. Each module-with-source sets its
+                                own ${jacoco.line.minimum} in <properties> (ratchet pattern —
+                                threshold slightly below current coverage so regressions are
+                                caught while existing baseline passes). Modules without their
+                                own tests (tck, community-testkit, parent, bom) produce no
+                                jacoco.exec — the check goal then no-ops silently. The check
+                                runs only when -Pcoverage is active (default CI main job).
+                            -->
+                            <execution>
+                                <id>jacoco-check</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.line.minimum}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                    <haltOnFailure>true</haltOnFailure>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## Summary

**Third "cheapest win"** from the v0.8 Coverage audit absorbed into Sprint 6 (after PR #131 kafka-integration-gate + OffHeapTlsEngineLoopbackIT untag). **Makes coverage % measurable AND enforceable** for every PR.

## JaCoCo \`<check>\` rule per module

Root pom coverage profile gains a third execution alongside \`prepare-jacoco-agent\` + \`jacoco-report\`:

```xml
<execution>
  <id>jacoco-check</id>
  <phase>verify</phase>
  <goals><goal>check</goal></goals>
  <configuration>
    <rules>
      <rule>
        <element>BUNDLE</element>
        <limits>
          <limit>
            <counter>LINE</counter>
            <value>COVEREDRATIO</value>
            <minimum>\${jacoco.line.minimum}</minimum>
          </limit>
        </limits>
      </rule>
    </rules>
    <haltOnFailure>true</haltOnFailure>
  </configuration>
</execution>
```

The threshold is a Maven property each module overrides in its own \`<properties>\`. **Ratchet pattern** — set ~5-9 pp below current measurement so existing baseline passes and regressions are blocked:

| Module | Current LINE | Floor | Notes |
|---|---|---|---|
| exeris-kernel-build-config | 91% | **0.80** | Small module, high coverage |
| exeris-kernel-spi | 36% | **0.30** | Records / enums inflate denominator |
| exeris-kernel-core | 74% | **0.65** | Deepest test coverage in reactor |
| exeris-kernel-community | 69% | **0.55** | IT coverage in persistence-rls-gate; not merged |
| exeris-kernel-community-kafka | 28% | **0.20** | Testcontainers IT coverage in kafka-integration-gate; not merged |

Default property (root pom) = **0.20**. Modules without their own tests (\`tck\`, \`community-testkit\`, \`parent\`, \`bom\`) produce no \`jacoco.exec\` — the check goal then no-ops silently.

## \`-Pcoverage\` activated in CI

The main \`build-and-verify\` job in \`.github/workflows/maven.yml\` now runs \`mvn clean verify -P coverage ...\`. This activates:

- \`prepare-jacoco-agent\` (initialize) — JaCoCo Java agent instruments classes
- \`jacoco-report\` (verify) — XML + HTML reports per module
- \`jacoco-check\` (verify) — per-module LINE floor enforcement

**Build time impact:** ~+5% from JaCoCo agent overhead (full reactor verify locally: 1:55 with coverage vs ~1:42 without). Acceptable.

## Sprint 6 Coverage C-P0 absorption — fully closed

| Item | Status |
|---|---|
| **C-P0-01 JaCoCo \`<check>\` rules + \`-Pcoverage\` in CI** | **✅ this PR** |
| C-P0-02a kafka-integration-gate | ✅ PR #131 |
| C-P0-02b OffHeapTlsEngineLoopbackIT untag | ✅ PR #131 |

## Follow-ups (not in this PR)

- **Coverage report merging across CI jobs**: \`kafka-integration-gate\` and \`persistence-rls-gate\` generate IT-specific \`jacoco.exec\` that is NOT merged into the main job's measurement. As a result, floors for \`community\` + \`community-kafka\` are conservative. Merging requires either \`jacoco-maven-plugin\`'s \`merge\` goal or a coverage-aggregator module.
- **Ratchet tightening**: once IT-merge lands, floors can be raised closer to current values (community 0.65, kafka 0.40+).
- **BRANCH coverage rule** (currently only LINE is enforced).

## Test plan

- [x] Full reactor verify locally with \`-P coverage\`: BUILD SUCCESS (PMD + Checkstyle + JaCoCo agent + report + check all green)
- [x] All 5 source-bearing modules pass their floors:
  - build-config 91% > 80
  - spi 36% > 30
  - core 74% > 65
  - community 69% > 55
  - community-kafka 28% > 20
- [x] tck / community-testkit / bom / parent — jacoco-check no-ops (no jacoco.exec produced)
- [x] CI build-and-verify command updated to include \`-P coverage\`
- [ ] CI green on this PR with coverage enforcement active

🤖 Generated with [Claude Code](https://claude.com/claude-code)