### PR TITLE
v0.8 Sprint 3 (QA-015): decompose CommunityHttpClientEngine — close GodClass + TooManyMethods

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientEngine.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientEngine.java
@@ -9,14 +9,11 @@
 package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
-import eu.exeris.kernel.core.http.http1.Http1ResponseEncoder;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpClientEngine;
 import eu.exeris.kernel.spi.http.HttpConfig;
-import eu.exeris.kernel.spi.http.HttpHeader;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpResponse;
-import eu.exeris.kernel.spi.http.HttpStatus;
 import eu.exeris.kernel.spi.http.HttpVersion;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
@@ -25,30 +22,28 @@ import eu.exeris.kernel.spi.transport.TransportConnection;
 import eu.exeris.kernel.spi.transport.TransportEngine;
 import eu.exeris.kernel.spi.transport.TransportStream;
 
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@SuppressWarnings({
-    "PMD.GodClass",
-    "PMD.CyclomaticComplexity",
-    "PMD.TooManyMethods"
-})
+/**
+ * Community HTTP/1.x client engine — drives outbound requests over a single
+ * {@link TransportConnection} per call, blocking the calling virtual thread.
+ *
+ * <h2>Decomposition (v0.8 Sprint 3 QA-015)</h2>
+ * <p>Request byte layout lives in {@link CommunityHttpClientRequestEncoder};
+ * response parsing + completeness helpers live in
+ * {@link CommunityHttpClientResponseDecoder}. This class retains the
+ * {@code TransportEngine} lifecycle (start/close/isRunning), the per-request
+ * connection orchestration, the response read loop, and dependency
+ * resolution (allocator + transport).
+ *
+ * @since 0.5.0
+ */
+@SuppressWarnings("PMD.CyclomaticComplexity") // multi-state response read loop is intrinsically cohesive.
 final class CommunityHttpClientEngine implements HttpClientEngine {
 
     private static final String ENGINE_NAME = "community-http-client";
-    private static final String HEADER_HOST = "Host";
-    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
-    private static final String HEADER_CONNECTION = "Connection";
-    private static final String HEADER_CLOSE = "close";
     private static final int READ_CHUNK_BYTES = 8 * 1024;
-    private static final int STATUS_LINE_MIN_PARTS = 2;
-    private static final int STATUS_LINE_PARTS_WITH_REASON = 3;
 
     private final HttpConfig config;
     private final MemoryAllocator allocator;
@@ -155,16 +150,8 @@ final class CommunityHttpClientEngine implements HttpClientEngine {
         int bodyBytes = request.hasBody() ? (int) request.body().size() : 0;
         int capacity = 512 + request.headers().size() * 128 + bodyBytes;
         try (LoanedBuffer outbound = allocator.allocateNetwork(capacity)) {
-            MemorySegment seg = outbound.segment();
-            long pos = writeRequestLine(seg, request);
-            HeaderWriteResult headerWriteResult = writeRequestHeaders(seg, pos, request);
-            pos = writeDefaultRequestHeaders(
-                    seg,
-                    headerWriteResult.position(),
-                    headerWriteResult.presence(),
-                    connection,
-                    bodyBytes);
-            pos = writeRequestBody(seg, pos, request, bodyBytes);
+            long pos = CommunityHttpClientRequestEncoder.writeRequest(
+                    outbound.segment(), request, connection, bodyBytes);
             outbound.setSize(pos);
             stream.write(outbound.segment(), (int) outbound.size());
         }
@@ -187,10 +174,11 @@ final class CommunityHttpClientEngine implements HttpClientEngine {
                     } else {
                         total += read;
                         aggregate.setSize(total);
-                        headerTerminator = resolveHeaderTerminator(headerTerminator, aggregate.segment(), total);
-                        expectedTotal = resolveExpectedTotal(expectedTotal, aggregate.segment(),
-                                        total, headerTerminator);
-                        responseComplete = isResponseComplete(total, expectedTotal);
+                        headerTerminator = CommunityHttpClientResponseDecoder.resolveHeaderTerminator(
+                                headerTerminator, aggregate.segment(), total);
+                        expectedTotal = CommunityHttpClientResponseDecoder.resolveExpectedTotal(
+                                expectedTotal, aggregate.segment(), total, headerTerminator);
+                        responseComplete = CommunityHttpClientResponseDecoder.isResponseComplete(total, expectedTotal);
                     }
                 }
             }
