### PR TITLE
v0.8 Sprint 5 (DOC-090): HikariCP prepared-statement cache defaults + Javadoc + flow.md sync

### DIFF
--- a/docs/subsystems/flow.md
+++ b/docs/subsystems/flow.md
@@ -144,6 +144,18 @@ Three additions land in 0.7 to support distributed saga state per ADR-013:
 
 In-memory bindings (`CommunityFlowSnapshotStore`, test stores) continue to ignore `schemaVersion`; the `markPersisted()` increment is harmless for them. Enterprise binding inherits the same SPI contract and TCK obligations on parity (`AbstractDistributedFlowSnapshotStoreTck`).
 
+### HikariCP statement-cache requirement (DOC-090, v0.8 Sprint 5)
+
+`JdbcFlowSnapshotStore.save` re-prepares two statements on every saga write — `SQL_UPDATE_OCC` (the OCC-guarded UPDATE) and `SQL_INSERT` (the first-writer INSERT on UPDATE → 0 rows). Without a driver-side prepared-statement cache the JDBC driver re-parses both per save and PostgreSQL never promotes them to server-side prepared form, so each accepted save pays full parse cost. The Community Hikari binding (`CommunityHikariSupport.applyDataSourceProperties`) sets these as **opt-out defaults**:
+
+| Property | Default | Status |
+|:--|:--|:--|
+| `cachePrepStmts` | `true` | **HARD requirement** — do not disable. |
+| `prepStmtCacheSize` | `250` | Recommended; covers OCC + outbox + RLS paths. Override smaller only for memory-constrained deployments. |
+| `prepStmtCacheSqlLimit` | `2048` | Recommended per-statement SQL length cap. Override smaller only if the operator audited their longest SQL emitted by the binding. |
+
+The same defaults apply to the outbox-orchestrator pump and the RLS-interceptor session-set path — both also re-prepare a small fixed statement set per request. Operators can override every value via `PersistenceConfig.properties()`; the Community binding's check-then-default pattern (matching how `ssl=true` and `defaultRowFetchSize=50` are applied) ensures user-supplied properties always win. The `JdbcFlowSnapshotStore` class-level Javadoc cross-references this section as the source of truth.
+
 ---
 
 ## Error Codes

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/flow/JdbcFlowSnapshotStore.java
@@ -63,6 +63,26 @@ import java.util.Optional;
  *       constructed this store.</li>
  * </ul>
  *
+ * <h2>HikariCP Statement-Cache Requirement (DOC-090, v0.8 Sprint 5)</h2>
+ * <p>This store relies on the underlying {@link PersistenceEngine}'s JDBC pool
+ * having driver-side prepared-statement caching enabled. The two-step UPSERT
+ * re-prepares the same {@code SQL_UPDATE_OCC} + {@code SQL_INSERT} statements
+ * on every saga write; without statement caching each save pays the SQL parse
+ * cost twice (UPDATE then INSERT on first-writer) and PostgreSQL never
+ * promotes them to server-side prepared form. The Community Hikari binding
+ * sets these as opt-out defaults in
+ * {@code CommunityHikariSupport.applyDataSourceProperties}:
+ * <ul>
+ *   <li>{@code cachePrepStmts=true}  — enable the cache (HARD requirement).</li>
+ *   <li>{@code prepStmtCacheSize=250} — entries; covers OCC + outbox + RLS paths.</li>
+ *   <li>{@code prepStmtCacheSqlLimit=2048} — per-statement SQL length cap.</li>
+ * </ul>
+ * Operators can override via {@code PersistenceConfig.properties()} (e.g., dial
+ * sizes down for memory-constrained deployments) but must keep
+ * {@code cachePrepStmts=true} — turning it off changes the OCC contract's
+ * performance envelope dramatically. See {@code docs/subsystems/flow.md}
+ * Persistence section.
+ *
  * @since 0.7.0
  */
 // QA-017 extracted JdbcFlowSnapshotCodec (binding + BYTEA compensation-stack pack/unpack +

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityHikariSupport.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/CommunityHikariSupport.java
@@ -99,6 +99,23 @@ final class CommunityHikariSupport {
                 && !CommunityHikariUtils.containsKeyIgnoreCase(properties, "defaultRowFetchSize")) {
             properties.put("defaultRowFetchSize", "50");
         }
