### PR TITLE
v0.8 Sprint 3 (QA-018a): decompose CommunityHttp2SessionProcessor — close ExcessiveImports+CouplingBetweenObjects

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2ControlFrames.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2ControlFrames.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.http2.Http2ErrorCode;
+import eu.exeris.kernel.core.http.http2.Http2FrameEncoder;
+import eu.exeris.kernel.core.http.http2.Http2FrameParser;
+import eu.exeris.kernel.core.http.http2.Http2FrameType;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.transport.TransportStream;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Package-private writers for HTTP/2 control frames issued by
+ * {@link CommunityHttp2SessionProcessor}: SETTINGS, SETTINGS-ACK,
+ * PING-ACK, RST_STREAM (REFUSED / CANCEL), and GOAWAY.
+ *
+ * <p>Extracted from {@link CommunityHttp2SessionProcessor} in v0.8 Sprint 3
+ * (QA-018a) as one of four seams of the processor's God-class decomposition.
+ * Each writer follows the same shape — borrow a small network slab, encode
+ * the frame via {@link Http2FrameEncoder}, write it to the transport.
+ */
+final class CommunityHttp2ControlFrames {
+
+    private static final int H2_HANDSHAKE_BUFFER_BYTES = 64;
+    private static final int H2_PING_PAYLOAD_BYTES = 8;
+    private static final int H2_PING_ACK_FLAG = 0x01;
+
+    private CommunityHttp2ControlFrames() {
+        // package-private static utility — never instantiated.
+    }
+
+    /* default */ static void sendPingAck(MemoryAllocator allocator,
+                                          TransportStream stream,
+                                          LoanedBuffer aggregate,
+                                          long payloadOffset) {
+        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
+            Http2FrameEncoder.writeHeader(
+                    outbound.segment(),
+                    0,
+                    H2_PING_PAYLOAD_BYTES,
+                    Http2FrameType.PING.code(),
+                    H2_PING_ACK_FLAG,
+                    0);
+            MemorySegment.copy(
+                    aggregate.segment(),
+                    payloadOffset,
+                    outbound.segment(),
+                    Http2FrameParser.FRAME_HEADER_SIZE,
+                    H2_PING_PAYLOAD_BYTES);
+            long written = Http2FrameParser.FRAME_HEADER_SIZE + (long) H2_PING_PAYLOAD_BYTES;
+            outbound.setSize(written);
+            stream.write(outbound.segment(), (int) written);
+        }
+    }
+
+    /* default */ static void sendServerSettings(MemoryAllocator allocator, TransportStream stream) {
+        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
+            long written = Http2FrameEncoder.writeSettings(outbound.segment(), 0, 0, false);
+            outbound.setSize(written);
+            stream.write(outbound.segment(), (int) written);
+        }
+    }
+
+    /* default */ static void sendSettingsAck(MemoryAllocator allocator, TransportStream stream) {
+        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
+            long written = Http2FrameEncoder.writeSettings(outbound.segment(), 0, 0, true);
+            outbound.setSize(written);
+            stream.write(outbound.segment(), (int) written);
+        }
+    }
+
+    /* default */ static void sendRstStreamRefused(MemoryAllocator allocator,
+                                                   TransportStream stream,
+                                                   int streamId) {
+        sendRstStream(allocator, stream, streamId, Http2ErrorCode.REFUSED_STREAM);
+    }
+
+    /* default */ static void sendRstStreamCancel(MemoryAllocator allocator,
+                                                  TransportStream stream,
+                                                  int streamId) {
+        sendRstStream(allocator, stream, streamId, Http2ErrorCode.CANCEL);
+    }
+
+    /* default */ static void sendGoAwayNoError(MemoryAllocator allocator, TransportStream stream) {
+        sendGoAway(allocator, stream, 0, Http2ErrorCode.NO_ERROR);
+    }
+
+    /* default */ static void sendGoAway(MemoryAllocator allocator,
+                                         TransportStream stream,
+                                         int lastStreamId,
+                                         Http2ErrorCode errorCode) {
+        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
+            long written = Http2FrameEncoder.writeGoAway(
+                    outbound.segment(), 0, lastStreamId, errorCode.code());
+            outbound.setSize(written);
+            stream.write(outbound.segment(), (int) written);
+        }
+    }
+
+    private static void sendRstStream(MemoryAllocator allocator,
+                                      TransportStream stream,
+                                      int streamId,
+                                      Http2ErrorCode errorCode) {
+        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
+            long written = Http2FrameEncoder.writeRstStream(
+                    outbound.segment(), 0, streamId, errorCode.code());
+            outbound.setSize(written);
+            stream.write(outbound.segment(), (int) written);
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2FrameFragments.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2FrameFragments.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.http2.Http2FrameParser;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Package-private pad/priority field extraction for HEADERS and DATA frame
+ * payloads used by {@link CommunityHttp2SessionProcessor}.
+ *
+ * <p>Extracted from {@link CommunityHttp2SessionProcessor} in v0.8 Sprint 3
+ * (QA-018a) as one of four seams of the processor's God-class decomposition.
+ * RFC 7540 §6.2 (HEADERS) and §6.1 (DATA) allow padding and (for HEADERS)
+ * an optional 5-byte priority section; the extracted helpers strip these
+ * envelope fields and return the inner header-block / data fragment.
+ */
+final class CommunityHttp2FrameFragments {
+
+    private static final int HTTP2_FLAG_PADDED = 0x08;
+    private static final int HTTP2_PADDED_LENGTH_FIELD_BYTES = 1;
+    private static final int HTTP2_PRIORITY_FIELD_BYTES = 5;
+
+    private CommunityHttp2FrameFragments() {
+        // package-private static utility — never instantiated.
+    }
+
+    /**
+     * Inner payload after stripping the optional pad-length byte, optional
+     * 5-byte priority section, and the trailing padding bytes.
+     */
+    /* default */ record Fragment(long offset, int length) {
+    }
+
+    /* default */ static Fragment extractHeadersFragment(LoanedBuffer aggregate,
+                                                         long payloadOffset,
+                                                         Http2FrameParser.FrameHeader header) {
+        long fragmentOffset = payloadOffset;
+        int fragmentLength = header.length();
+        int padLength = 0;
+
+        if (header.isPadded()) {
+            if (fragmentLength < HTTP2_PADDED_LENGTH_FIELD_BYTES) {
+                throw new IllegalStateException("Invalid PADDED HEADERS frame");
+            }
+            padLength = aggregate.segment().get(ValueLayout.JAVA_BYTE, fragmentOffset) & 0xFF;
+            fragmentOffset += HTTP2_PADDED_LENGTH_FIELD_BYTES;
+            fragmentLength -= HTTP2_PADDED_LENGTH_FIELD_BYTES;
+        }
+
+        if (header.isPriority()) {
+            if (fragmentLength < HTTP2_PRIORITY_FIELD_BYTES) {
+                throw new IllegalStateException("Invalid PRIORITY section in HEADERS frame");
+            }
+            fragmentOffset += HTTP2_PRIORITY_FIELD_BYTES;
+            fragmentLength -= HTTP2_PRIORITY_FIELD_BYTES;
+        }
+
+        if (padLength > fragmentLength) {
+            throw new IllegalStateException("Invalid HEADERS padding");
+        }
+        fragmentLength -= padLength;
+        return new Fragment(fragmentOffset, fragmentLength);
+    }
+
+    /* default */ static Fragment extractDataFragment(LoanedBuffer aggregate,
+                                                      long payloadOffset,
+                                                      Http2FrameParser.FrameHeader header) {
+        long fragmentOffset = payloadOffset;
+        int fragmentLength = header.length();
+        int padLength = 0;
+
+        if ((header.flags() & HTTP2_FLAG_PADDED) != 0) {
+            if (fragmentLength < HTTP2_PADDED_LENGTH_FIELD_BYTES) {
+                throw new IllegalStateException("Invalid PADDED DATA frame");
+            }
+            padLength = aggregate.segment().get(ValueLayout.JAVA_BYTE, fragmentOffset) & 0xFF;
+            fragmentOffset += HTTP2_PADDED_LENGTH_FIELD_BYTES;
+            fragmentLength -= HTTP2_PADDED_LENGTH_FIELD_BYTES;
+        }
+
+        if (padLength > fragmentLength) {
+            throw new IllegalStateException("Invalid DATA padding");
+        }
+        fragmentLength -= padLength;
+        return new Fragment(fragmentOffset, fragmentLength);
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
@@ -8,19 +8,12 @@
  */
 package eu.exeris.kernel.community.http;
 
-import eu.exeris.kernel.core.http.hpack.HpackDecoder;
-import eu.exeris.kernel.core.http.hpack.HpackDynamicTable;
-import eu.exeris.kernel.core.http.hpack.HpackEncoder;
 import eu.exeris.kernel.core.http.http2.Http2ErrorCode;
-import eu.exeris.kernel.core.http.http2.Http2FrameCodec;
 import eu.exeris.kernel.core.http.http2.Http2FrameEncoder;
 import eu.exeris.kernel.core.http.http2.Http2FrameParser;
 import eu.exeris.kernel.core.http.http2.Http2FrameType;
-import eu.exeris.kernel.core.http.http2.Http2HeaderBlockAssembler;
 import eu.exeris.kernel.spi.http.HttpConfig;
 import eu.exeris.kernel.spi.http.HttpHandler;
-import eu.exeris.kernel.spi.http.HttpHeader;
-import eu.exeris.kernel.spi.http.HttpMethod;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpResponse;
 import eu.exeris.kernel.spi.http.HttpResponseBodyEncoderRegistry;
@@ -31,23 +24,26 @@ import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.transport.TransportStream;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 
+// QA-018a extracted 4 seams: Http2SessionContext (HPACK + assembler + per-stream state),
+// PendingRequestHeaders (HPACK-decode accumulator), CommunityHttp2ControlFrames (SETTINGS/PING/
+// RST_STREAM/GOAWAY writers), and CommunityHttp2FrameFragments (pad/priority extraction).
+// Residual processor retains the frame-loop, frame dispatcher, headers/data frame handlers,
+// response writer, and ingress read loop.
+// Retained suppressions:
+// - GodClass / TooManyMethods: residual WMC=72; frame-loop + dispatcher + frame handlers +
+//   response writer remain cohesive; further split deferred.
+// - AvoidCatchingGenericException: frame-loop catches RuntimeException to surface PROTOCOL_ERROR via GOAWAY.
+// - CloseResource: LoanedBuffer ownership transfers via response.body() pipeline.
+// - CyclomaticComplexity: frame-dispatcher switch + frame loop are intrinsically cohesive.
 @SuppressWarnings({
+        "PMD.GodClass",
+        "PMD.TooManyMethods",
         "PMD.AvoidCatchingGenericException",
         "PMD.CloseResource",
-        "PMD.CouplingBetweenObjects",
-        "PMD.CyclomaticComplexity",
-        "PMD.ExcessiveImports",
-        "PMD.GodClass",
-        "PMD.TooManyMethods"
+        "PMD.CyclomaticComplexity"
 })
 final class CommunityHttp2SessionProcessor {
 
@@ -55,21 +51,12 @@ final class CommunityHttp2SessionProcessor {
             System.getLogger(CommunityHttp2SessionProcessor.class.getName());
 
     private static final String CRLF = "\r\n";
-    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
-    private static final String UPGRADE_TOKEN = "upgrade";
     private static final long HTTP2_FRAME_LOOP_INVALID = -1L;
     private static final long HTTP2_FRAME_LOOP_STOP = -2L;
-    private static final int HTTP2_MAX_DYNAMIC_TABLE_SIZE = 4096;
-    private static final int HTTP2_MAX_HEADER_LIST_SIZE = 65_536;
     private static final int HTTP2_MAX_HEADER_BLOCK_BYTES = 65_536;
     private static final int HTTP2_MAX_FRAME_PAYLOAD_BYTES = 16 * 1024;
     private static final int HTTP2_FLAG_END_STREAM = 0x01;
     private static final int HTTP2_FLAG_END_HEADERS = 0x04;
-    private static final int HTTP2_FLAG_PADDED = 0x08;
-    private static final int HTTP2_SETTINGS_HEADER_TABLE_SIZE = 0x01;
-    private static final int HTTP2_PADDED_LENGTH_FIELD_BYTES = 1;
-    private static final int HTTP2_PRIORITY_FIELD_BYTES = 5;
-    private static final int H2_HANDSHAKE_BUFFER_BYTES = 64;
 
     private final MemoryAllocator allocator;
     private final HttpResponseBodyEncoderRegistry encoderRegistry;
@@ -101,7 +88,7 @@ final class CommunityHttp2SessionProcessor {
             LOG.log(System.Logger.Level.INFO,
                     "HTTP/2 prior-knowledge preface detected; entering h2c request frame-loop mode");
         }
-        sendHttp2ServerSettings(stream);
+        CommunityHttp2ControlFrames.sendServerSettings(allocator, stream);
         try (Http2SessionContext session = Http2SessionContext.create(allocator)) {
             processBufferedHttp2Frames(stream, handler, session, state, totalBytes, initialFrameOffset);
         }
@@ -114,7 +101,7 @@ final class CommunityHttp2SessionProcessor {
         LoanedBuffer aggregate = state.aggregate();
         writeHttp11UpgradeResponse(stream);
         long bufferedHttp2Bytes = CommunityHttpBufferOps.retainUnreadBytes(aggregate, readResult.consumedBytes());
-        sendHttp2ServerSettings(stream);
+        CommunityHttp2ControlFrames.sendServerSettings(allocator, stream);
         try (Http2SessionContext session = Http2SessionContext.create(allocator)) {
             processBufferedHttp2Frames(stream, handler, session, state, bufferedHttp2Bytes, 0);
         }
@@ -147,7 +134,8 @@ final class CommunityHttp2SessionProcessor {
                 return;
             }
             if (offset == HTTP2_FRAME_LOOP_INVALID) {
-                sendHttp2GoAway(stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
+                CommunityHttp2ControlFrames.sendGoAway(
+                        allocator, stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
                 return;
             }
 
@@ -156,13 +144,14 @@ final class CommunityHttp2SessionProcessor {
             bufferedBytes = unreadBytes;
 
             if (bufferedBytes >= maxAggregateBytes) {
-                sendHttp2GoAway(stream, session.lastProcessedStreamId(), Http2ErrorCode.FRAME_SIZE_ERROR);
+                CommunityHttp2ControlFrames.sendGoAway(
+                        allocator, stream, session.lastProcessedStreamId(), Http2ErrorCode.FRAME_SIZE_ERROR);
                 return;
             }
 
             int read = readHttp2Bytes(stream, state, bufferedBytes);
             if (read < 0) {
-                sendHttp2GoAwayNoError(stream);
+                CommunityHttp2ControlFrames.sendGoAwayNoError(allocator, stream);
                 return;
             }
             if (read > 0) {
@@ -221,8 +210,8 @@ final class CommunityHttp2SessionProcessor {
                     throw new IllegalStateException("Invalid SETTINGS stream");
                 }
                 if (!header.isAck()) {
-                    applyHttp2SettingsFromPeer(session, aggregate, payloadOffset, header.length());
-                    sendHttp2SettingsAck(stream);
+                    session.applyPeerSettings(aggregate, payloadOffset, header.length());
+                    CommunityHttp2ControlFrames.sendSettingsAck(allocator, stream);
                 }
                 yield true;
             }
@@ -231,7 +220,7 @@ final class CommunityHttp2SessionProcessor {
                     throw new IllegalStateException("Invalid PING frame");
                 }
                 if (!header.isAck()) {
-                    sendHttp2PingAck(stream, aggregate, payloadOffset);
+                    CommunityHttp2ControlFrames.sendPingAck(allocator, stream, aggregate, payloadOffset);
                 }
                 yield true;
             }
@@ -254,34 +243,6 @@ final class CommunityHttp2SessionProcessor {
         };
     }
 
-    private void applyHttp2SettingsFromPeer(Http2SessionContext session,
-                                            LoanedBuffer aggregate,
-                                            long payloadOffset,
-                                            int payloadLength) {
-        if (payloadLength == 0) {
-            return;
-        }
-        if (payloadLength % 6 != 0) {
-            throw new IllegalStateException("Invalid SETTINGS payload length");
-        }
-        for (int offset = 0; offset < payloadLength; offset += 6) {
-            long cursor = payloadOffset + offset;
-            int settingId = ((aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor) & 0xFF) << 8)
-                    | (aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor + 1) & 0xFF);
-            long settingValue = ((aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor + 2) & 0xFFL) << 24)
-                    | ((aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor + 3) & 0xFFL) << 16)
-                    | ((aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor + 4) & 0xFFL) << 8)
-                    | (aggregate.segment().get(ValueLayout.JAVA_BYTE, cursor + 5) & 0xFFL);
-            if (settingId == HTTP2_SETTINGS_HEADER_TABLE_SIZE) {
-                session.applyPeerHeaderTableSize(settingValue);
-            } else if (settingId == 0x05
-                    && settingValue >= Http2FrameCodec.MIN_MAX_FRAME_SIZE
-                    && settingValue <= Http2FrameCodec.MAX_MAX_FRAME_SIZE) {
-                session.applyPeerMaxFrameSize((int) settingValue);
-            }
-        }
-    }
-
     private boolean handleHttp2HeadersFrame(TransportStream stream,
                                             HttpHandler handler,
                                             Http2SessionContext session,
@@ -292,10 +253,12 @@ final class CommunityHttp2SessionProcessor {
             throw new IllegalStateException("Invalid HEADERS stream");
         }
         if (session.isAwaitingContinuation()) {
-            sendHttp2GoAway(stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
+            CommunityHttp2ControlFrames.sendGoAway(
+                    allocator, stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
             return false;
         }
-        HeaderFragment fragment = extractHeadersFragment(aggregate, payloadOffset, header);
+        CommunityHttp2FrameFragments.Fragment fragment =
+                CommunityHttp2FrameFragments.extractHeadersFragment(aggregate, payloadOffset, header);
         session.setPendingEndStream(header.isEndStream());
         session.beginHeaders(header, aggregate.segment(), fragment.offset(), fragment.length());
         if (session.isAwaitingContinuation()) {
@@ -330,15 +293,16 @@ final class CommunityHttp2SessionProcessor {
 
         Http2RequestStreamState requestStream = session.requestStream(header.streamId());
         if (requestStream == null) {
-            sendHttp2RstStreamRefused(stream, header.streamId());
+            CommunityHttp2ControlFrames.sendRstStreamRefused(allocator, stream, header.streamId());
             return;
         }
 
-        HeaderFragment dataFragment = extractDataFragment(aggregate, payloadOffset, header);
+        CommunityHttp2FrameFragments.Fragment dataFragment =
+                CommunityHttp2FrameFragments.extractDataFragment(aggregate, payloadOffset, header);
         int nextBodyBytes = requestStream.bodyBytes() + dataFragment.length();
         long maxBodyBytes = config.maxRequestBodyBytes();
         if (maxBodyBytes >= 0 && nextBodyBytes > maxBodyBytes) {
-            sendHttp2RstStreamCancel(stream, header.streamId());
+            CommunityHttp2ControlFrames.sendRstStreamCancel(allocator, stream, header.streamId());
             session.resetRequestStream(header.streamId());
             return;
         }
@@ -350,7 +314,7 @@ final class CommunityHttp2SessionProcessor {
 
         Http2RequestStreamState finished = session.takeRequestStream(header.streamId());
         if (finished == null) {
-            sendHttp2RstStreamRefused(stream, header.streamId());
+            CommunityHttp2ControlFrames.sendRstStreamRefused(allocator, stream, header.streamId());
             return;
         }
         dispatchHttp2Request(stream, handler, session, finished.streamId(), finished.request(), finished.detachBody());
@@ -503,136 +467,6 @@ final class CommunityHttp2SessionProcessor {
         stream.write(outboundFrame.segment(), (int) written);
     }
 
-    private void sendHttp2PingAck(TransportStream stream,
-                                  LoanedBuffer aggregate,
-                                  long payloadOffset) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            Http2FrameEncoder.writeHeader(
-                    outbound.segment(),
-                    0,
-                    8,
-                    Http2FrameType.PING.code(),
-                    0x01,
-                    0);
-            MemorySegment.copy(
-                    aggregate.segment(),
-                    payloadOffset,
-                    outbound.segment(),
-                    Http2FrameParser.FRAME_HEADER_SIZE,
-                    8);
-            long written = Http2FrameParser.FRAME_HEADER_SIZE + 8L;
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private void sendHttp2ServerSettings(TransportStream stream) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            long written = Http2FrameEncoder.writeSettings(outbound.segment(), 0, 0, false);
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private void sendHttp2SettingsAck(TransportStream stream) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            long written = Http2FrameEncoder.writeSettings(outbound.segment(), 0, 0, true);
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private void sendHttp2RstStreamRefused(TransportStream stream, int streamId) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            long written = Http2FrameEncoder.writeRstStream(
-                    outbound.segment(),
-                    0,
-                    streamId,
-                    Http2ErrorCode.REFUSED_STREAM.code());
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private void sendHttp2RstStreamCancel(TransportStream stream, int streamId) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            long written = Http2FrameEncoder.writeRstStream(
-                    outbound.segment(),
-                    0,
-                    streamId,
-                    Http2ErrorCode.CANCEL.code());
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private void sendHttp2GoAwayNoError(TransportStream stream) {
-        sendHttp2GoAway(stream, 0, Http2ErrorCode.NO_ERROR);
-    }
-
-    private void sendHttp2GoAway(TransportStream stream, int lastStreamId, Http2ErrorCode errorCode) {
-        try (LoanedBuffer outbound = allocator.allocateNetwork(H2_HANDSHAKE_BUFFER_BYTES)) {
-            long written = Http2FrameEncoder.writeGoAway(
-                    outbound.segment(), 0, lastStreamId, errorCode.code());
-            outbound.setSize(written);
-            stream.write(outbound.segment(), (int) written);
-        }
-    }
-
-    private HeaderFragment extractHeadersFragment(LoanedBuffer aggregate,
-                                                  long payloadOffset,
-                                                  Http2FrameParser.FrameHeader header) {
-        long fragmentOffset = payloadOffset;
-        int fragmentLength = header.length();
-        int padLength = 0;
-
-        if (header.isPadded()) {
-            if (fragmentLength < HTTP2_PADDED_LENGTH_FIELD_BYTES) {
-                throw new IllegalStateException("Invalid PADDED HEADERS frame");
-            }
-            padLength = aggregate.segment().get(ValueLayout.JAVA_BYTE, fragmentOffset) & 0xFF;
-            fragmentOffset += HTTP2_PADDED_LENGTH_FIELD_BYTES;
-            fragmentLength -= HTTP2_PADDED_LENGTH_FIELD_BYTES;
-        }
-
-        if (header.isPriority()) {
-            if (fragmentLength < HTTP2_PRIORITY_FIELD_BYTES) {
-                throw new IllegalStateException("Invalid PRIORITY section in HEADERS frame");
-            }
-            fragmentOffset += HTTP2_PRIORITY_FIELD_BYTES;
-            fragmentLength -= HTTP2_PRIORITY_FIELD_BYTES;
-        }
-
-        if (padLength > fragmentLength) {
-            throw new IllegalStateException("Invalid HEADERS padding");
-        }
-        fragmentLength -= padLength;
-        return new HeaderFragment(fragmentOffset, fragmentLength);
-    }
-
-    private HeaderFragment extractDataFragment(LoanedBuffer aggregate,
-                                               long payloadOffset,
-                                               Http2FrameParser.FrameHeader header) {
-        long fragmentOffset = payloadOffset;
-        int fragmentLength = header.length();
-        int padLength = 0;
-
-        if ((header.flags() & HTTP2_FLAG_PADDED) != 0) {
-            if (fragmentLength < HTTP2_PADDED_LENGTH_FIELD_BYTES) {
-                throw new IllegalStateException("Invalid PADDED DATA frame");
-            }
-            padLength = aggregate.segment().get(ValueLayout.JAVA_BYTE, fragmentOffset) & 0xFF;
-            fragmentOffset += HTTP2_PADDED_LENGTH_FIELD_BYTES;
-            fragmentLength -= HTTP2_PADDED_LENGTH_FIELD_BYTES;
-        }
-
-        if (padLength > fragmentLength) {
-            throw new IllegalStateException("Invalid DATA padding");
-        }
-        fragmentLength -= padLength;
-        return new HeaderFragment(fragmentOffset, fragmentLength);
-    }
-
     private int readHttp2Bytes(TransportStream stream,
                                ProcessingState state,
                                long bufferedBytes) {
@@ -645,252 +479,4 @@ final class CommunityHttp2SessionProcessor {
         return stream.read(aggregate.segment().asSlice(bufferedBytes, chunk), chunk);
     }
 
-    private record HeaderFragment(long offset, int length) {
-    }
-
-    private static final class Http2SessionContext implements AutoCloseable {
-        private final HpackDynamicTable encodeTable;
-        private final HpackDecoder decoder;
-        private final HpackEncoder encoder;
-        private final Http2FrameCodec codec;
-        private final Http2HeaderBlockAssembler assembler;
-        private final Map<Integer, Http2RequestStreamState> requestStreams;
-        private boolean pendingEndStream;
-        private int lastProcessedStreamId;
-
-        private Http2SessionContext(HpackDynamicTable encodeTable,
-                                    HpackDecoder decoder,
-                                    HpackEncoder encoder,
-                                    Http2FrameCodec codec,
-                                    Http2HeaderBlockAssembler assembler) {
-            this.encodeTable = encodeTable;
-            this.decoder = decoder;
-            this.encoder = encoder;
-            this.codec = codec;
-            this.assembler = assembler;
-            this.requestStreams = new HashMap<>();
-            this.pendingEndStream = false;
-            this.lastProcessedStreamId = 0;
-        }
-
-        private static Http2SessionContext create(MemoryAllocator allocator) {
-            HpackDynamicTable decodeTable = new HpackDynamicTable(HTTP2_MAX_DYNAMIC_TABLE_SIZE);
-            HpackDynamicTable encodeTable = new HpackDynamicTable(HTTP2_MAX_DYNAMIC_TABLE_SIZE);
-            HpackDecoder decoder = new HpackDecoder(decodeTable, allocator, HTTP2_MAX_HEADER_LIST_SIZE);
-            HpackEncoder encoder = new HpackEncoder(encodeTable, allocator, false);
-            Http2FrameCodec codec = new Http2FrameCodec();
-            Http2HeaderBlockAssembler assembler = new Http2HeaderBlockAssembler(allocator);
-            return new Http2SessionContext(encodeTable, decoder, encoder, codec, assembler);
-        }
-
-        private void applyPeerHeaderTableSize(long headerTableSize) {
-            encodeTable.setMaxSize(headerTableSize);
-        }
-
-        private Http2FrameCodec codec() {
-            return codec;
-        }
-
-        private void applyPeerMaxFrameSize(int maxFrameSize) {
-            codec.setMaxFrameSize(maxFrameSize);
-        }
-
-        private boolean isAwaitingContinuation() {
-            return assembler.isAwaitingContinuation();
-        }
-
-        private void setPendingEndStream(boolean endStream) {
-            this.pendingEndStream = endStream;
-        }
-
-        private boolean pendingEndStream() {
-            return pendingEndStream;
-        }
-
-        private void beginHeaders(Http2FrameParser.FrameHeader header,
-                                  MemorySegment payload,
-                                  long dataOffset,
-                                  int dataLength) {
-            assembler.beginHeaders(header, payload, dataOffset, dataLength);
-        }
-
-        private void appendContinuation(Http2FrameParser.FrameHeader header,
-                                        MemorySegment payload,
-                                        long dataOffset,
-                                        int dataLength) {
-            assembler.appendContinuation(header, payload, dataOffset, dataLength);
-        }
-
-        private void validateContinuationMode(Http2FrameParser.FrameHeader header) {
-            assembler.validateContinuationMode(header);
-        }
-
-        private Http2DecodedRequest decodePendingRequest() {
-            if (!assembler.isComplete()) {
-                return new Http2DecodedRequest(0, null, "", List.of(), false);
-            }
-            int streamId = assembler.currentStreamId();
-            PendingRequestHeaders pendingHeaders = new PendingRequestHeaders();
-            MemorySegment block = assembler.completeBlock();
-            try {
-                decoder.decode(block, 0, (int) block.byteSize(),
-                        (name, value, _) -> pendingHeaders.accept(name, value));
-            } catch (RuntimeException _) {
-                pendingHeaders.invalidate();
-            }
-            assembler.reset();
-            pendingEndStream = false;
-            return pendingHeaders.toDecodedRequest(streamId);
-        }
-
-        private void openRequestStream(Http2DecodedRequest request) {
-            Http2RequestStreamState previous = requestStreams.put(
-                    request.streamId(),
-                    new Http2RequestStreamState(request.streamId(), request));
-            if (previous != null) {
-                previous.close();
-            }
-        }
-
-        private Http2RequestStreamState requestStream(int streamId) {
-            return requestStreams.get(streamId);
-        }
-
-        private Http2RequestStreamState takeRequestStream(int streamId) {
-            return requestStreams.remove(streamId);
-        }
-
-        private void resetRequestStream(int streamId) {
-            Http2RequestStreamState removed = requestStreams.remove(streamId);
-            if (removed != null) {
-                removed.close();
-            }
-        }
-
-        private long encodeResponseHeaders(MemorySegment target, HttpResponse response) {
-            long position = 0;
-            position = encoder.encodeHeader(
-                    target,
-                    position,
-                    ":status",
-                    Integer.toString(response.status().code()),
-                    false);
-
-            boolean hasContentLength = false;
-            for (HttpHeader header : response.headers()) {
-                if (header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
-                    hasContentLength = true;
-                }
-                if (isConnectionSpecificHeader(header.name()) || header.name().startsWith(":")) {
-                    continue;
-                }
-                position = encoder.encodeHeader(
-                        target,
-                        position,
-                        header.name().toLowerCase(Locale.ROOT),
-                        header.value(),
-                        false);
-            }
-
-            LoanedBuffer body = response.body();
-            if (!hasContentLength) {
-                int bodyBytes = body == null ? 0 : (int) body.size();
-                position = encoder.encodeHeader(target, position, "content-length", Integer.toString(bodyBytes), false);
-            }
-            return position;
-        }
-
-        private void clearPendingIfStreamMatches(int streamId) {
-            if (assembler.currentStreamId() == streamId) {
-                assembler.reset();
-                pendingEndStream = false;
-            }
-        }
-
-        private int lastProcessedStreamId() {
-            return lastProcessedStreamId;
-        }
-
-        private void setLastProcessedStreamId(int lastProcessedStreamId) {
-            this.lastProcessedStreamId = Math.max(this.lastProcessedStreamId, lastProcessedStreamId);
-        }
-
-        private static boolean isConnectionSpecificHeader(String headerName) {
-            return "connection".equalsIgnoreCase(headerName)
-                    || "keep-alive".equalsIgnoreCase(headerName)
-                    || "proxy-connection".equalsIgnoreCase(headerName)
-                    || UPGRADE_TOKEN.equalsIgnoreCase(headerName)
-                    || "transfer-encoding".equalsIgnoreCase(headerName);
-        }
-
-        @Override
-        public void close() {
-            assembler.reset();
-            for (Http2RequestStreamState requestStream : requestStreams.values()) {
-                requestStream.close();
-            }
-            requestStreams.clear();
-        }
-    }
-
-    private static final class PendingRequestHeaders {
-        private String methodToken;
-        private String path;
-        private boolean valid = true;
-        private boolean sawRegularHeader;
-        private final List<HttpHeader> requestHeaders = new ArrayList<>();
-
-        private void accept(String name, String value) {
-            if (!valid) {
-                return;
-            }
-            if (name.startsWith(":")) {
-                acceptPseudoHeader(name, value);
-                return;
-            }
-            sawRegularHeader = true;
-            if (Http2SessionContext.isConnectionSpecificHeader(name)) {
-                valid = false;
-                return;
-            }
-            requestHeaders.add(new HttpHeader(name, value));
-        }
-
-        private void invalidate() {
-            valid = false;
-        }
-
-        private Http2DecodedRequest toDecodedRequest(int streamId) {
-            HttpMethod method = parseHttp2Method(methodToken);
-            String resolvedPath = path == null ? "" : path;
-            boolean requestValid = valid && method != null && !resolvedPath.isEmpty();
-            return new Http2DecodedRequest(streamId, method, resolvedPath, List.copyOf(requestHeaders), requestValid);
-        }
-
-        private void acceptPseudoHeader(String name, String value) {
-            if (sawRegularHeader) {
-                valid = false;
-                return;
-            }
-            switch (name) {
-                case ":method" -> methodToken = value;
-                case ":path" -> path = value;
-                case ":authority", ":scheme" -> {
-                    // Accepted but not required for this processing path.
-                }
-                default -> valid = false;
-            }
-        }
-
-        private static HttpMethod parseHttp2Method(String methodToken) {
-            if (methodToken == null || methodToken.isBlank()) {
-                return null;
-            }
-            try {
-                return HttpMethod.valueOf(methodToken);
-            } catch (IllegalArgumentException _) {
-                return null;
-            }
-        }
-    }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/Http2SessionContext.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/Http2SessionContext.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.hpack.HpackDecoder;
+import eu.exeris.kernel.core.http.hpack.HpackDynamicTable;
+import eu.exeris.kernel.core.http.hpack.HpackEncoder;
+import eu.exeris.kernel.core.http.http2.Http2FrameCodec;
+import eu.exeris.kernel.core.http.http2.Http2FrameParser;
+import eu.exeris.kernel.core.http.http2.Http2HeaderBlockAssembler;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Package-private per-connection HTTP/2 session state used by
+ * {@link CommunityHttp2SessionProcessor}.
+ *
+ * <p>Extracted from {@link CommunityHttp2SessionProcessor} in v0.8 Sprint 3
+ * (QA-018a) as one of four seams of the processor's God-class decomposition.
+ * Owns:
+ * <ul>
+ *   <li>The per-connection HPACK encoder/decoder pair (RFC 7541) and their
+ *       dynamic tables.</li>
+ *   <li>The frame codec ({@link Http2FrameCodec}) with peer-advertised
+ *       {@code SETTINGS_MAX_FRAME_SIZE}.</li>
+ *   <li>The header-block assembler ({@link Http2HeaderBlockAssembler}) that
+ *       tracks HEADERS / CONTINUATION continuation state.</li>
+ *   <li>The per-stream request registry ({@link Http2RequestStreamState}).</li>
+ *   <li>The {@code last-stream-id} pointer for GOAWAY framing.</li>
+ * </ul>
+ *
+ * <p>Lifetime is one HTTP/2 connection; the processor wraps each session in a
+ * try-with-resources so {@link #close()} discards any unprocessed assembler
+ * state and request streams.
+ */
+// Retained suppressions:
+// - TooManyMethods: session state requires accessors for assembler + codec + per-stream registry.
+// - CyclomaticComplexity: applyPeerSettings dispatcher + decodePendingRequest path drive total CC=41.
+// - CloseResource: Http2RequestStreamState ownership transfers on put/remove; LoanedBuffer transfers
+//   via response.body() pipeline.
+@SuppressWarnings({
+        "PMD.TooManyMethods",
+        "PMD.CyclomaticComplexity",
+        "PMD.CloseResource"
+})
+final class Http2SessionContext implements AutoCloseable {
+
+    private static final int HTTP2_MAX_DYNAMIC_TABLE_SIZE = 4096;
+    private static final int HTTP2_MAX_HEADER_LIST_SIZE = 65_536;
+    private static final int HTTP2_SETTINGS_ENTRY_BYTES = 6;
+    private static final int HTTP2_SETTINGS_HEADER_TABLE_SIZE = 0x01;
+    private static final int HTTP2_SETTINGS_MAX_FRAME_SIZE = 0x05;
+    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
+    private static final String UPGRADE_TOKEN = "upgrade";
+
+    private final HpackDynamicTable encodeTable;
+    private final HpackDecoder decoder;
+    private final HpackEncoder encoder;
+    private final Http2FrameCodec codec;
+    private final Http2HeaderBlockAssembler assembler;
+    private final Map<Integer, Http2RequestStreamState> requestStreams;
+    private boolean pendingEndStream;
+    private int lastProcessedStreamId;
+
+    private Http2SessionContext(HpackDynamicTable encodeTable,
+                                HpackDecoder decoder,
+                                HpackEncoder encoder,
+                                Http2FrameCodec codec,
+                                Http2HeaderBlockAssembler assembler) {
+        this.encodeTable = encodeTable;
+        this.decoder = decoder;
+        this.encoder = encoder;
+        this.codec = codec;
+        this.assembler = assembler;
+        this.requestStreams = new HashMap<>();
+        this.pendingEndStream = false;
+        this.lastProcessedStreamId = 0;
+    }
+
+    /* default */ static Http2SessionContext create(MemoryAllocator allocator) {
+        HpackDynamicTable decodeTable = new HpackDynamicTable(HTTP2_MAX_DYNAMIC_TABLE_SIZE);
+        HpackDynamicTable encodeTable = new HpackDynamicTable(HTTP2_MAX_DYNAMIC_TABLE_SIZE);
+        HpackDecoder decoder = new HpackDecoder(decodeTable, allocator, HTTP2_MAX_HEADER_LIST_SIZE);
+        HpackEncoder encoder = new HpackEncoder(encodeTable, allocator, false);
+        Http2FrameCodec codec = new Http2FrameCodec();
+        Http2HeaderBlockAssembler assembler = new Http2HeaderBlockAssembler(allocator);
+        return new Http2SessionContext(encodeTable, decoder, encoder, codec, assembler);
+    }
+
+    /* default */ Http2FrameCodec codec() {
+        return codec;
+    }
+
+    /**
+     * Parses peer-advertised SETTINGS entries from the frame payload and
+     * applies the ones this implementation honours: HEADER_TABLE_SIZE (0x01)
+     * resizes the HPACK encoder dynamic table, MAX_FRAME_SIZE (0x05) clamps
+     * the frame codec's maximum frame size to the codec-enforced bounds.
+     * All other settings are accepted but ignored. Throws when the payload
+     * length is not a multiple of {@value #HTTP2_SETTINGS_ENTRY_BYTES}.
+     */
+    /* default */ void applyPeerSettings(LoanedBuffer aggregate, long payloadOffset, int payloadLength) {
+        if (payloadLength == 0) {
+            return;
+        }
+        if (payloadLength % HTTP2_SETTINGS_ENTRY_BYTES != 0) {
+            throw new IllegalStateException("Invalid SETTINGS payload length");
+        }
+        MemorySegment segment = aggregate.segment();
+        for (int offset = 0; offset < payloadLength; offset += HTTP2_SETTINGS_ENTRY_BYTES) {
+            long cursor = payloadOffset + offset;
+            int settingId = ((segment.get(ValueLayout.JAVA_BYTE, cursor) & 0xFF) << 8)
+                    | (segment.get(ValueLayout.JAVA_BYTE, cursor + 1) & 0xFF);
+            long settingValue = ((segment.get(ValueLayout.JAVA_BYTE, cursor + 2) & 0xFFL) << 24)
+                    | ((segment.get(ValueLayout.JAVA_BYTE, cursor + 3) & 0xFFL) << 16)
+                    | ((segment.get(ValueLayout.JAVA_BYTE, cursor + 4) & 0xFFL) << 8)
+                    | (segment.get(ValueLayout.JAVA_BYTE, cursor + 5) & 0xFFL);
+            if (settingId == HTTP2_SETTINGS_HEADER_TABLE_SIZE) {
+                encodeTable.setMaxSize(settingValue);
+            } else if (settingId == HTTP2_SETTINGS_MAX_FRAME_SIZE
+                    && settingValue >= Http2FrameCodec.MIN_MAX_FRAME_SIZE
+                    && settingValue <= Http2FrameCodec.MAX_MAX_FRAME_SIZE) {
+                codec.setMaxFrameSize((int) settingValue);
+            }
+        }
+    }
+
+    /* default */ boolean isAwaitingContinuation() {
+        return assembler.isAwaitingContinuation();
+    }
+
+    /* default */ void setPendingEndStream(boolean endStream) {
+        this.pendingEndStream = endStream;
+    }
+
+    /* default */ boolean pendingEndStream() {
+        return pendingEndStream;
+    }
+
+    /* default */ void beginHeaders(Http2FrameParser.FrameHeader header,
+                                    MemorySegment payload,
+                                    long dataOffset,
+                                    int dataLength) {
+        assembler.beginHeaders(header, payload, dataOffset, dataLength);
+    }
+
+    /* default */ void appendContinuation(Http2FrameParser.FrameHeader header,
+                                          MemorySegment payload,
+                                          long dataOffset,
+                                          int dataLength) {
+        assembler.appendContinuation(header, payload, dataOffset, dataLength);
+    }
+
+    /* default */ void validateContinuationMode(Http2FrameParser.FrameHeader header) {
+        assembler.validateContinuationMode(header);
+    }
+
+    // HPACK decode errors surface as RuntimeException; marked as protocol-invalid for GOAWAY.
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    /* default */ Http2DecodedRequest decodePendingRequest() {
+        if (!assembler.isComplete()) {
+            return new Http2DecodedRequest(0, null, "", List.of(), false);
+        }
+        int streamId = assembler.currentStreamId();
+        PendingRequestHeaders pendingHeaders = new PendingRequestHeaders();
+        MemorySegment block = assembler.completeBlock();
+        try {
+            decoder.decode(block, 0, (int) block.byteSize(),
+                    (name, value, _) -> pendingHeaders.accept(name, value));
+        } catch (RuntimeException _) {
+            pendingHeaders.invalidate();
+        }
+        assembler.reset();
+        pendingEndStream = false;
+        return pendingHeaders.toDecodedRequest(streamId);
+    }
+
+    /* default */ void openRequestStream(Http2DecodedRequest request) {
+        Http2RequestStreamState previous = requestStreams.put(
+                request.streamId(),
+                new Http2RequestStreamState(request.streamId(), request));
+        if (previous != null) {
+            previous.close();
+        }
+    }
+
+    /* default */ Http2RequestStreamState requestStream(int streamId) {
+        return requestStreams.get(streamId);
+    }
+
+    /* default */ Http2RequestStreamState takeRequestStream(int streamId) {
+        return requestStreams.remove(streamId);
+    }
+
+    /* default */ void resetRequestStream(int streamId) {
+        Http2RequestStreamState removed = requestStreams.remove(streamId);
+        if (removed != null) {
+            removed.close();
+        }
+    }
+
+    /* default */ long encodeResponseHeaders(MemorySegment target, HttpResponse response) {
+        long position = 0;
+        position = encoder.encodeHeader(
+                target,
+                position,
+                ":status",
+                Integer.toString(response.status().code()),
+                false);
+
+        boolean hasContentLength = false;
+        for (HttpHeader header : response.headers()) {
+            if (header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
+                hasContentLength = true;
+            }
+            if (isConnectionSpecificHeader(header.name()) || header.name().startsWith(":")) {
+                continue;
+            }
+            position = encoder.encodeHeader(
+                    target,
+                    position,
+                    header.name().toLowerCase(Locale.ROOT),
+                    header.value(),
+                    false);
+        }
+
+        LoanedBuffer body = response.body();
+        if (!hasContentLength) {
+            int bodyBytes = body == null ? 0 : (int) body.size();
+            position = encoder.encodeHeader(target, position, "content-length", Integer.toString(bodyBytes), false);
+        }
+        return position;
+    }
+
+    /* default */ void clearPendingIfStreamMatches(int streamId) {
+        if (assembler.currentStreamId() == streamId) {
+            assembler.reset();
+            pendingEndStream = false;
+        }
+    }
+
+    /* default */ int lastProcessedStreamId() {
+        return lastProcessedStreamId;
+    }
+
+    /* default */ void setLastProcessedStreamId(int lastProcessedStreamId) {
+        this.lastProcessedStreamId = Math.max(this.lastProcessedStreamId, lastProcessedStreamId);
+    }
+
+    /**
+     * Connection-specific HTTP/1 headers that MUST NOT appear in HTTP/2
+     * messages (RFC 7540 §8.1.2.2). Used both by the response-encoding path
+     * and by the request-decoding path in {@link PendingRequestHeaders}.
+     */
+    /* default */ static boolean isConnectionSpecificHeader(String headerName) {
+        return "connection".equalsIgnoreCase(headerName)
+                || "keep-alive".equalsIgnoreCase(headerName)
+                || "proxy-connection".equalsIgnoreCase(headerName)
+                || UPGRADE_TOKEN.equalsIgnoreCase(headerName)
+                || "transfer-encoding".equalsIgnoreCase(headerName);
+    }
+
+    @Override
+    public void close() {
+        assembler.reset();
+        for (Http2RequestStreamState requestStream : requestStreams.values()) {
+            requestStream.close();
+        }
+        requestStreams.clear();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/PendingRequestHeaders.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/PendingRequestHeaders.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Package-private HPACK-decode accumulator for one HTTP/2 request used by
+ * {@link Http2SessionContext#decodePendingRequest()}.
+ *
+ * <p>Extracted from {@link CommunityHttp2SessionProcessor} in v0.8 Sprint 3
+ * (QA-018a) as one of four seams of the processor's God-class decomposition.
+ * Enforces RFC 7540 §8.1.2.1 pseudo-header ordering (pseudo-headers MUST
+ * precede regular headers), §8.1.2.2 connection-specific header rejection,
+ * and the {@code :method} / {@code :path} pseudo-header requirements.
+ *
+ * <p>Instances are short-lived (one per HEADERS+CONTINUATION block).
+ */
+final class PendingRequestHeaders {
+
+    private String methodToken;
+    private String path;
+    private boolean valid = true;
+    private boolean sawRegularHeader;
+    private final List<HttpHeader> requestHeaders = new ArrayList<>();
+
+    /* default */ void accept(String name, String value) {
+        if (!valid) {
+            return;
+        }
+        if (name.startsWith(":")) {
+            acceptPseudoHeader(name, value);
+            return;
+        }
+        sawRegularHeader = true;
+        if (Http2SessionContext.isConnectionSpecificHeader(name)) {
+            valid = false;
+            return;
+        }
+        requestHeaders.add(new HttpHeader(name, value));
+    }
+
+    /* default */ void invalidate() {
+        valid = false;
+    }
+
+    /* default */ Http2DecodedRequest toDecodedRequest(int streamId) {
+        HttpMethod method = parseHttp2Method(methodToken);
+        String resolvedPath = path == null ? "" : path;
+        boolean requestValid = valid && method != null && !resolvedPath.isEmpty();
+        return new Http2DecodedRequest(streamId, method, resolvedPath, List.copyOf(requestHeaders), requestValid);
+    }
+
+    private void acceptPseudoHeader(String name, String value) {
+        if (sawRegularHeader) {
+            valid = false;
+            return;
+        }
+        switch (name) {
+            case ":method" -> methodToken = value;
+            case ":path" -> path = value;
+            case ":authority", ":scheme" -> {
+                // Accepted but not required for this processing path.
+            }
+            default -> valid = false;
+        }
+    }
+
+    private static HttpMethod parseHttp2Method(String methodToken) {
+        if (methodToken == null || methodToken.isBlank()) {
+            return null;
+        }
+        try {
+            return HttpMethod.valueOf(methodToken);
+        } catch (IllegalArgumentException _) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Decomposes the 896-LOC HTTP/2 session processor by extracting four pkg-private seams. Processor retains the frame-loop + dispatcher switch + frame handlers + response writer + ingress read loop.

| Seam | File | LOC | Concern |
|:--|:--|:--|:--|
| **Http2SessionContext** | `Http2SessionContext.java` (new) | 275 | Per-connection HPACK encoder/decoder, frame codec, header-block assembler, per-stream registry, last-stream-id pointer, `applyPeerSettings` dispatcher, `encodeResponseHeaders`, `isConnectionSpecificHeader` (RFC 7540 §8.1.2.2). |
| **PendingRequestHeaders** | `PendingRequestHeaders.java` (new) | 94 | HPACK-decode accumulator — enforces RFC 7540 §8.1.2.1 pseudo-header ordering, §8.1.2.2 connection-specific header rejection, `:method`/`:path` requirements. |
| **CommunityHttp2ControlFrames** | `CommunityHttp2ControlFrames.java` (new) | 120 | Writers for SETTINGS / SETTINGS-ACK / PING-ACK / RST_STREAM (REFUSED+CANCEL) / GOAWAY — uniform `borrow → encode → write` shape parameterized over MemoryAllocator + TransportStream. |
| **CommunityHttp2FrameFragments** | `CommunityHttp2FrameFragments.java` (new) | 96 | Pad/priority field extraction for HEADERS and DATA frame payloads (RFC 7540 §6.1 / §6.2). |

## Numbers

- **Processor LOC:** 896 → 472 (**-47%**)
- **Class-level @SuppressWarnings on processor:** 7 → 5
  - **Closed:** `PMD.ExcessiveImports` + `PMD.CouplingBetweenObjects` (extracted HPACK/codec/assembler types out of outer's import surface — 8 imports removed from processor)
  - **Retained:** GodClass (residual WMC=72), TooManyMethods, CyclomaticComplexity, CloseResource, AvoidCatchingGenericException — all with rationale

### Suppression migration

- `PMD.GodClass` + `PMD.TooManyMethods` — residual on processor (WMC=72 still over threshold; frame-loop + dispatcher + frame handlers + response writer remain intrinsically cohesive). Optional QA-018a-followup could split response writer if WMC threshold drives it.
- New seam files take their own targeted class-level suppressions:
  - `Http2SessionContext` — `TooManyMethods` (accessor surface for assembler/codec/registry), `CyclomaticComplexity` (CC=41 from `applyPeerSettings` + `decodePendingRequest`), `CloseResource` (request-stream/LoanedBuffer ownership transfer).

## Public surface

**Unchanged.** Processor pkg-private constructor signature, `handlePriorKnowledge` / `handleUpgrade` entry points, and all related types (`Http2DecodedRequest`, `Http2RequestStreamState`) preserved. Callers need no source changes.

## Invariants preserved

- **`tlsLock` synchronization** — N/A here (Session ctx owns its own assembler/codec; processor frame dispatch is single-threaded per connection).
- **PERF-061 per-response reusable carrier** — `writeHttp2Response` still allocates one `outboundFrame` slab + one `headerBlock` slab per response; frame writers serialize wire image into the slab in place.
- **Connection-specific header rejection** — `isConnectionSpecificHeader` now centralized in `Http2SessionContext` and consumed by both response-encode path and `PendingRequestHeaders.accept`.
- **RFC 7540 §8.1.2.1 / §8.1.2.2** — pseudo-header ordering, regular-after-pseudo invalidation, `:authority`/`:scheme` acceptance preserved verbatim from extracted code.

## Verification

- ✅ Full reactor `mvn verify -Pcoverage -DskipITs` SUCCESS (1:44)
- ✅ HTTP test suite 75/76 green (1 pre-existing skip — no new failures)
- ✅ `AbstractHttpProviderTck`, `AbstractHttpClientEngineTck`, `AbstractHttpHandlerTck`, `AbstractHttpExchangeTck` bindings all green
- ✅ `CommunityHttpProviderLoopbackTckTest`, `CommunityHttpSecurityAdmissionIntegrationTest`, `CommunityHttpRequestProcessorTest` all green
- ✅ PMD + Checkstyle 0 violations
- ✅ JaCoCo BUNDLE LINE coverage check met

## Sprint 3 GodClass tracker after this PR

| QA-* | Class | Status |
|:--|:--|:--|
| QA-015 | CommunityHttpClientEngine | ✅ #133 |
| QA-016 | NativeTcpStream | ✅ #134 |
| QA-017 | JdbcFlowSnapshotStore | ✅ #136 |
| **QA-018a** | **CommunityHttp2SessionProcessor** | **this PR ✅** |
| QA-018b | SubsystemOrchestrator (Core/bootstrap, boundary-sensitive) | next |

## Test plan

- [x] Full reactor `mvn verify -Pcoverage -DskipITs` locally green
- [x] HTTP test suite + TCK bindings green locally
- [x] PMD/Checkstyle 0 violations
- [ ] CI Build & TCK Verification green
- [ ] Persistence RLS/Interceptor Gate green
- [ ] Kafka Integration Gate green
- [ ] Transport Stress Gate green (post-dedup #135 — single run)
- [ ] SonarCloud Code Analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)