### PR TITLE
v0.8 Sprint 3 (CI): exclude feature branches from push trigger — halve GHA duplication

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,18 @@
 name: Exeris L0 Citadel CI
 
 on:
+  # Push events trigger CI only on long-lived branches (main + RC trunks) — these
+  # carry the SNAPSHOT publish responsibility. Feature branches under
+  # development/feat/** are excluded here; they get validated once via the
+  # pull_request event when a PR is opened. This avoids running every gate
+  # twice on the same SHA (push + PR), which doubled GHA minutes and doubled
+  # the flake chance on the Transport Stress Gate under 2-vCPU schedule
+  # pressure (see v0.8 Sprint 1 CI hotfix v6 + Sprint 3 PR #133/#134).
   push:
-    branches: [ "main", "development/**" ]   # RC trunk branches (development/0.8, development/0.9, ...) also trigger build + SNAPSHOT publish
+    branches:
+      - main
+      - 'development/**'
+      - '!development/feat/**'
   pull_request:
     branches: [ "main", "development/**" ]   # validate PRs targeting RC trunks before merge
   schedule:


### PR DESCRIPTION
## Problem

Push events to `development/feat/**` branches were triggering the full L0 Citadel CI **in parallel** with the `pull_request` event on the same SHA. Concretely, on PR #133 and #134:

| Event | Transport Stress Gate (PR #134, same commit) |
|:--|:--|
| `pull_request` | ✅ SUCCESS @ 5:59:37Z |
| `push` | ❌ FAILURE @ 6:02:32Z (180s drain hit) |

This doubled:
- GHA minutes consumed per PR
- Flake chance on the Transport Stress Gate under 2-vCPU schedule pressure (the systematic JDK 26+35 + carrier pinning + FFM blocking `recv()` pattern documented in v0.8 Sprint 1 CI hotfix v6 memory note)

## Fix

Push trigger excludes `development/feat/**`:

```yaml
push:
  branches:
    - main
    - 'development/**'
    - '!development/feat/**'
pull_request:
  branches: [ "main", "development/**" ]   # unchanged
```

## Behavior

| Branch | Push event | Pull request event |
|:--|:--|:--|
| `main` | ✅ runs (SNAPSHOT publish) | ✅ runs (PRs targeting main) |
| `development/0.8.0` (RC trunk) | ✅ runs (SNAPSHOT publish) | ✅ runs (PRs targeting it) |
| `development/feat/0.8.0-qa-016-*` (feature) | ❌ skipped | ✅ runs (when PR opened) |

Feature branches are validated **exactly once** per commit via the PR-event. RC trunk pushes (after PR merge) still trigger CI and SNAPSHOT publish — no regression on that path.

## Other workflows

Already scoped correctly:
- `codeql.yml` — `push: main` only
- `claude-code-review.yml` — `pull_request` only
- `dependency-review.yml` — `pull_request: main` only

Only `maven.yml` had the duplication.

## Verification

- ✅ YAML syntactically valid (`python3 -c 'yaml.safe_load(open(...))'`)
- ✅ No effect on this PR's CI run (the change applies from the next push onwards; this PR itself still triggers via PR-event normally)

## Test plan

- [x] YAML parses cleanly
- [ ] PR-event CI runs once on this PR
- [ ] After merge, next feature branch PR (e.g., QA-017) shows only one Transport Stress Gate run per commit
- [ ] Push to `development/0.8.0` after this PR's merge still triggers CI + SNAPSHOT publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)