+        // DOC-090 (v0.8 Sprint 5): JDBC driver-side prepared-statement cache. Required for
+        // JdbcFlowSnapshotStore + outbox + RLS-interceptor paths to amortise SQL parse cost
+        // across the two-step OCC UPDATE-then-INSERT pattern. The first-writer's UPDATE_OCC
+        // and INSERT statements are re-prepared every save without the cache; PostgreSQL also
+        // promotes cached statements to server-side prepared form (saving a parse round trip
+        // per save). Defaults match the Spring Boot reference set (size=250, sqlLimit=2048)
+        // and stay overridable via PersistenceConfig.properties() — operators can dial them
+        // down for memory-constrained deployments without removing the requirement.
+        if (!CommunityHikariUtils.containsKeyIgnoreCase(properties, "cachePrepStmts")) {
+            properties.put("cachePrepStmts", "true");
+        }
+        if (!CommunityHikariUtils.containsKeyIgnoreCase(properties, "prepStmtCacheSize")) {
+            properties.put("prepStmtCacheSize", "250");
+        }
+        if (!CommunityHikariUtils.containsKeyIgnoreCase(properties, "prepStmtCacheSqlLimit")) {
+            properties.put("prepStmtCacheSqlLimit", "2048");
+        }
         properties.forEach(hikariConfig::addDataSourceProperty);
     }
 


### PR DESCRIPTION
## Summary

\`JdbcFlowSnapshotStore.save\` re-prepares \`SQL_UPDATE_OCC\` + \`SQL_INSERT\` on every saga write. Without driver-side prepared-statement caching, each save re-parses both statements and PostgreSQL never promotes them to server-side prepared form. Same parse-cost amortisation applies to the outbox pump and RLS-interceptor session-set path.

This PR (1) sets sensible opt-out defaults in the Community Hikari binding, (2) documents the requirement in the \`JdbcFlowSnapshotStore\` Javadoc, and (3) cross-links from \`docs/subsystems/flow.md\` Persistence section.

## Code change — \`CommunityHikariSupport.applyDataSourceProperties\`

Adds three opt-out defaults via the same check-then-default pattern used for \`ssl\` / \`sslmode\` / \`defaultRowFetchSize\`:

| Property | Default | Status |
|:--|:--|:--|
| \`cachePrepStmts\` | \`true\` | **HARD requirement** |
| \`prepStmtCacheSize\` | \`250\` | Recommended; covers OCC + outbox + RLS paths |
| \`prepStmtCacheSqlLimit\` | \`2048\` | Recommended per-statement SQL length cap |

User-supplied \`PersistenceConfig.properties()\` always wins; operators can dial sizes down for memory-constrained deployments but should keep \`cachePrepStmts=true\`.

## Doc changes

**\`JdbcFlowSnapshotStore\` class-level Javadoc:** new \"HikariCP Statement-Cache Requirement (DOC-090, v0.8 Sprint 5)\" section explaining why the cache matters (OCC parse cost + PG server-side prepared promotion) with table of defaults and override guidance. Cross-references \`docs/subsystems/flow.md\`.

**\`docs/subsystems/flow.md\` Persistence section:** new \"HikariCP statement-cache requirement (DOC-090, v0.8 Sprint 5)\" subsection under \`Distributed Snapshot Store Contract\` heading. Source-of-truth table for the three properties with default + override guidance. The store's Javadoc points back here.

## Public surface

**Unchanged.** \`CommunityHikariSupport\` is pkg-private. \`PersistenceConfig.properties()\` contract preserved — user properties always override defaults.

## Verification

- ✅ Full reactor \`mvn verify -Pcoverage -DskipITs\` SUCCESS (1:46)
- ✅ Persistence + Flow test suites 38/38 green (CommunityHikariSupportTest, CommunityPersistenceProviderTckTest, CommunityPersistenceEnginePrewarmTest, AbstractDistributedFlowSnapshotStoreTck bindings, CommunityJdbcFlowSnapshotStoreTckIT)
- ✅ PMD + Checkstyle 0 violations
- ✅ JaCoCo BUNDLE LINE coverage check met

## Sprint 5 progress after this PR

| ID | Subject | Status |
|:--|:--|:--|
| JFR-091 | publish + save error JFR events | ✅ #141 |
| **DOC-090** | **cachePrepStmts defaults + Javadoc + flow.md** | **this PR ✅** |
| EVENT-111 | Events backpressure + projection confidence | pending |
| HTTP-112 | Community HTTP/2 lifecycle hardening | pending |

## Test plan

- [x] Full reactor \`mvn verify -Pcoverage -DskipITs\` locally green
- [x] Persistence + Flow + Hikari tests green locally
- [x] PMD/Checkstyle 0 violations
- [ ] CI Build & TCK Verification green
- [ ] Persistence RLS/Interceptor Gate green
- [ ] Kafka Integration Gate green (chains after persistence per PR #142)
- [ ] Transport Stress Gate green (chains after kafka per PR #142)
- [ ] SonarCloud Code Analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)