@@ -199,245 +187,14 @@ final class CommunityHttpClientEngine implements HttpClientEngine {
                 throw new IllegalStateException("Remote peer returned an empty HTTP response");
             }
 
-            return decodeResponse(aggregate, total, requestVersion);
+            return CommunityHttpClientResponseDecoder.decodeResponse(allocator, aggregate, total, requestVersion);
         }
-    }
-
-    private static long writeRequestLine(MemorySegment seg, HttpRequest request) {
-        long pos = 0L;
-        pos = writeAscii(seg, pos, request.method().name());
-        seg.set(ValueLayout.JAVA_BYTE, pos, (byte) ' ');
-        pos += 1;
-        pos = writeAscii(seg, pos, request.path());
-        seg.set(ValueLayout.JAVA_BYTE, pos, (byte) ' ');
-        pos += 1;
-        pos = writeAscii(seg, pos, versionToken(request.version()));
-        return Http1ResponseEncoder.writeHeaderEnd(seg, pos);
-    }
-
-    private static HeaderWriteResult writeRequestHeaders(MemorySegment seg, long startPos, HttpRequest request) {
-        long pos = startPos;
-        boolean hasHost = false;
-        boolean hasContentLength = false;
-        boolean hasConnection = false;
-        for (HttpHeader header : request.headers()) {
-            if (header.nameEqualsIgnoreCase(HEADER_HOST)) {
-                hasHost = true;
-            }
-            if (header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
-                hasContentLength = true;
-            }
-            if (header.nameEqualsIgnoreCase(HEADER_CONNECTION)) {
-                hasConnection = true;
-            }
-            pos = Http1ResponseEncoder.writeHeader(seg, pos, header.name(), header.value());
-        }
-        return new HeaderWriteResult(pos, new HeaderPresence(hasHost, hasContentLength, hasConnection));
-    }
-
-    private static long writeDefaultRequestHeaders(MemorySegment seg,
-                                                   long startPos,
-                                                   HeaderPresence presence,
-                                                   TransportConnection connection,
-                                                   int bodyBytes) {
-        long pos = startPos;
-        if (!presence.hasHost()) {
-            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_HOST,
-                    connection.remoteAddress() + ":" + connection.remotePort());
-        }
-        if (!presence.hasContentLength()) {
-            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_CONTENT_LENGTH,
-                    Integer.toString(bodyBytes));
-        }
-        if (!presence.hasConnection()) {
-            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_CONNECTION, HEADER_CLOSE);
-        }
-        return Http1ResponseEncoder.writeHeaderEnd(seg, pos);
-    }
-
-    private static long writeRequestBody(MemorySegment seg, long startPos, HttpRequest request, int bodyBytes) {
-        long pos = startPos;
-        if (bodyBytes > 0) {
-            MemorySegment.copy(request.body().segment(), 0L, seg, pos, bodyBytes);
-            pos += bodyBytes;
-        }
-        return pos;
-    }
-
-    private static long resolveHeaderTerminator(long currentHeaderTerminator, MemorySegment segment, long totalBytes) {
-        if (currentHeaderTerminator >= 0) {
-            return currentHeaderTerminator;
-        }
-        return findHeaderTerminator(segment, 0, totalBytes);
-    }
-
-    private static long resolveExpectedTotal(long currentExpectedTotal,
-                                             MemorySegment segment,
-                                             long totalBytes,
-                                             long headerTerminator) {
-        if (currentExpectedTotal >= 0 || headerTerminator < 0) {
-            return currentExpectedTotal;
-        }
-        long statusLineEnd = CommunityHttpBufferOps.findCrLf(segment, 0, totalBytes);
-        if (statusLineEnd < 0) {
-            return -1;
-        }
-        List<HttpHeader> headers = parseHeaders(segment, statusLineEnd + 2, headerTerminator);
-        long contentLength = resolveContentLengthFromHeaders(headers);
-        if (contentLength < 0) {
-            return -1;
-        }
-        return headerTerminator + 4 + contentLength;
-    }
-
-    private static boolean isResponseComplete(long totalBytes, long expectedTotalBytes) {
-        return expectedTotalBytes > 0 && totalBytes >= expectedTotalBytes;
-    }
-
-    private HttpResponse decodeResponse(LoanedBuffer aggregate, long total, HttpVersion requestVersion) {
-        long statusLineEnd = CommunityHttpBufferOps.findCrLf(aggregate.segment(), 0, total);
-        if (statusLineEnd < 0) {
-            throw new IllegalStateException("Invalid HTTP response: missing status line terminator");
-        }
-
-        String statusLine = asciiString(aggregate.segment(), 0, statusLineEnd);
-        StatusLine parsedStatus = parseStatusLine(statusLine, requestVersion);
-
-        long headerStart = statusLineEnd + 2;
-        long headerEnd = findHeaderTerminator(aggregate.segment(), headerStart, total);
-        if (headerEnd < 0) {
-            throw new IllegalStateException("Invalid HTTP response: missing header terminator");
-        }
-
-        List<HttpHeader> headers = parseHeaders(aggregate.segment(), headerStart, headerEnd);
-        long bodyStart = headerEnd + 4;
-        long availableBodyBytes = total - bodyStart;
-        if (availableBodyBytes < 0) {
-            throw new IllegalStateException("Invalid HTTP response: body start exceeds received bytes");
-        }
-        long bodyLength = resolveBodyLength(headers, availableBodyBytes);
-        if (bodyLength > availableBodyBytes) {
-            throw new IllegalStateException(
-                    "Truncated HTTP response body: expected " + bodyLength
-                    + " bytes but received " + availableBodyBytes + " bytes");
-        }
-
-        LoanedBuffer bodyBuffer = null;
-        if (bodyLength > 0) {
-            bodyBuffer = allocator.allocateNetwork((int) bodyLength);
-            MemorySegment.copy(aggregate.segment(), bodyStart, bodyBuffer.segment(), 0, bodyLength);
-            bodyBuffer.setSize(bodyLength);
-        }
-        return new HttpResponse(parsedStatus.status(), parsedStatus.version(), headers, bodyBuffer);
-    }
-
-    private static List<HttpHeader> parseHeaders(MemorySegment segment, long start, long endExclusive) {
-        List<HttpHeader> headers = new ArrayList<>();
-        long cursor = start;
-        while (cursor < endExclusive) {
-            long lineEnd = CommunityHttpBufferOps.findCrLf(segment, cursor, endExclusive + 2);
-            if (lineEnd < 0 || lineEnd == cursor) {
-                break;
-            }
-            String line = asciiString(segment, cursor, lineEnd);
-            int separator = line.indexOf(':');
-            if (separator > 0) {
-                String name = line.substring(0, separator).trim();
-                String value = line.substring(separator + 1).trim();
-                headers.add(new HttpHeader(name, value));
-            }
-            cursor = lineEnd + 2;
-        }
-        return List.copyOf(headers);
-    }
-
-    private static long resolveBodyLength(List<HttpHeader> headers, long fallbackBytes) {
-        Optional<String> contentLength = headers.stream()
-                .filter(header -> header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH))
-                .map(HttpHeader::value)
-                .findFirst();
-        if (contentLength.isPresent()) {
-            try {
-                return Long.parseLong(contentLength.get());
-            } catch (NumberFormatException _) {
-                return Math.max(fallbackBytes, 0L);
-            }
-        }
-        return Math.max(fallbackBytes, 0L);
-    }
-
-    private static long resolveContentLengthFromHeaders(List<HttpHeader> headers) {
-        for (HttpHeader h : headers) {
-            if (h.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
-                try {
-                    return Long.parseLong(h.value().trim());
-                } catch (NumberFormatException _) {
-                    return -1;
-                }
-            }
-        }
-        return -1;
-    }
-
-    private static StatusLine parseStatusLine(String statusLine, HttpVersion requestVersion) {
-        String[] parts = statusLine.split(" ", STATUS_LINE_PARTS_WITH_REASON);
-        if (parts.length < STATUS_LINE_MIN_PARTS) {
-            throw new IllegalStateException("Invalid HTTP response status line: " + statusLine);
-        }
-        HttpVersion version = switch (parts[0]) {
-            case "HTTP/1.0" -> HttpVersion.HTTP_1_0;
-            case "HTTP/1.1" -> HttpVersion.HTTP_1_1;
-            case "HTTP/2", "HTTP/2.0" -> HttpVersion.HTTP_2;
-            default -> requestVersion;
-        };
-        int code;
-        try {
-            code = Integer.parseInt(parts[1]);
-        } catch (NumberFormatException ex) {
-            throw new IllegalStateException("Invalid HTTP status code in status line: " + statusLine, ex);
-        }
-        String reason = parts.length == STATUS_LINE_PARTS_WITH_REASON ? parts[2] : "";
-        return new StatusLine(version, new HttpStatus(code, reason));
-    }
-
-    private static long findHeaderTerminator(MemorySegment segment, long start, long endExclusive) {
-        for (long index = start; index + 3 < endExclusive; index++) {
-            if (segment.get(ValueLayout.JAVA_BYTE, index) == '\r'
-                    && segment.get(ValueLayout.JAVA_BYTE, index + 1) == '\n'
-                    && segment.get(ValueLayout.JAVA_BYTE, index + 2) == '\r'
-                    && segment.get(ValueLayout.JAVA_BYTE, index + 3) == '\n') {
-                return index;
-            }
-        }
-        return -1;
     }
 
     private int resolveAggregateCapacity() {
         long configured = config.maxRequestBodyBytes();
         long bounded = configured < 0 ? 64L * 1024L : configured + 8L * 1024L;
         return (int) Math.max(bounded, 8L * 1024L);
-    }
-
-    private static String asciiString(MemorySegment segment, long startInclusive, long endExclusive) {
-        int length = Math.toIntExact(endExclusive - startInclusive);
-        byte[] bytes = segment.asSlice(startInclusive, length).toArray(ValueLayout.JAVA_BYTE);
-        return new String(bytes, StandardCharsets.US_ASCII);
-    }
-
-    private static long writeAscii(MemorySegment seg, long pos, String value) {
-        for (int i = 0; i < value.length(); i++) {
-            seg.set(ValueLayout.JAVA_BYTE, pos + i, (byte) value.charAt(i));
-        }
-        return pos + value.length();
-    }
-
-    private static String versionToken(HttpVersion version) {
-        return switch (version) {
-            case HTTP_1_0 -> "HTTP/1.0";
-            case HTTP_1_1 -> "HTTP/1.1";
-            case HTTP_2 -> "HTTP/2";
-            case HTTP_3 -> "HTTP/3";
-        };
     }
 
     private static MemoryAllocator resolveAllocator(HttpConfig config) {
@@ -458,14 +215,5 @@ final class CommunityHttpClientEngine implements HttpClientEngine {
     private record ResolvedHttpClientDeps(MemoryAllocator allocator,
                                           TransportEngine transport,
                                           boolean closeAllocatorOnClose) {
-    }
-
-    private record HeaderPresence(boolean hasHost, boolean hasContentLength, boolean hasConnection) {
-    }
-
-    private record HeaderWriteResult(long position, HeaderPresence presence) {
-    }
-
-    private record StatusLine(HttpVersion version, HttpStatus status) {
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientRequestEncoder.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientRequestEncoder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.http1.Http1ResponseEncoder;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.transport.TransportConnection;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Package-private static encoder for outbound HTTP/1.x requests issued by
+ * {@link CommunityHttpClientEngine}.
+ *
+ * <p>Extracted from {@link CommunityHttpClientEngine} in v0.8 Sprint 3 (QA-015)
+ * to close the engine's {@code PMD.GodClass} suppression block. Owns the
+ * request-line + headers + body byte-layout into a {@link MemorySegment}.
+ *
+ * <p>Layout (RFC 9112):
+ * <pre>
+ *   METHOD SP REQUEST-TARGET SP HTTP/VERSION CRLF
+ *   header-name: header-value CRLF
+ *   ...
+ *   CRLF
+ *   [body bytes]
+ * </pre>
+ *
+ * <p>Default headers added when absent from {@link HttpRequest#headers()}:
+ * {@code Host: host:port} (from {@link TransportConnection}), {@code Content-Length: N},
+ * {@code Connection: close}.
+ */
+final class CommunityHttpClientRequestEncoder {
+
+    private static final String HEADER_HOST = "Host";
+    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
+    private static final String HEADER_CONNECTION = "Connection";
+    private static final String HEADER_CLOSE = "close";
+
+    private CommunityHttpClientRequestEncoder() {
+        // package-private static utility — never instantiated.
+    }
+
+    /**
+     * Writes the full outbound HTTP/1.x request into {@code seg} starting at
+     * offset 0. Returns the position one past the last written byte.
+     */
+    /* default */ static long writeRequest(MemorySegment seg,
+                                           HttpRequest request,
+                                           TransportConnection connection,
+                                           int bodyBytes) {
+        long pos = writeRequestLine(seg, request);
+        HeaderWriteResult headerWriteResult = writeRequestHeaders(seg, pos, request);
+        pos = writeDefaultRequestHeaders(
+                seg,
+                headerWriteResult.position(),
+                headerWriteResult.presence(),
+                connection,
+                bodyBytes);
+        return writeRequestBody(seg, pos, request, bodyBytes);
+    }
+
+    private static long writeRequestLine(MemorySegment seg, HttpRequest request) {
+        long pos = 0L;
+        pos = writeAscii(seg, pos, request.method().name());
+        seg.set(ValueLayout.JAVA_BYTE, pos, (byte) ' ');
+        pos += 1;
+        pos = writeAscii(seg, pos, request.path());
+        seg.set(ValueLayout.JAVA_BYTE, pos, (byte) ' ');
+        pos += 1;
+        pos = writeAscii(seg, pos, versionToken(request.version()));
+        return Http1ResponseEncoder.writeHeaderEnd(seg, pos);
+    }
+
+    private static HeaderWriteResult writeRequestHeaders(MemorySegment seg, long startPos, HttpRequest request) {
+        long pos = startPos;
+        boolean hasHost = false;
+        boolean hasContentLength = false;
+        boolean hasConnection = false;
+        for (HttpHeader header : request.headers()) {
+            if (header.nameEqualsIgnoreCase(HEADER_HOST)) {
+                hasHost = true;
+            }
+            if (header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
+                hasContentLength = true;
+            }
+            if (header.nameEqualsIgnoreCase(HEADER_CONNECTION)) {
+                hasConnection = true;
+            }
+            pos = Http1ResponseEncoder.writeHeader(seg, pos, header.name(), header.value());
+        }
+        return new HeaderWriteResult(pos, new HeaderPresence(hasHost, hasContentLength, hasConnection));
+    }
+
+    private static long writeDefaultRequestHeaders(MemorySegment seg,
+                                                   long startPos,
+                                                   HeaderPresence presence,
+                                                   TransportConnection connection,
+                                                   int bodyBytes) {
+        long pos = startPos;
+        if (!presence.hasHost()) {
+            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_HOST,
+                    connection.remoteAddress() + ":" + connection.remotePort());
+        }
+        if (!presence.hasContentLength()) {
+            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_CONTENT_LENGTH,
+                    Integer.toString(bodyBytes));
+        }
+        if (!presence.hasConnection()) {
+            pos = Http1ResponseEncoder.writeHeader(seg, pos, HEADER_CONNECTION, HEADER_CLOSE);
+        }
+        return Http1ResponseEncoder.writeHeaderEnd(seg, pos);
+    }
+
+    private static long writeRequestBody(MemorySegment seg, long startPos, HttpRequest request, int bodyBytes) {
+        long pos = startPos;
+        if (bodyBytes > 0) {
+            MemorySegment.copy(request.body().segment(), 0L, seg, pos, bodyBytes);
+            pos += bodyBytes;
+        }
+        return pos;
+    }
+
+    private static long writeAscii(MemorySegment seg, long pos, String value) {
+        for (int i = 0; i < value.length(); i++) {
+            seg.set(ValueLayout.JAVA_BYTE, pos + i, (byte) value.charAt(i));
+        }
+        return pos + value.length();
+    }
+
+    private static String versionToken(HttpVersion version) {
+        return switch (version) {
+            case HTTP_1_0 -> "HTTP/1.0";
+            case HTTP_1_1 -> "HTTP/1.1";
+            case HTTP_2 -> "HTTP/2";
+            case HTTP_3 -> "HTTP/3";
+        };
+    }
+
+    /* default */ record HeaderPresence(boolean hasHost, boolean hasContentLength, boolean hasConnection) {
+    }
+
+    /* default */ record HeaderWriteResult(long position, HeaderPresence presence) {
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientResponseDecoder.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpClientResponseDecoder.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Package-private static decoder for inbound HTTP/1.x responses received by
+ * {@link CommunityHttpClientEngine}.
+ *
+ * <p>Extracted from {@link CommunityHttpClientEngine} in v0.8 Sprint 3 (QA-015)
+ * as the second seam of the engine's God-class decomposition (request encoding
+ * lives in {@link CommunityHttpClientRequestEncoder}). Owns status-line parsing,
+ * header parsing, body length resolution, and the incremental completeness
+ * helpers that the engine's read loop consults to know when to stop reading.
+ */
+@SuppressWarnings("PMD.CyclomaticComplexity") // parseStatusLine + parseHeaders + completeness checks have flat CC.
+final class CommunityHttpClientResponseDecoder {
+
+    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
+    private static final int STATUS_LINE_MIN_PARTS = 2;
+    private static final int STATUS_LINE_PARTS_WITH_REASON = 3;
+
+    private CommunityHttpClientResponseDecoder() {
+        // package-private static utility — never instantiated.
+    }
+
+    /**
+     * Caches the offset of the header-block terminator ({@code CRLF CRLF}) once
+     * found — read-loop consults this to know when headers are complete.
+     */
+    /* default */ static long resolveHeaderTerminator(long currentHeaderTerminator,
+                                                      MemorySegment segment,
+                                                      long totalBytes) {
+        if (currentHeaderTerminator >= 0) {
+            return currentHeaderTerminator;
+        }
+        return findHeaderTerminator(segment, 0, totalBytes);
+    }
+
+    /**
+     * Caches the expected total response size (headers + body) once both the
+     * header terminator AND a parseable Content-Length are known.
+     */
+    /* default */ static long resolveExpectedTotal(long currentExpectedTotal,
+                                                   MemorySegment segment,
+                                                   long totalBytes,
+                                                   long headerTerminator) {
+        if (currentExpectedTotal >= 0 || headerTerminator < 0) {
+            return currentExpectedTotal;
+        }
+        long statusLineEnd = CommunityHttpBufferOps.findCrLf(segment, 0, totalBytes);
+        if (statusLineEnd < 0) {
+            return -1;
+        }
+        List<HttpHeader> headers = parseHeaders(segment, statusLineEnd + 2, headerTerminator);
+        long contentLength = resolveContentLengthFromHeaders(headers);
+        if (contentLength < 0) {
+            return -1;
+        }
+        return headerTerminator + 4 + contentLength;
+    }
+
+    /* default */ static boolean isResponseComplete(long totalBytes, long expectedTotalBytes) {
+        return expectedTotalBytes > 0 && totalBytes >= expectedTotalBytes;
+    }
+
+    /**
+     * Decodes the fully aggregated response buffer into an {@link HttpResponse}.
+     * Allocates a dedicated body buffer via {@code allocator} if the response
+     * carries a non-empty body; ownership transfers to the returned response.
+     */
+    /* default */ static HttpResponse decodeResponse(MemoryAllocator allocator,
+                                                     LoanedBuffer aggregate,
+                                                     long total,
+                                                     HttpVersion requestVersion) {
+        long statusLineEnd = CommunityHttpBufferOps.findCrLf(aggregate.segment(), 0, total);
+        if (statusLineEnd < 0) {
+            throw new IllegalStateException("Invalid HTTP response: missing status line terminator");
+        }
+
+        String statusLine = asciiString(aggregate.segment(), 0, statusLineEnd);
+        StatusLine parsedStatus = parseStatusLine(statusLine, requestVersion);
+
+        long headerStart = statusLineEnd + 2;
+        long headerEnd = findHeaderTerminator(aggregate.segment(), headerStart, total);
+        if (headerEnd < 0) {
+            throw new IllegalStateException("Invalid HTTP response: missing header terminator");
+        }
+
+        List<HttpHeader> headers = parseHeaders(aggregate.segment(), headerStart, headerEnd);
+        long bodyStart = headerEnd + 4;
+        long availableBodyBytes = total - bodyStart;
+        if (availableBodyBytes < 0) {
+            throw new IllegalStateException("Invalid HTTP response: body start exceeds received bytes");
+        }
+        long bodyLength = resolveBodyLength(headers, availableBodyBytes);
+        if (bodyLength > availableBodyBytes) {
+            throw new IllegalStateException(
+                    "Truncated HTTP response body: expected " + bodyLength
+                    + " bytes but received " + availableBodyBytes + " bytes");
+        }
+
+        LoanedBuffer bodyBuffer = null;
+        if (bodyLength > 0) {
+            bodyBuffer = allocator.allocateNetwork((int) bodyLength);
+            MemorySegment.copy(aggregate.segment(), bodyStart, bodyBuffer.segment(), 0, bodyLength);
+            bodyBuffer.setSize(bodyLength);
+        }
+        return new HttpResponse(parsedStatus.status(), parsedStatus.version(), headers, bodyBuffer);
+    }
+
+    private static List<HttpHeader> parseHeaders(MemorySegment segment, long start, long endExclusive) {
+        List<HttpHeader> headers = new ArrayList<>();
+        long cursor = start;
+        while (cursor < endExclusive) {
+            long lineEnd = CommunityHttpBufferOps.findCrLf(segment, cursor, endExclusive + 2);
+            if (lineEnd < 0 || lineEnd == cursor) {
+                break;
+            }
+            String line = asciiString(segment, cursor, lineEnd);
+            int separator = line.indexOf(':');
+            if (separator > 0) {
+                String name = line.substring(0, separator).trim();
+                String value = line.substring(separator + 1).trim();
+                headers.add(new HttpHeader(name, value));
+            }
+            cursor = lineEnd + 2;
+        }
+        return List.copyOf(headers);
+    }
+
+    private static long resolveBodyLength(List<HttpHeader> headers, long fallbackBytes) {
+        Optional<String> contentLength = headers.stream()
+                .filter(header -> header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH))
+                .map(HttpHeader::value)
+                .findFirst();
+        if (contentLength.isPresent()) {
+            try {
+                return Long.parseLong(contentLength.get());
+            } catch (NumberFormatException _) {
+                return Math.max(fallbackBytes, 0L);
+            }
+        }
+        return Math.max(fallbackBytes, 0L);
+    }
+
+    private static long resolveContentLengthFromHeaders(List<HttpHeader> headers) {
+        for (HttpHeader h : headers) {
+            if (h.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
+                try {
+                    return Long.parseLong(h.value().trim());
+                } catch (NumberFormatException _) {
+                    return -1;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static StatusLine parseStatusLine(String statusLine, HttpVersion requestVersion) {
+        String[] parts = statusLine.split(" ", STATUS_LINE_PARTS_WITH_REASON);
+        if (parts.length < STATUS_LINE_MIN_PARTS) {
+            throw new IllegalStateException("Invalid HTTP response status line: " + statusLine);
+        }
+        HttpVersion version = switch (parts[0]) {
+            case "HTTP/1.0" -> HttpVersion.HTTP_1_0;
+            case "HTTP/1.1" -> HttpVersion.HTTP_1_1;
+            case "HTTP/2", "HTTP/2.0" -> HttpVersion.HTTP_2;
+            default -> requestVersion;
+        };
+        int code;
+        try {
+            code = Integer.parseInt(parts[1]);
+        } catch (NumberFormatException ex) {
+            throw new IllegalStateException("Invalid HTTP status code in status line: " + statusLine, ex);
+        }
+        String reason = parts.length == STATUS_LINE_PARTS_WITH_REASON ? parts[2] : "";
+        return new StatusLine(version, new HttpStatus(code, reason));
+    }
+
+    private static long findHeaderTerminator(MemorySegment segment, long start, long endExclusive) {
+        for (long index = start; index + 3 < endExclusive; index++) {
+            if (segment.get(ValueLayout.JAVA_BYTE, index) == '\r'
+                    && segment.get(ValueLayout.JAVA_BYTE, index + 1) == '\n'
+                    && segment.get(ValueLayout.JAVA_BYTE, index + 2) == '\r'
+                    && segment.get(ValueLayout.JAVA_BYTE, index + 3) == '\n') {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static String asciiString(MemorySegment segment, long startInclusive, long endExclusive) {
+        int length = Math.toIntExact(endExclusive - startInclusive);
+        byte[] bytes = segment.asSlice(startInclusive, length).toArray(ValueLayout.JAVA_BYTE);
+        return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    /* default */ record StatusLine(HttpVersion version, HttpStatus status) {
+    }
+}


### PR DESCRIPTION
## Summary

**First Sprint 3 GodClass closure** (Quality batch II follow-up after Sprint 1 closure of QA-010..014). Splits \`CommunityHttpClientEngine\` along two cohesive HTTP/1.x seams:

- Request byte layout (request line + headers + body) → **encoder**
- Response parsing (status line + headers + body length) → **decoder**

## Three files now

### \`CommunityHttpClientRequestEncoder\` (153 LOC, pkg-private static) — request layout

- \`writeRequest(seg, request, connection, bodyBytes)\` — top entry
- \`writeRequestLine\` / \`writeRequestHeaders\` / \`writeDefaultRequestHeaders\`
- \`writeRequestBody\` / \`writeAscii\` / \`versionToken\`
- \`HeaderPresence\` + \`HeaderWriteResult\` records
- Default headers added when absent: \`Host: host:port\` (from \`TransportConnection\`), \`Content-Length: N\`, \`Connection: close\`

### \`CommunityHttpClientResponseDecoder\` (220 LOC, pkg-private static) — response parsing

- \`decodeResponse(allocator, aggregate, total, requestVersion)\` — top entry
- \`resolveHeaderTerminator\` / \`resolveExpectedTotal\` / \`isResponseComplete\` — incremental completeness helpers consulted by the engine's read loop
- \`parseHeaders\` / \`parseStatusLine\` / \`resolveBodyLength\` / \`resolveContentLengthFromHeaders\` / \`findHeaderTerminator\` / \`asciiString\`
- \`StatusLine\` record
- Class-level \`@SuppressWarnings("PMD.CyclomaticComplexity")\` with rationale (flat status-line + header parsing CC)

### \`CommunityHttpClientEngine\` (219 LOC, refactored)

**Public surface UNCHANGED:** \`HttpClientEngine.start\`/\`send\`/\`close\`/\`isRunning\`/\`engineName\` all preserved verbatim.

- Per-call orchestration (\`transport.connect\` → \`stream.openStream\` → \`sendRequest\` → \`readResponse\`) retained
- \`sendRequest\` allocates outbound buffer + delegates to \`Encoder.writeRequest\`
- \`readResponse\` retains the multi-state read loop (incremental header terminator + expected total + completeness) but delegates each step to \`Decoder\`
- Dependency resolution (allocator + transport) retained at the bottom
- \`ResolvedHttpClientDeps\` internal record retained

## Suppression delta on \`CommunityHttpClientEngine\`

| | Before | After |
|---|---|---|
| \`PMD.GodClass\` | ✓ | ✅ removed |
| \`PMD.TooManyMethods\` | ✓ | ✅ removed |
| \`PMD.CyclomaticComplexity\` | ✓ | retained (multi-state read loop intrinsically cohesive) |

**Net: 3 → 1 class-level suppressions (-2 closed).**

## Delta

| File | LOC | Δ |
|---|---|---|
| CommunityHttpClientEngine | 470 → 219 | **-251 / -53%** |
| CommunityHttpClientRequestEncoder (NEW) | 153 | +153 |
| CommunityHttpClientResponseDecoder (NEW) | 220 | +220 |

## Test plan

- [x] \`CommunityHttpClientEngineTckTest\` 7/7 green (TCK contract preserved)
- [x] \`AbstractHttpClientEngineTck\` nested classes 7/7 green (Identity 2/2, StartState 2/2, CreatedState 2/2, Close 2/2)
- [x] \`ExerisWebClientIntegrationTest\` 8/8 green (the Sprint 2 client SPI that layers on top of CommunityHttpClientEngine — no regression)
- [x] Full reactor verify SUCCESS with \`-P coverage\` (Sprint 6 JaCoCo gate still passes: community 69% > 0.55 floor)
- [x] PMD 0 violations on community module
- [x] Checkstyle 0 violations on community module

## Sprint 3 GodClass tracker after this PR

| QA-* | Class | LOC | Class-suppressions | PR |
|---|---|---|---|---|
| **QA-015** | **CommunityHttpClientEngine** | **470→219** | **3→1 (-2)** | **this PR** |
| QA-016 | NativeTcpStream (HEUR-061 carry-over) | 1229 | TBD | next |
| QA-017 | JdbcFlowSnapshotStore | TBD | TBD | next |
| QA-018 | CommunityHttp2SessionProcessor + SubsystemOrchestrator | TBD | TBD | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)