### PR TITLE
v0.8 Sprint 5 (EVENT-111): CommunityEventQueueOverflowEvent JFR observability

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/CommunityEventEngine.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/CommunityEventEngine.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.events;
 
+import eu.exeris.kernel.community.events.jfr.CommunityEventQueueOverflowEvent;
 import eu.exeris.kernel.core.events.InMemoryEventBus;
 import eu.exeris.kernel.core.events.outbox.OutboxBrokerPort;
 import eu.exeris.kernel.core.events.outbox.OutboxEventStore;
@@ -50,7 +51,8 @@ final class CommunityEventEngine implements EventEngine {
         this.loop = new CommunityEventLoop(registry, queue, config.batchSize());
 
         InMemoryEventBus delegateBus = new InMemoryEventBus(registry);
-        this.bus = new PersistentQueueingBus(delegateBus, queue, registry, publishedTotal, failFastOnFull);
+        this.bus = new PersistentQueueingBus(config.engineName(), delegateBus, queue,
+                registry, publishedTotal, failFastOnFull);
         this.outboxOrchestrator = buildOutboxOrchestrator(config, delegateBus, registry);
     }
 
@@ -138,6 +140,7 @@ final class CommunityEventEngine implements EventEngine {
 
     private static final class PersistentQueueingBus implements EventBus {
 
+        private final String engineName;
         private final EventBus delegate;
         private final EventQueue queue;
         private final CommunityEventRegistry registry;
@@ -145,11 +148,13 @@ final class CommunityEventEngine implements EventEngine {
         private final boolean failFastOnFull;
 
         private PersistentQueueingBus(
+                String engineName,
                 EventBus delegate,
                 EventQueue queue,
                 CommunityEventRegistry registry,
                 AtomicLong publishedTotal,
                 boolean failFastOnFull) {
+            this.engineName = Objects.requireNonNull(engineName, "engineName");
             this.delegate = Objects.requireNonNull(delegate, "delegate");
             this.queue = Objects.requireNonNull(queue, "queue");
             this.registry = Objects.requireNonNull(registry, "registry");
@@ -207,10 +212,17 @@ final class CommunityEventEngine implements EventEngine {
          * Fail-fast mode uses the typed factory carrying the documented Glass-Box rawArgs
          * {@code [eventType, queueDepth, queueCapacity]}; legacy mode falls back to the
          * message-only constructor (interrupt path).
+         *
+         * <p>EVENT-111 (v0.8 Sprint 5): also emit
+         * {@link CommunityEventQueueOverflowEvent} on the fail-fast branch so operator
+         * dashboards can attribute overflow rates to specific engine + event-type pairs
+         * — the publishing-caller exception is per-call and leaves no post-mortem trail.
          */
         private EventBusException failedPushException(EventDescriptor descriptor) {
             String eventType = registry.nameOfOrdinal(descriptor.eventTypeOrdinal());
             if (failFastOnFull) {
+                CommunityEventQueueOverflowEvent.emit(
+                        engineName, eventType, queue.size(), queue.capacity());
                 return EventBusException.publishOverflow(eventType, queue.size(), queue.capacity());
             }
             return new EventBusException("Interrupted while enqueueing persistent event '" + eventType + '\'');

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/jfr/CommunityEventQueueOverflowEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/jfr/CommunityEventQueueOverflowEvent.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.events.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Emitted when {@code CommunityEventQueue} refuses a push because the bus is in
+ * fail-fast mode and the queue is at capacity (EVENT-111, v0.8 Sprint 5).
+ *
+ * <p>Operators rely on this event to attribute publish overflow rates to
+ * specific event types and to track backpressure trends over time — the
+ * publishing-caller {@code EventBusException} surface is per-call and leaves
+ * no post-mortem trail.
+ *
+ * <p>Mirrors the established overflow-telemetry pattern:
+ * {@code AsyncTelemetryDropEvent} (telemetry sink),
+ * {@code TransportIngressQueueDepthEvent} (transport ingress),
+ * {@code OutboxDlqEvent} (DLQ transitions). All four can be aggregated into
+ * a single operator dashboard for system-wide backpressure visibility.
+ */
+@Name("eu.exeris.kernel.events.CommunityEventQueueOverflow")
+@Label("Community Event Queue Overflow")
+@Category({"Exeris Kernel", "Events"})
+@Description("Emitted when CommunityEventQueue.push refuses a fail-fast publish because the "
+        + "queue is at capacity. Carries engine name, event type, observed depth, and capacity "
+        + "so operators can attribute overflow rates to specific publishers + event types and "
+        + "track backpressure trends over time.")
+@StackTrace(false)
+public final class CommunityEventQueueOverflowEvent extends Event {
+
+    @Label("Engine Name")
+    @Description("Human-readable engine name from EventEngineConfig.engineName()")
+    /* default */ String engineName;
+
+    @Label("Event Type")
+    @Description("Event type name from the registry (registry.nameOfOrdinal(...)); "
+            + "blank when the ordinal is unregistered")
+    /* default */ String eventType;
+
+    @Label("Queue Depth")
+    @Description("Queue size observed at the moment of overflow (equal to capacity by definition)")
+    /* default */ int queueDepth;
+
+    @Label("Queue Capacity")
+    @Description("Configured queue capacity from EventEngineConfig.queueCapacity()")
+    /* default */ int queueCapacity;
+
+    public static void emit(String engineName,
+                            String eventType,
+                            int queueDepth,
+                            int queueCapacity) {
+        CommunityEventQueueOverflowEvent event = new CommunityEventQueueOverflowEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.begin();
+        event.engineName = engineName;
+        event.eventType = eventType == null ? "" : eventType;
+        event.queueDepth = queueDepth;
+        event.queueCapacity = queueCapacity;
+        event.commit();
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Sprint 5 \`Events backpressure + projection confidence\`. Fills the publish-overflow observability gap on the Community in-memory event bus: previously the only signal was the per-call \`EventBusException\` (\`EX-EVENT-6002 publishOverflow\`); operators tracking system-wide backpressure rates had no post-mortem trail.

## New JFR event

| Element | Value |
|:--|:--|
| Name | \`eu.exeris.kernel.events.CommunityEventQueueOverflow\` |
| Category | Exeris Kernel / Events |
| StackTrace | false |
| Visibility | public (application code can install \`RecordingStream\` consumers) |
| Fields | \`engineName\`, \`eventType\`, \`queueDepth\`, \`queueCapacity\` |

## Wire-up

\`CommunityEventEngine.PersistentQueueingBus\`:
- Constructor takes \`engineName\` (forwarded from \`config.engineName()\`).
- \`failedPushException\` emits \`CommunityEventQueueOverflowEvent\` **before** building the \`EX-EVENT-6002 publishOverflow\` exception on the fail-fast branch. Legacy blocking-mode (interrupt) branch is unchanged — no overflow JFR there because the queue isn't refusing the push.

## Pattern alignment

Mirrors the established overflow / failure telemetry pattern across the kernel:

| Event | Where | Trigger |
|:--|:--|:--|
| \`AsyncTelemetryDropEvent\` | telemetry sink | Async sink drops on ring overflow |
| \`TransportIngressQueueDepthEvent\` | transport ingress | Stream-ingress queue threshold crossed |
| \`OutboxDlqEvent\` | outbox | Event moved to DLQ after max retries |
| \`KafkaPublishFailedEvent\` | kafka publish (#141) | Kafka driver exception wrapped |
| \`FlowSnapshotSaveFailedEvent\` | saga save (#141) | Non-OCC SQL fail rollback |
| **\`CommunityEventQueueOverflowEvent\`** | **community event bus (this PR)** | **Fail-fast push refused** |

All six aggregate into a single operator dashboard for system-wide backpressure + failure visibility.

## Public surface

**UNCHANGED.** \`CommunityEventEngine\` public constructor signature, \`EventEngine\` SPI methods, \`EX-EVENT-6002 publishOverflow\` \`rawArgs\` layout — all preserved.

## Verification

- ✅ Full reactor \`mvn verify -Pcoverage -DskipITs\` SUCCESS (1:49)
- ✅ CommunityEvent suite 33/34 green (1 pre-existing skip — no new failures), including \`CommunityEventBackpressureTckTest\`
- ✅ PMD + Checkstyle 0 violations
- ✅ JaCoCo BUNDLE LINE coverage check met

## Sprint 5 progress after this PR

| ID | Subject | Status |
|:--|:--|:--|
| JFR-091 | publish + save error JFR events | ✅ #141 |
| DOC-090 | cachePrepStmts + Javadoc + flow.md | ✅ #143 |
| HTTP-112 slice 1 | stream admission | ✅ #144 |
| **EVENT-111 slice 1** | **queue-overflow JFR** | **this PR ✅** |
| HTTP-112 follow-ups | GOAWAY clean-shutdown, idle-stream cleanup | separate PRs |
| EVENT-111 follow-ups | retry/DLQ metrics, projection consistency tests | separate PRs |

Sprint 5 main scope (one slice per item) effectively closed. Follow-ups continue as standalone PRs.

## Test plan

- [x] Full reactor \`mvn verify -Pcoverage -DskipITs\` locally green
- [x] CommunityEvent suite green locally (incl. CommunityEventBackpressureTckTest)
- [x] PMD/Checkstyle 0 violations
- [x] CI Build & TCK Verification green
- [x] Persistence RLS/Interceptor Gate green
- [x] Kafka Integration Gate green (chains after persistence per #142)
- [x] Transport Stress Gate green (chains after kafka per #142)
- [x] SonarCloud Code Analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)