### PR TITLE
perf(transport): zero-allocation ingress read — elide per-read segment slice (Sprint 6 PERF-072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 
 ## [Unreleased] — 0.8.0-SNAPSHOT
 
+### Performance — Zero-allocation ingress read (Sprint 6 PERF-072)
+
+- `NativeTcpStreamPlainSocketIo` seam and NIO read paths no longer allocate a redundant `NativeMemorySegmentImpl` wrapper per read: `target.asSlice(0, maxBytes)` is elided to `target` when `maxBytes == target.byteSize()` (always true for the carrier's full-slab ingress read). Egress sub-range slices are unchanged. Community-internal; no SPI/Core contract change. See `docs/ROADMAP.md` → "Transport: Zero-Allocation Ingress Read".
+
 ### Fixed — Flow snapshot store wiring gap (Sprint 0b)
 
 - `CommunityFlowSubsystem.initialize()` now selects `JdbcFlowSnapshotStore` when a Community `PersistenceEngine` is bootstrapped alongside, instead of always falling back to the in-memory `CommunityFlowSnapshotStore`. Parked saga snapshots now survive a kernel restart whenever `flow.persistenceEnabled=true` and a JDBC-backed engine is present (ADR-022 §1). The in-memory store remains the fallback when no engine is available.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -809,6 +809,18 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 
 ---
 
+### Transport: Zero-Allocation Ingress Read — Elide Per-Read Segment Slice (Sprint 6 PERF-072)
+
+**Gap:** The plain-socket ingress read path allocates a fresh heap `NativeMemorySegmentImpl` wrapper on **every** read. `NativeTcpCarrier.readIngress` calls `NativeTcpStream.readPlainIngress(slab.segment(), (int) slab.capacity())`, where `slab.capacity() == slab.segment().byteSize()` (`AbstractLoanedBuffer.capacity()`). Both seam and NIO read paths in `NativeTcpStreamPlainSocketIo` then evaluate `target.asSlice(0, maxBytes)` — but since `maxBytes == target.byteSize()`, the slice is base- and length-identical to `target`: a pure wrapper allocation with no semantic effect. A constrained `entity-read-by-id` JFR profile (`-XX:+UseSerialGC -XX:ActiveProcessorCount=1 -Xmx192m`, ~3.1k rps) attributed ~2,400 `ObjectAllocationSample` hits to `asSliceNoCheck`/`dup` under `trySocketSeamRead → readPlainIngress → readIngress`. STW pause is negligible (37 ms over 46 s) but the run was CPU-throttled 465/547 cgroup periods, so allocation→GC CPU (470 ms) competes directly with request servicing — reducing it tightens the throttled tail rather than the pause budget.
+
+**Owner:** Transport subsystem (`exeris-kernel-community`).
+
+**Resolution:** Guard the slice so it materialises only for a genuine sub-range: `MemorySegment dst = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes)`, passing `dst` to the `recv` downcall (length is already a separate argument, so the full segment is safe) and to the NIO-fallback `asByteBuffer()`. The guard is also semantically required on the NIO path — a `ByteBuffer` over the full segment would have `capacity == byteSize`, letting `channel.read()` overrun `maxBytes`; eliding only on equality keeps behaviour identical. Egress `send`/write paths pass a real `(offset, length)` sub-range and are intentionally left unchanged.
+
+**Merge Gate:** Community-internal only — no SPI/Core contract change, ownership and loaned-buffer lifecycle unchanged. Existing transport read/write coverage stays green (`NativeTcpClientServerE2eIntegrationTest`, stream wakeup tests). Validation: a re-run of the constrained `entity-read-by-id` JFR shows `NativeMemorySegmentImpl`/`asSliceNoCheck`/`dup` samples under the ingress read path drop to ~0; a JMH `-prof gc` harness over `readIngress` asserts `gc.alloc.rate.norm ≈ 0 B/op` on the seam-read path.
+
+---
+
 ### Security: `@RequiresRole` Operator Wiring
 
 **Gap:** ADR-014 compile-time RBAC machinery is in place (Sprints 8a / 8b-i / 8b-ii) but the operator-side wiring deferred from Sprint 8b-ii has not landed: the `LazyConstant<RoleCheckRegistry>` bootstrap loader, automatic discovery and wiring of the APT-generated registry into runtime, and `ImmutablePrincipal.roleMask()` integration with the CitadelGuard fast path.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPlainSocketIo.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPlainSocketIo.java
@@ -92,15 +92,9 @@ final class NativeTcpStreamPlainSocketIo {
                                       int maxBytes,
                                       long streamId) throws IOException {
         try {
-            // Zero-alloc ingress (PERF-072): the carrier always reads the full loaned slab
-            // (maxBytes == segment byteSize), so asSlice(0, maxBytes) would allocate a fresh
-            // NativeMemorySegmentImpl wrapper identical to target on every read. Pass target
-            // directly in that case — recv() takes the length as a separate argument, so the
-            // wrapper is a pure no-op. Slice only for a genuine sub-range.
-            MemorySegment dst = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
             long result = (long) socketHandles.recv().invokeExact(
                     plainSocketHandle,
-                    dst,
+                    readDestination(target, maxBytes),
                     (long) maxBytes,
                     POSIX_SOCKET_IO_FLAGS);
             if (result > 0) {
@@ -165,12 +159,10 @@ final class NativeTcpStreamPlainSocketIo {
     /* default */ static int nioFallbackRead(SocketChannel channel,
                                              MemorySegment target,
                                              int maxBytes) throws IOException {
-        // Zero-alloc ingress (PERF-072): elide the redundant asSlice wrapper when the caller
-        // reads the full segment. The guard is also semantically required here — a ByteBuffer
-        // over the full segment would have capacity == byteSize, letting channel.read() overrun
-        // maxBytes; only elide when they are equal (slice and full segment are then identical).
-        MemorySegment readInto = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
-        ByteBuffer targetBuffer = readInto.asByteBuffer();
+        // Zero-alloc ingress (PERF-072): the guard in readDestination is also semantically
+        // required here — a ByteBuffer over the full segment would have capacity == byteSize,
+        // letting channel.read() overrun maxBytes; eliding only on equality keeps it identical.
+        ByteBuffer targetBuffer = readDestination(target, maxBytes).asByteBuffer();
         targetBuffer.clear();
         return channel.read(targetBuffer);
     }
@@ -185,5 +177,18 @@ final class NativeTcpStreamPlainSocketIo {
         MemorySegment slice = source.asSlice(offset, length);
         ByteBuffer sourceBuffer = slice.asByteBuffer();
         return channel.write(sourceBuffer);
+    }
+
+    /**
+     * Selects the destination segment for a read of up to {@code maxBytes}.
+     *
+     * <p>Zero-alloc ingress (PERF-072): the carrier always reads the full loaned slab
+     * ({@code maxBytes == target.byteSize()}), where {@code target.asSlice(0, maxBytes)}
+     * would be base- and length-identical to {@code target} — a pure {@code NativeMemorySegmentImpl}
+     * wrapper allocated on every read. Return {@code target} directly in that case; the syscall
+     * length is passed separately, so the slice is a no-op. Slice only for a genuine sub-range.
+     */
+    private static MemorySegment readDestination(MemorySegment target, int maxBytes) {
+        return maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPlainSocketIo.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPlainSocketIo.java
@@ -92,9 +92,15 @@ final class NativeTcpStreamPlainSocketIo {
                                       int maxBytes,
                                       long streamId) throws IOException {
         try {
+            // Zero-alloc ingress (PERF-072): the carrier always reads the full loaned slab
+            // (maxBytes == segment byteSize), so asSlice(0, maxBytes) would allocate a fresh
+            // NativeMemorySegmentImpl wrapper identical to target on every read. Pass target
+            // directly in that case — recv() takes the length as a separate argument, so the
+            // wrapper is a pure no-op. Slice only for a genuine sub-range.
+            MemorySegment dst = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
             long result = (long) socketHandles.recv().invokeExact(
                     plainSocketHandle,
-                    target.asSlice(0, maxBytes),
+                    dst,
                     (long) maxBytes,
                     POSIX_SOCKET_IO_FLAGS);
             if (result > 0) {
@@ -159,7 +165,12 @@ final class NativeTcpStreamPlainSocketIo {
     /* default */ static int nioFallbackRead(SocketChannel channel,
                                              MemorySegment target,
                                              int maxBytes) throws IOException {
-        ByteBuffer targetBuffer = target.asSlice(0, maxBytes).asByteBuffer();
+        // Zero-alloc ingress (PERF-072): elide the redundant asSlice wrapper when the caller
+        // reads the full segment. The guard is also semantically required here — a ByteBuffer
+        // over the full segment would have capacity == byteSize, letting channel.read() overrun
+        // maxBytes; only elide when they are equal (slice and full segment are then identical).
+        MemorySegment readInto = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
+        ByteBuffer targetBuffer = readInto.asByteBuffer();
         targetBuffer.clear();
         return channel.read(targetBuffer);
     }


### PR DESCRIPTION
## What

Elides a redundant per-read `NativeMemorySegmentImpl` allocation on the plain-socket ingress read path (`NativeTcpStreamPlainSocketIo`).

## Why — benchmark evidence

A constrained `entity-read-by-id` JFR profile (`-XX:+UseSerialGC -XX:ActiveProcessorCount=1 -Xmx192m`, ~3.1k rps, loopback h1) attributed **~2,400 `ObjectAllocationSample` hits** to `AbstractMemorySegmentImpl.asSliceNoCheck` / `NativeMemorySegmentImpl.dup` under the stack `trySocketSeamRead → readPlainIngress → NativeTcpCarrier.readIngress`.

Root cause: `readIngress` reads the **full** loaned slab — `readPlainIngress(slab.segment(), (int) slab.capacity())` where `slab.capacity() == slab.segment().byteSize()` (`AbstractLoanedBuffer.capacity()`). So `target.asSlice(0, maxBytes)` produces a segment base- and length-**identical** to `target`: a pure heap wrapper with no semantic effect, allocated on every read.

GC STW pause was negligible (37 ms over 46 s), but the run was **CPU-throttled 465/547 cgroup periods** (5.57 s throttled) on 1 vCPU, and GC consumed 470 ms of CPU. On a throttled budget, allocation→GC CPU competes directly with request servicing — so removing it tightens the throttled tail latency, not the pause budget.

## Change

```java
MemorySegment dst = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes);
```

- Applied to the `recv` seam downcall (length is a separate arg, so passing the full segment is safe) and the NIO-fallback `asByteBuffer()`.
- The guard is **semantically required** on the NIO path: a `ByteBuffer` over the full segment would have `capacity == byteSize`, letting `channel.read()` overrun `maxBytes`. Eliding only on equality keeps behaviour identical.
- Egress `send`/write paths pass a genuine `(offset, length)` sub-range and are **intentionally unchanged**.

## Scope / boundaries

Community-internal. No SPI/Core contract change. Loaned-buffer ownership and lifecycle unchanged. The Wall intact.

## Verification

- `exeris-kernel-community` compiles (JDK 26).
- Transport read/write coverage green: `NativeTcpClientServerE2eIntegrationTest`, `NativeTcpStreamIngressArrivalWakeupTest`, `NativeTcpStreamCloseWakeupTest` (9 tests, 0 failures, 1 skipped).
- Follow-up validation (not in this PR): re-run the constrained `entity-read-by-id` JFR and confirm the ingress-read `NativeMemorySegmentImpl`/`asSliceNoCheck`/`dup` samples drop to ~0; JMH `-prof gc` over `readIngress` asserting `gc.alloc.rate.norm ≈ 0 B/op`.

## Roadmap

Tracked as **Sprint 6 PERF-072** — see `docs/ROADMAP.md` → "Transport: Zero-Allocation Ingress Read — Elide Per-Read Segment Slice" + CHANGELOG `[Unreleased]` Performance entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)