### PR TITLE
v0.8 Sprint 5 (JFR-091): publish-side + non-OCC save-side JFR observability

### DIFF
--- a/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/KafkaEventEngine.java
+++ b/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/KafkaEventEngine.java
@@ -111,7 +111,8 @@ public final class KafkaEventEngine implements EventEngine {
         this.localDelegate = new InMemoryEventBus(registry);
         this.queue         = new NoOpQueue(spiConfig.queueCapacity());
         this.producer      = createProducer(kafkaConfig);
-        this.publishBus    = new KafkaPublishBus(producer, registry, kafkaConfig,
+        this.publishBus    = new KafkaPublishBus(spiConfig.engineName(),
+                                                 producer, registry, kafkaConfig,
                                                  localDelegate, publishedTotal);
         this.loop          = new ConsumerLoop(spiConfig.engineName(), kafkaConfig,
                                               registry, localDelegate);
@@ -186,17 +187,22 @@ public final class KafkaEventEngine implements EventEngine {
 
     private static final class KafkaPublishBus implements EventBus {
 
+        private static final String UNKNOWN_TOPIC = "<unknown>";
+
+        private final String                   engineName;
         private final Producer<byte[], byte[]> producer;
         private final KafkaEventRegistry       registry;
         private final KafkaEventConfig         config;
         private final EventBus                 localDelegate;
         private final AtomicLong               publishedTotal;
 
-        private KafkaPublishBus(Producer<byte[], byte[]> producer,
+        private KafkaPublishBus(String engineName,
+                                Producer<byte[], byte[]> producer,
                                 KafkaEventRegistry registry,
                                 KafkaEventConfig config,
                                 EventBus localDelegate,
                                 AtomicLong publishedTotal) {
+            this.engineName     = engineName;
             this.producer       = producer;
             this.registry       = registry;
             this.config         = config;
@@ -222,6 +228,14 @@ public final class KafkaEventEngine implements EventEngine {
                 // it unchanged; the generic Kafka-failure wrap below would mask the real cause.
                 throw ex;
             } catch (RuntimeException ex) { //NOPMD AvoidCatchingGenericException
+                // JFR-091: post-mortem trail for publish-side failures (timeout, broker
+                // disconnect, authorisation, etc.). Topic resolved best-effort — if the
+                // ordinal is unregistered (rare on this path since buildRecord would have
+                // thrown EventBusException first), emit "<unknown>" rather than masking the
+                // real Kafka failure with a registry NPE.
+                KafkaPublishFailedEvent.emit(engineName, resolveTopicSafe(descriptor),
+                        descriptor.eventTypeOrdinal(), "publish",
+                        ex.getClass().getName(), String.valueOf(ex.getMessage()));
                 throw new EventBusException("Kafka producer.send failed", ex);
             }
         }
@@ -240,8 +254,23 @@ public final class KafkaEventEngine implements EventEngine {
                 // below would mask the real cause.
                 throw ex;
             } catch (ExecutionException | RuntimeException ex) { //NOPMD KafkaException is RuntimeException
+                // JFR-091: same publish-side failure post-mortem as publish() above; "publishAndAwait"
+                // mode differentiates the two call paths in operator JFR analysis.
+                KafkaPublishFailedEvent.emit(engineName, resolveTopicSafe(descriptor),
+                        descriptor.eventTypeOrdinal(), "publishAndAwait",
+                        ex.getClass().getName(), String.valueOf(ex.getMessage()));
                 throw new EventBusException("Kafka producer.send failed", ex);
             }
+        }
+
+        /**
+         * Best-effort topic resolution for failure-side JFR emission — returns
+         * {@code "<unknown>"} when the ordinal is not registered, so JFR emit never NPEs
+         * inside the catch block and the real cause exception propagates unchanged.
+         */
+        private String resolveTopicSafe(EventDescriptor descriptor) {
+            String typeName = registry.nameOfOrdinal(descriptor.eventTypeOrdinal());
+            return (typeName == null || typeName.isBlank()) ? UNKNOWN_TOPIC : config.topicFor(typeName);
         }
 
         @Override

--- a/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/KafkaPublishFailedEvent.java
+++ b/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/KafkaPublishFailedEvent.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.kafka;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Emitted when {@code KafkaPublishBus.publish} (or {@code publishAndAwait}) wraps a Kafka
+ * driver exception as {@code EventBusException}. JFR-091 (v0.8 Sprint 5) — fills the
+ * observability gap on the publisher side; the symmetric consumer-side event is
+ * {@link KafkaConsumerLoopFailedEvent}.
+ *
+ * <p>Captures: engine name, topic (so operators can localise the failure to a specific event
+ * type's topic-mapping), event ordinal (for type-level diagnostics without revealing payload
+ * bytes), and the exception class + message. Payload bytes are NEVER logged — Kafka producer
+ * credentials and event-domain data must not surface in JFR.
+ */
+@Name("eu.exeris.kernel.events.kafka.PublishFailed")
+@Label("Kafka Publish Failed")
+@Category({"Exeris Kernel", "Events", "Kafka"})
+@Description("Emitted when KafkaPublishBus.publish wraps a Kafka driver exception "
+        + "(timeout, broker disconnect, authorisation failure, etc.) as EventBusException. "
+        + "Operators rely on this to attribute publish failures to specific topic + event "
+        + "ordinal pairs — without it, the exception surface tells callers but leaves no "
+        + "post-mortem trail for analysing publish-side failure rates.")
+@StackTrace(false)
+final class KafkaPublishFailedEvent extends Event {
+
+    @Label("Engine Name")
+    @Description("Human-readable engine name from EventEngineConfig.engineName()")
+    /* default */ String engineName;
+
+    @Label("Topic")
+    @Description("Kafka topic the publish targeted (per topicFor(eventType) mapping)")
+    /* default */ String topic;
+
+    @Label("Event Type Ordinal")
+    @Description("Wire ordinal of the event type being published (descriptor.eventTypeOrdinal)")
+    /* default */ int eventTypeOrdinal;
+
+    @Label("Publish Mode")
+    @Description("Either \"publish\" (fire-and-forget) or \"publishAndAwait\" (awaited future)")
+    /* default */ String publishMode;
+
+    @Label("Exception Class")
+    @Description("Fully-qualified class name of the exception wrapped as EventBusException")
+    /* default */ String exceptionClass;
+
+    @Label("Exception Message")
+    @Description("Exception message — secret-safe; Kafka credentials are never included")
+    /* default */ String exceptionMessage;
+
+    /* default */ static void emit(
+            String engineName,
+            String topic,
+            int eventTypeOrdinal,
+            String publishMode,
+            String exceptionClass,
+            String exceptionMessage) {
+        KafkaPublishFailedEvent event = new KafkaPublishFailedEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.begin();
+        event.engineName = engineName;
+        event.topic = topic;
+        event.eventTypeOrdinal = eventTypeOrdinal;
+        event.publishMode = publishMode;
+        event.exceptionClass = exceptionClass;
+        event.exceptionMessage = exceptionMessage;
+        event.commit();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/FlowSnapshotSaveFailedEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/FlowSnapshotSaveFailedEvent.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.flow;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * JFR event emitted when {@link JdbcFlowSnapshotStore#save} rolls back on a generic
+ * (non-OCC) persistence failure. JFR-091 (v0.8 Sprint 5) — closes the observability
+ * gap on the save path: optimistic-lock conflicts already emit
+ * {@link OptimisticLockConflictEvent}; this event fires for everything else (driver
+ * timeout, deadlock, network partition, schema mismatch, etc.).
+ *
+ * <p>Captures the engine name, the conflicting SQLSTATE (when extractable from the
+ * exception chain), and the wrapped exception class + message. Secret-safe — JDBC
+ * credentials are never included.
+ */
+@Name("eu.exeris.kernel.flow.FlowSnapshotSaveFailed")
+@Label("Flow Snapshot Save Failed")
+@Category({"Exeris Kernel", "Flow"})
+@Description("Emitted when JdbcFlowSnapshotStore.save catches a non-OCC "
+        + "PersistenceProviderException, rolls back the transaction, and wraps the cause "
+        + "as FlowEngineException. Operators rely on this to attribute save-side failures "
+        + "to specific SQLSTATE classes (connection lost, deadlock, schema drift, etc.) "
+        + "without the OCC race-loser noise that OptimisticLockConflictEvent already filters.")
+@StackTrace(false)
+public final class FlowSnapshotSaveFailedEvent extends Event {
+
+    /** Sentinel for "no SQLSTATE could be extracted from the cause chain". */
+    public static final String SQLSTATE_UNKNOWN = "<unknown>";
+
+    @Label("Engine Name")
+    @Description("Human-readable engine name from FlowEngineConfig.engineName()")
+    /* default */ String engineName;
+
+    @Label("SQLSTATE")
+    @Description("ANSI SQLSTATE class of the underlying SQLException, or '<unknown>' "
+            + "if no SQLException was found in the cause chain")
+    /* default */ String sqlState;
+
+    @Label("Exception Class")
+    @Description("Fully-qualified class name of the PersistenceProviderException cause")
+    /* default */ String exceptionClass;
+
+    @Label("Exception Message")
+    @Description("Exception message — secret-safe; JDBC credentials are never included")
+    /* default */ String exceptionMessage;
+
+    /* default */ static void emit(String engineName,
+                                   String sqlState,
+                                   String exceptionClass,
+                                   String exceptionMessage) {
+        FlowSnapshotSaveFailedEvent event = new FlowSnapshotSaveFailedEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.begin();
+        event.engineName = engineName;
+        event.sqlState = sqlState;
+        event.exceptionClass = exceptionClass;
+        event.exceptionMessage = exceptionMessage;
+        event.commit();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
@@ -67,10 +67,14 @@ import java.util.Optional;
  */
 // QA-017 extracted JdbcFlowSnapshotCodec (binding + BYTEA compensation-stack pack/unpack +
 // row decoder). Residual store retains the FlowSnapshotStore SPI surface, the two-step
-// UPDATE-then-INSERT OCC orchestration (ADR-013 §5), and the integrity-violation race
-// remapping — splitting these further would fragment the transactional boundary the OCC
-// contract hangs on.
-@SuppressWarnings({"PMD.CyclomaticComplexity"})
+// UPDATE-then-INSERT OCC orchestration (ADR-013 §5), the integrity-violation race remapping,
+// and the JFR-091 generic-failure diagnostics (extractSqlState + emit FlowSnapshotSaveFailedEvent).
+// Splitting further would fragment the transactional boundary the OCC contract hangs on.
+//
+// TooManyMethods retained: JFR-091 added FlowSnapshotSaveFailedEvent + extractSqlState helper,
+// pushing the method count back over the PMD threshold that QA-017 had closed. Acceptable cost
+// for the operator-facing diagnostic surface.
+@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.TooManyMethods"})
 public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
 
     private static final String SQL_INSERT =
@@ -166,6 +170,14 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
                 throw occ;
             } catch (PersistenceProviderException ppe) {
                 conn.rollback();
+                // JFR-091: post-mortem trail for non-OCC save failures (driver timeout,
+                // deadlock, connection lost, schema drift, etc.). OCC race losers already
+                // emit OptimisticLockConflictEvent on the FlowEngineException catch above.
+                FlowSnapshotSaveFailedEvent.emit(
+                        engineName,
+                        extractSqlState(ppe),
+                        ppe.getClass().getName(),
+                        String.valueOf(ppe.getMessage()));
                 throw new FlowEngineException("Failed to save flow snapshot", ppe);
             }
         }
@@ -212,6 +224,25 @@ public final class JdbcFlowSnapshotStore implements FlowSnapshotStore {
             }
         }
         return false;
+    }
+
+    /**
+     * Extracts the first non-null SQLSTATE found while walking the cause chain.
+     * Used by {@link FlowSnapshotSaveFailedEvent} (JFR-091) for operator-facing
+     * diagnostics. Returns {@link FlowSnapshotSaveFailedEvent#SQLSTATE_UNKNOWN}
+     * when no {@link SQLException} carries a SQLSTATE — keeps the JFR field
+     * present (never null) for analyser tooling.
+     */
+    private static String extractSqlState(Throwable thrown) {
+        for (Throwable current = thrown; current != null; current = current.getCause()) {
+            if (current instanceof SQLException sql) {
+                String state = sql.getSQLState();
+                if (state != null && !state.isBlank()) {
+                    return state;
+                }
+            }
+        }
+        return FlowSnapshotSaveFailedEvent.SQLSTATE_UNKNOWN;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fills two observability gaps flagged in the Sprint 5 plan: Kafka **publish-side** failures and `JdbcFlowSnapshotStore.save` **generic SQL** failures (non-OCC) now emit dedicated JFR events. Operators can attribute failure rates to specific topic / SQLSTATE pairs without trawling SLF4J logs.

## New JFR events

| Event | Visibility | Category | Fields |
|:--|:--|:--|:--|
| `KafkaPublishFailedEvent` | pkg-private | Events / Kafka | engineName, topic, eventTypeOrdinal, publishMode, exceptionClass, exceptionMessage |
| `FlowSnapshotSaveFailedEvent` | public | Flow | engineName, sqlState, exceptionClass, exceptionMessage |

Both emit with `@StackTrace(false)` — secret-safe per Glass-Box contract; Kafka credentials + JDBC payload bytes are never logged.

## Wire-up

**`KafkaEventEngine.KafkaPublishBus`:**
- Constructor takes `engineName` (forwarded from `spiConfig.engineName()`).
- Both `publish()` and `publishAndAwait()` catch blocks emit `KafkaPublishFailedEvent` before wrapping as `EventBusException`.
- `publishMode` field discriminates the two call paths in operator analysis (\"publish\" / \"publishAndAwait\").
- `resolveTopicSafe(descriptor)` — best-effort topic lookup (returns `\"<unknown>\"` on unregistered ordinal) so JFR emit never NPEs inside the catch and the real cause exception propagates unchanged.

**`JdbcFlowSnapshotStore.save`:**
- Non-OCC `PersistenceProviderException` rollback path emits `FlowSnapshotSaveFailedEvent` before wrapping as `FlowEngineException`.
- OCC race losers still emit `OptimisticLockConflictEvent` (UPDATE_STALE / INSERT_TOCTOU) — unchanged.
- `extractSqlState()` helper walks the cause chain for the first non-blank `SQLSTATE`; returns `SQLSTATE_UNKNOWN` sentinel if none found.

## Suppressions

`JdbcFlowSnapshotStore`: `PMD.TooManyMethods` re-added at class level. QA-017 had closed it (after extracting `JdbcFlowSnapshotCodec`); JFR-091's `extractSqlState` helper + `FlowSnapshotSaveFailedEvent.emit` call site push the method count back over the PMD threshold. Acceptable cost for the operator-facing diagnostic surface.

## Public surface

- `KafkaPublishFailedEvent` — pkg-private (only `KafkaEventEngine` uses it). Matches `KafkaConsumerLoopFailedEvent` visibility.
- `FlowSnapshotSaveFailedEvent` — **public**. Mirrors `OptimisticLockConflictEvent` visibility so application code can install `RecordingStream` consumers for saga health dashboards.

## Verification

- ✅ Full reactor `mvn verify -Pcoverage -DskipITs` SUCCESS (1:42)
- ✅ `FlowSnapshotStore` TCK 12/12 green (`SaveLoadRoundTrip`, `ConcurrentSaveContention`, `DeleteAndExists`, `ListParkedContract`, `CrossRestartRecovery`)
- ✅ `KafkaEventCodecTest` + `KafkaEventBrokerPortTest` 10/10 green
- ✅ PMD + Checkstyle 0 violations
- ✅ JaCoCo BUNDLE LINE coverage check met

## Sprint 5 progress after this PR

| ID | Subject | Status |
|:--|:--|:--|
| **JFR-091** | **publish + save error JFR events** | **this PR ✅** |
| DOC-090 | cachePrepStmts Javadoc + flow.md sync | next |
| EVENT-111 | Events backpressure + projection confidence | pending |
| HTTP-112 | Community HTTP/2 lifecycle hardening | pending |

## Test plan

- [x] Full reactor `mvn verify -Pcoverage -DskipITs` locally green
- [x] Flow + Kafka tests green locally
- [x] PMD/Checkstyle 0 violations
- [ ] CI Build & TCK Verification green
- [ ] Persistence RLS/Interceptor Gate green
- [ ] Kafka Integration Gate green
- [ ] Transport Stress Gate green
- [ ] SonarCloud Code Analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)