### PR TITLE
v0.8 Sprint 5 (HTTP-112): RFC 7540 §5.1.1 + §5.1.2 stream admission

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
@@ -38,12 +38,18 @@ import java.util.Objects;
 // - AvoidCatchingGenericException: frame-loop catches RuntimeException to surface PROTOCOL_ERROR via GOAWAY.
 // - CloseResource: LoanedBuffer ownership transfers via response.body() pipeline.
 // - CyclomaticComplexity: frame-dispatcher switch + frame loop are intrinsically cohesive.
+// - CouplingBetweenObjects (HTTP-112): the processor coordinates the full HTTP/2 frame
+//   pipeline — types include the session context, four CommunityHttp2* sibling utilities,
+//   five Core http2/hpack types, and the StreamAdmission enum. Coupling=21 (threshold 20)
+//   reflects this orchestration role; QA-018a already extracted everything semantically
+//   splittable, so further splitting would fragment the frame-loop entry point.
 @SuppressWarnings({
         "PMD.GodClass",
         "PMD.TooManyMethods",
         "PMD.AvoidCatchingGenericException",
         "PMD.CloseResource",
-        "PMD.CyclomaticComplexity"
+        "PMD.CyclomaticComplexity",
+        "PMD.CouplingBetweenObjects"
 })
 final class CommunityHttp2SessionProcessor {
 
@@ -256,6 +262,21 @@ final class CommunityHttp2SessionProcessor {
             CommunityHttp2ControlFrames.sendGoAway(
                     allocator, stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
             return false;
+        }
+        // HTTP-112 (v0.8 Sprint 5): RFC 7540 §5.1.1 stream-id monotonicity + §5.1.2
+        // SETTINGS_MAX_CONCURRENT_STREAMS cap. INVALID_ID is a connection-fatal protocol
+        // error (GOAWAY + close loop); OVER_CAP is a per-stream refusal that keeps the
+        // connection open for other streams (RST_STREAM REFUSED_STREAM + skip body).
+        Http2SessionContext.StreamAdmission admission =
+                session.admitClientStreamId(header.streamId());
+        if (admission == Http2SessionContext.StreamAdmission.REJECT_INVALID_ID) {
+            CommunityHttp2ControlFrames.sendGoAway(
+                    allocator, stream, session.lastProcessedStreamId(), Http2ErrorCode.PROTOCOL_ERROR);
+            return false;
+        }
+        if (admission == Http2SessionContext.StreamAdmission.REJECT_OVER_CAP) {
+            CommunityHttp2ControlFrames.sendRstStreamRefused(allocator, stream, header.streamId());
+            return true;
         }
         CommunityHttp2FrameFragments.Fragment fragment =
                 CommunityHttp2FrameFragments.extractHeadersFragment(aggregate, payloadOffset, header);

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/Http2SessionContext.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/Http2SessionContext.java
@@ -68,14 +68,29 @@ final class Http2SessionContext implements AutoCloseable {
     private static final String HEADER_CONTENT_LENGTH = "Content-Length";
     private static final String UPGRADE_TOKEN = "upgrade";
 
+    /**
+     * Default max concurrent client-initiated streams per connection (RFC 7540 §5.1.2).
+     * Matches the recommended floor in §6.5.2 — operators tuning for high-fanout workloads
+     * can raise this via a future SETTINGS extension; for v0.8 it's a fixed conservative
+     * cap that protects the server from stream-table exhaustion (HTTP-112).
+     */
+    private static final int HTTP2_DEFAULT_MAX_CONCURRENT_STREAMS = 100;
+
     private final HpackDynamicTable encodeTable;
     private final HpackDecoder decoder;
     private final HpackEncoder encoder;
     private final Http2FrameCodec codec;
     private final Http2HeaderBlockAssembler assembler;
     private final Map<Integer, Http2RequestStreamState> requestStreams;
+    private final int maxConcurrentStreams;
     private boolean pendingEndStream;
     private int lastProcessedStreamId;
+    /**
+     * Highest peer-initiated stream-id observed so far on this connection. Used to enforce
+     * RFC 7540 §5.1.1 (client-initiated stream IDs MUST be odd and strictly increasing).
+     * Zero means "no stream opened yet"; the first acceptable client stream is id 1.
+     */
+    private int lastClientStreamId;
 
     private Http2SessionContext(HpackDynamicTable encodeTable,
                                 HpackDecoder decoder,
@@ -88,8 +103,10 @@ final class Http2SessionContext implements AutoCloseable {
         this.codec = codec;
         this.assembler = assembler;
         this.requestStreams = new HashMap<>();
+        this.maxConcurrentStreams = HTTP2_DEFAULT_MAX_CONCURRENT_STREAMS;
         this.pendingEndStream = false;
         this.lastProcessedStreamId = 0;
+        this.lastClientStreamId = 0;
     }
 
     /* default */ static Http2SessionContext create(MemoryAllocator allocator) {
@@ -150,6 +167,55 @@ final class Http2SessionContext implements AutoCloseable {
 
     /* default */ boolean pendingEndStream() {
         return pendingEndStream;
+    }
+
+    /**
+     * Admission decision for a newly-arriving peer-initiated HEADERS frame's stream-id
+     * (HTTP-112, v0.8 Sprint 5). Captures the three cases RFC 7540 distinguishes between
+     * an acceptable new stream and the two refuse-reasons:
+     *
+     * <ul>
+     *   <li>{@link #ACCEPT} — odd id, strictly greater than {@code lastClientStreamId},
+     *       and {@code requestStreams.size() < maxConcurrentStreams}. The session
+     *       advances {@code lastClientStreamId}; caller proceeds with HEADERS decode.</li>
+     *   <li>{@link #REJECT_INVALID_ID} — RFC 7540 §5.1.1 violation: even id (server-side
+     *       reserved) OR id ≤ {@code lastClientStreamId}. Caller MUST send GOAWAY
+     *       PROTOCOL_ERROR and close the connection.</li>
+     *   <li>{@link #REJECT_OVER_CAP} — RFC 7540 §5.1.2 cap exceeded. Caller MUST send
+     *       RST_STREAM REFUSED_STREAM for this stream-id and skip the HEADERS body. The
+     *       connection stays open; other streams continue normally.</li>
+     * </ul>
+     */
+    /* default */ enum StreamAdmission {
+        ACCEPT,
+        REJECT_INVALID_ID,
+        REJECT_OVER_CAP
+    }
+
+    /**
+     * Validates {@code streamId} against RFC 7540 §5.1.1 (peer-initiated IDs MUST be odd
+     * and strictly increasing) and §5.1.2 ({@code SETTINGS_MAX_CONCURRENT_STREAMS} cap).
+     * On {@link StreamAdmission#ACCEPT} the session advances its
+     * {@code lastClientStreamId} watermark; the caller is responsible for any subsequent
+     * error-frame emission on the two reject paths.
+     */
+    /* default */ StreamAdmission admitClientStreamId(int streamId) {
+        if ((streamId & 1) == 0 || streamId <= lastClientStreamId) {
+            return StreamAdmission.REJECT_INVALID_ID;
+        }
+        if (requestStreams.size() >= maxConcurrentStreams) {
+            return StreamAdmission.REJECT_OVER_CAP;
+        }
+        lastClientStreamId = streamId;
+        return StreamAdmission.ACCEPT;
+    }
+
+    /* default */ int maxConcurrentStreams() {
+        return maxConcurrentStreams;
+    }
+
+    /* default */ int lastClientStreamId() {
+        return lastClientStreamId;
     }
 
     /* default */ void beginHeaders(Http2FrameParser.FrameHeader header,

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/Http2SessionContextAdmissionTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/Http2SessionContextAdmissionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link Http2SessionContext#admitClientStreamId(int)} — HTTP-112 (v0.8 Sprint 5).
+ *
+ * <p>Covers RFC 7540 §5.1.1 (peer-initiated stream IDs MUST be odd and strictly
+ * increasing) and §5.1.2 ({@code SETTINGS_MAX_CONCURRENT_STREAMS} cap, currently
+ * 100 by default in {@link Http2SessionContext}).
+ */
+@DisplayName("Http2SessionContext — admission decision (HTTP-112)")
+final class Http2SessionContextAdmissionTest {
+
+    private MemoryAllocator allocator;
+    private Http2SessionContext session;
+
+    @BeforeEach
+    void setUp() {
+        allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        session = Http2SessionContext.create(allocator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        session.close();
+        allocator.close();
+    }
+
+    @Nested
+    @DisplayName("RFC 7540 §5.1.1 stream-id monotonicity")
+    class Monotonicity {
+
+        @Test
+        @DisplayName("first odd id (1) is accepted")
+        void firstOddIdAccepted() {
+            assertThat(session.admitClientStreamId(1))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.ACCEPT);
+            assertThat(session.lastClientStreamId()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("strictly increasing odd ids are accepted in sequence")
+        void strictlyIncreasingOddIdsAccepted() {
+            assertThat(session.admitClientStreamId(1))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.ACCEPT);
+            assertThat(session.admitClientStreamId(3))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.ACCEPT);
+            assertThat(session.admitClientStreamId(5))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.ACCEPT);
+            assertThat(session.lastClientStreamId()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("even id is rejected as invalid (server-reserved)")
+        void evenIdRejected() {
+            assertThat(session.admitClientStreamId(2))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.REJECT_INVALID_ID);
+            // High watermark must NOT advance on a rejection
+            assertThat(session.lastClientStreamId()).isZero();
+        }
+
+        @Test
+        @DisplayName("id equal to high-water is rejected as invalid (strict increase)")
+        void idEqualToHighWaterRejected() {
+            session.admitClientStreamId(5);
+            assertThat(session.admitClientStreamId(5))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.REJECT_INVALID_ID);
+            assertThat(session.lastClientStreamId()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("id below high-water is rejected as invalid (no reuse)")
+        void idBelowHighWaterRejected() {
+            session.admitClientStreamId(7);
+            assertThat(session.admitClientStreamId(3))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.REJECT_INVALID_ID);
+            assertThat(session.lastClientStreamId()).isEqualTo(7);
+        }
+    }
+
+    @Nested
+    @DisplayName("RFC 7540 §5.1.2 max-concurrent cap")
+    class MaxConcurrentCap {
+
+        @Test
+        @DisplayName("admission past the cap returns REJECT_OVER_CAP")
+        void admissionPastCapRejected() {
+            // Open and KEEP open `maxConcurrentStreams` streams. Use openRequestStream to
+            // populate the requestStreams map (the cap reads requestStreams.size()).
+            int cap = session.maxConcurrentStreams();
+            for (int idx = 0; idx < cap; idx++) {
+                int streamId = idx * 2 + 1; // 1, 3, 5, ...
+                assertThat(session.admitClientStreamId(streamId))
+                        .as("stream %d below cap should ACCEPT", streamId)
+                        .isEqualTo(Http2SessionContext.StreamAdmission.ACCEPT);
+                session.openRequestStream(
+                        new Http2DecodedRequest(streamId, null, "/", java.util.List.of(), true));
+            }
+            int overCapStreamId = cap * 2 + 1;
+            assertThat(session.admitClientStreamId(overCapStreamId))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.REJECT_OVER_CAP);
+            // OVER_CAP must NOT advance high-water; another stream with the same id
+            // could legally be re-admitted later if the table drains.
+            assertThat(session.lastClientStreamId()).isEqualTo((cap - 1) * 2 + 1);
+        }
+
+        @Test
+        @DisplayName("INVALID_ID check precedes OVER_CAP check")
+        void invalidIdTakesPrecedenceOverOverCap() {
+            // Fill the table to the cap.
+            int cap = session.maxConcurrentStreams();
+            for (int idx = 0; idx < cap; idx++) {
+                int streamId = idx * 2 + 1;
+                session.admitClientStreamId(streamId);
+                session.openRequestStream(
+                        new Http2DecodedRequest(streamId, null, "/", java.util.List.of(), true));
+            }
+            // Even id at the cap → still rejected as INVALID_ID first (protocol error wins
+            // over cap error so the peer sees the right diagnostic).
+            assertThat(session.admitClientStreamId(2))
+                    .isEqualTo(Http2SessionContext.StreamAdmission.REJECT_INVALID_ID);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Sprint 5 HTTP/2 lifecycle hardening. Enforces two RFC 7540 invariants the Community h2c session previously did not validate:

- **§5.1.1 stream-id monotonicity** — peer-initiated stream IDs MUST be odd and strictly greater than the previous client-initiated ID on the same connection.
- **§5.1.2 \`SETTINGS_MAX_CONCURRENT_STREAMS\` cap** — server refuses new streams when the request-stream table is full.

| Invariant | Violation case | Response | Connection |
|:--|:--|:--|:--|
| §5.1.1 (odd + monotonic) | Even ID (server-reserved), or ID ≤ \`lastClientStreamId\` | GOAWAY PROTOCOL_ERROR | Closed (fatal) |
| §5.1.2 (max-concurrent) | \`requestStreams.size() ≥ maxConcurrentStreams\` | RST_STREAM REFUSED_STREAM | Kept (per-stream refusal) |

## Implementation

**\`Http2SessionContext\`:**
- New constants: \`HTTP2_DEFAULT_MAX_CONCURRENT_STREAMS = 100\` (RFC 7540 §6.5.2 recommended floor).
- New fields: \`lastClientStreamId\` watermark + \`maxConcurrentStreams\` cap.
- New enum: \`StreamAdmission\` (\`ACCEPT\` / \`REJECT_INVALID_ID\` / \`REJECT_OVER_CAP\`).
- New API: \`admitClientStreamId(int)\` — advances watermark on ACCEPT; no state change on either reject branch (an OVER_CAP id can be re-admitted later when the table drains).

**\`CommunityHttp2SessionProcessor.handleHttp2HeadersFrame\`:**
- \`INVALID_ID\` → \`CommunityHttp2ControlFrames.sendGoAway(PROTOCOL_ERROR)\`; \`return false\` to stop the frame loop.
- \`OVER_CAP\` → \`CommunityHttp2ControlFrames.sendRstStreamRefused\`; \`return true\` to keep the connection alive for other streams.

## Test coverage — \`Http2SessionContextAdmissionTest\` (new, 7 tests)

- §5.1.1: first odd id accepted, strictly increasing odd ids accepted, even id rejected, equal-to-watermark rejected, below-watermark rejected.
- §5.1.2: admission past cap rejected; INVALID_ID takes precedence over OVER_CAP (protocol error wins so peer sees the right diagnostic).
- Pure-function tests, no I/O — 7/7 green in <0.1s.

## Suppression

- \`PMD.CouplingBetweenObjects\` added to processor class-level: type count went from 20 → 21 with \`StreamAdmission\`. QA-018a already extracted everything semantically splittable; further split would fragment the frame-loop entry point.

## Public surface

**UNCHANGED.** \`handleHttp2HeadersFrame\` signature preserved; processor pkg-private constructor + entry methods (\`handlePriorKnowledge\`, \`handleUpgrade\`) unchanged.

## Verification

- ✅ Full reactor \`mvn verify -Pcoverage -DskipITs\` SUCCESS (1:52)
- ✅ HTTP test suite 75/76 green (1 pre-existing skip — no new failures)
- ✅ \`Http2SessionContextAdmissionTest\` 7/7 green
- ✅ PMD + Checkstyle 0 violations
- ✅ JaCoCo BUNDLE LINE coverage check met

## Sprint 5 progress after this PR

| ID | Subject | Status |
|:--|:--|:--|
| JFR-091 | publish + save error JFR events | ✅ #141 |
| DOC-090 | cachePrepStmts + Javadoc + flow.md | ✅ #143 |
| **HTTP-112** | **stream admission (first slice)** | **this PR ✅** |
| HTTP-112 follow-ups | GOAWAY clean-shutdown, idle-stream cleanup, more RFC compliance | separate PRs |
| EVENT-111 | Events backpressure + projection confidence | pending |

## Test plan

- [x] Full reactor \`mvn verify -Pcoverage -DskipITs\` locally green
- [x] HTTP suite + new admission unit test green locally
- [x] PMD/Checkstyle 0 violations
- [ ] CI Build & TCK Verification green
- [ ] Persistence RLS/Interceptor Gate green (chains first per #142)
- [ ] Kafka Integration Gate green (chains after persistence per #142)
- [ ] Transport Stress Gate green (chains after kafka per #142)
- [ ] SonarCloud Code Analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)