### PR TITLE
v0.8 Sprint 3 (CI): serialize integration gates — no two run simultaneously

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -197,9 +197,14 @@ jobs:
     #
     # Mirrors persistence-rls-gate exactly: override -DincludedGroups=integration
     # and clear -DexcludedGroups= so Surefire picks them up.
+    #
+    # Sprint 3 cont. (CI sequencing): chains after persistence-rls-gate (not
+    # parallel) so integration gates don't all kick off simultaneously. Order:
+    # build-and-verify → persistence-rls-gate → kafka-integration-gate
+    # → transport-stress-gate. Trades wall-clock for predictable scheduling.
     name: Kafka Integration Gate
     runs-on: ubuntu-latest
-    needs: build-and-verify
+    needs: persistence-rls-gate
     permissions:
       contents: read
 
@@ -256,9 +261,14 @@ jobs:
     # echo loops and post-test verification deadlines (`NativeTcpTransportStressTest`).
     # The TCK pinning teardown now exposes a configurable drain budget via
     # `-Dexeris.tck.transport.drainTimeoutSeconds=N` for constrained runners.
+    #
+    # Sprint 3 cont. (CI sequencing): chains after kafka-integration-gate (last in
+    # the integration-gate chain). Order: build-and-verify → persistence-rls-gate
+    # → kafka-integration-gate → transport-stress-gate. Sequencing isolates each
+    # gate's scheduler pressure — no two stress-prone jobs run simultaneously.
     name: Transport Stress Gate
     runs-on: ubuntu-latest
-    needs: build-and-verify
+    needs: kafka-integration-gate
     permissions:
       contents: read
 


### PR DESCRIPTION
## Problem

The three integration gates (\`persistence-rls-gate\`, \`kafka-integration-gate\`, \`transport-stress-gate\`) all kick off in parallel as soon as the main \`build-and-verify\` finishes. Each on its own isolated 2-vCPU GHA-hosted VM, but **simultaneously** — three stress-prone test suites starting at the same time across the runner pool.

## Change

Chain them sequentially:

\`\`\`
build-and-verify
    ↓
persistence-rls-gate
    ↓
kafka-integration-gate
    ↓
transport-stress-gate
\`\`\`

Single-line diff per gate:

| Gate | Was | Now |
|:--|:--|:--|
| persistence-rls-gate | \`needs: build-and-verify\` | \`needs: build-and-verify\` (unchanged) |
| kafka-integration-gate | \`needs: build-and-verify\` | \`needs: persistence-rls-gate\` |
| transport-stress-gate | \`needs: build-and-verify\` | \`needs: kafka-integration-gate\` |

## Trade-offs

**Cost:** +5-7 minutes worst-case PR feedback latency (chain length × 3-5 min per gate). Slight reduction in total parallelism across in-flight PRs.

**Wins:**
- No two stress-prone gates ever kick off at the same time on the runner pool.
- Cleaner per-PR check sequence in the GitHub UI (gates appear in order).
- Compatible with the future Sprint 7 non-blocking client-ingress refactor that retires the drain-budget hotfix ladder.

## What this DOES NOT fix

The underlying \`CommunityTransportCarrierPinningTck\` flake remains — its root cause is JDK 26+35 + carrier pinning on blocking FFM \`recv()\` under 2-vCPU pressure, not job scheduling. The fix is Sprint 7 production work. This change isolates the stress gate's scheduler context so any future flake is attributable cleanly.

## Verification

- ✅ YAML syntactically valid (\`python3 -c 'yaml.safe_load(open(...))'\`)
- ✅ Single-file change — no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)