### PR TITLE
v0.8 Sprint 4 (SEC-080): @RequiresRole runtime wiring — registry loader + roleMask population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 
 ## [Unreleased] — 0.8.0-SNAPSHOT
 
+### Security — @RequiresRole runtime wiring (Sprint 4 SEC-080)
+
+- `eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader` (new, Core) resolves the build-time generated `eu.exeris.kernel.security.generated.RoleCheckRegistry` reflectively (by FQN string — no compile edge on `exeris-kernel-build-config`, preserving the processor's reactor-cycle avoidance) and binds its five static accessors (`requiredAny`/`requiredAll`/`matchIsAll`/`methodCount`/`roleNameToBit`) to `MethodHandle`s once at bootstrap, exposed as a `RoleRegistry`. The per-request accessors use `invokeExact` — no `Method.invoke`, allocation-free. ADR-014 §3.
+- When no `@RequiresRole` is compiled anywhere (the common case) the loader returns a **fail-closed empty registry** singleton (`methodCount() == 0`, all required masks `0L`, `matchIsAll == false`, `roleNameToBit == -1`) — never allow-all. A `ClassNotFoundException` or signature mismatch both fall through to the same fail-closed empty registry.
+- New one-shot JFR event `eu.exeris.kernel.security.RoleRegistryLoaded` (`@StackTrace(false)`, single-phase commit) records whether the generated class was found and its `methodCount`, letting operators distinguish "no annotations" from "load failed".
+- `SecurityInterceptor` gains a `(SecurityProvider, RoleRegistry)` constructor (the existing single-arg constructor now delegates with the fail-closed empty registry). On `intercept(...)` / `interceptPreAuthenticated(...)`, when `methodCount() > 0` it resolves the principal's role names through `registry.roleNameToMask(...)` and binds a new Core-internal `MaskedPrincipal` (delegating `PrincipalContext` wrapper) carrying the precomputed `roleMask()`; an empty registry binds the original principal unchanged (no allocation, mask stays `0L`). `runAsSystem(...)` is left untouched so a pre-masked system principal is never wrapped or downgraded.
+- `CommunityHttpRequestProcessor` wires the bootstrap-loaded registry into the constructed `SecurityInterceptor`.
+- No SPI change: `RoleRegistry`, `PrincipalContext.roleMask()`, and `RoleCheckEnforcer` are unchanged — Sprint 4 only makes the enforcer's inputs live. New TCK coverage: `AbstractGeneratedRoleRegistryLoaderTck` + `AbstractRoleMaskPopulationTck` with Community bindings; existing `AbstractRequiresRoleTck` stays green.
+- **Descoped (Sprint 4 finding):** the kernel HTTP dispatcher remains scope/path-based; kernel-edge URL→`methodId` enforcement for path-routed handlers is a codegen concern owned by `exeris-tooling` (cross-repo), not `CommunityHttpRequestDispatcher`. See `docs/subsystems/security.md`.
+
 ### Performance — Zero-allocation ingress read (Sprint 6 PERF-072)
 
 - `NativeTcpStreamPlainSocketIo` seam and NIO read paths no longer allocate a redundant `NativeMemorySegmentImpl` wrapper per read: `target.asSlice(0, maxBytes)` is elided to `target` when `maxBytes == target.byteSize()` (always true for the carrier's full-slab ingress read). Egress sub-range slices are unchanged. Community-internal; no SPI/Core contract change. See `docs/ROADMAP.md` → "Transport: Zero-Allocation Ingress Read".

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -198,10 +198,33 @@ token lifetime. The following contract governs token lifecycle in the Kernel:
 > - SPI runtime carriers (`RoleRegistry` interface, `PrincipalContext.roleMask()` default) and
 >   the Core `RoleCheckEnforcer` decision helper plus `AbstractRequiresRoleTck` —
 >   Sprint 8b-ii.
-> - Operator-side wiring (load the generated registry through a `LazyConstant`, populate
->   `principal.roleMask()` at authentication time via `registry.roleNameToBit(...)`, and call
->   `RoleCheckEnforcer.check(methodId, principal, registry)` from the transport admission path)
->   remains explicit until the auto-bind landing.
+> - Runtime wiring (Sprint 4 SEC-080): the Core `GeneratedRoleRegistryLoader` resolves the
+>   generated `RoleCheckRegistry` reflectively (by FQN string, no compile edge — preserves the
+>   processor's reactor-cycle avoidance) and binds its five static accessors to `MethodHandle`s
+>   once at bootstrap, exposed as a `RoleRegistry`. When no `@RequiresRole` is compiled anywhere
+>   the loader returns a **fail-closed empty registry** (`methodCount() == 0`, all masks `0L`),
+>   never allow-all. A one-shot `eu.exeris.kernel.security.RoleRegistryLoaded` JFR event records
+>   whether the generated class was found and its `methodCount`, so operators distinguish
+>   "no annotations" from "load failed". `SecurityInterceptor` consumes the loaded registry: when
+>   `methodCount() > 0` it resolves the authenticated principal's role names through
+>   `registry.roleNameToMask(...)` and binds a Core-internal `MaskedPrincipal` carrying the
+>   precomputed `roleMask()`; when the registry is empty the original principal is bound unchanged
+>   (no allocation, mask stays `0L`). `RoleCheckEnforcer` is unchanged — Sprint 4 only made its
+>   inputs live (loadable registry + masked principal in scope).
+>
+> **Loader mechanism note:** the brief originally anticipated a `LazyConstant`-backed load. The
+> loader is eager-at-bootstrap instead (constructed once on the `CommunityHttpRequestProcessor`
+> construction path, a platform thread) — there is no per-request lazy access to amortise, and
+> eager binding keeps the JFR bootstrap signal deterministic.
+>
+> **Kernel-edge methodId enforcement is descoped from the kernel (Sprint 4 finding).** The
+> Community HTTP dispatcher remains scope/path-based; it does **not** map a request URL to a
+> compile-time `methodId`. Calling `RoleCheckEnforcer.check(methodId, ...)` at the edge for a
+> path-routed handler requires a generated URL→methodId routing table, which is a **codegen
+> concern owned by `exeris-tooling` (cross-repo)**, not the kernel dispatcher. Sprint 4 delivers
+> the loader, the `roleMask` population seam, the live `RoleCheckEnforcer` inputs, and TCK
+> coverage (`AbstractGeneratedRoleRegistryLoaderTck`, `AbstractRoleMaskPopulationTck`); it
+> deliberately does not add URL→methodId routing to `CommunityHttpRequestDispatcher`.
 >
 > Dynamic role decisions continue to use `CitadelGuard.requireRole(...)` — both paths emit
 > `EX-SEC-2003` so operators see uniform telemetry.
@@ -240,7 +263,10 @@ contract end-to-end.
    between the principal's role bitmask (extracted from the JWT at parse time) and the required role bitmask
    from the registry. This is O(1) and allocation-free.
 3. **No `Class.getAnnotation()` on hot path:** Zero reflection calls occur after JVM startup. The APT-generated
-   registry is loaded once via `LazyConstant.of(...)` at first access.
+   registry is resolved once at bootstrap by `eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader`
+   (reflective `Class.forName` by FQN, then `MethodHandle` binding of the five static accessors). The
+   per-request accessors invoke the bound handles via `invokeExact` — no `Method.invoke`, allocation-free.
+   When the class is absent the loader returns a fail-closed empty registry (Sprint 4 SEC-080).
 
 ```text
 Hot-path check (RoleMatch.ANY): (principal.roleMask() & registry.requiredAny(methodId)) != 0L

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -10,6 +10,7 @@ package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.community.persistence.PersistenceSessionBox;
 import eu.exeris.kernel.core.http.http1.Http1Codec;
+import eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader;
 import eu.exeris.kernel.core.security.SecurityInterceptor;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpConfig;
@@ -76,7 +77,9 @@ public final class CommunityHttpRequestProcessor {
         this.config = Objects.requireNonNull(config, "config must not be null");
 
         SecurityInterceptor securityInterceptor = KernelProviders.SECURITY_PROVIDER.isBound()
-                ? new SecurityInterceptor(KernelProviders.SECURITY_PROVIDER.get())
+                ? new SecurityInterceptor(
+                        KernelProviders.SECURITY_PROVIDER.get(),
+                        GeneratedRoleRegistryLoader.load())
                 : null;
         PersistenceEngine persistenceEngine = KernelProviders.PERSISTENCE_ENGINE.isBound()
                 ? KernelProviders.PERSISTENCE_ENGINE.get()

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityGeneratedRoleRegistryLoaderTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityGeneratedRoleRegistryLoaderTckTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader;
+import eu.exeris.kernel.core.security.RoleCheckEnforcer;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import eu.exeris.kernel.tck.contract.security.AbstractGeneratedRoleRegistryLoaderTck;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Community binding for {@link AbstractGeneratedRoleRegistryLoaderTck}.
+ *
+ * <p>{@link #loadPresent()} drives the real reflective {@code load()}: a hand-written
+ * fixture at {@code eu.exeris.kernel.security.generated.RoleCheckRegistry} (mirroring
+ * the processor output) sits on this module's test classpath, so {@code Class.forName}
+ * resolves it and the loader binds its static accessors via {@code MethodHandle}.
+ * {@link #loadAbsent()} returns the loader's documented absent-class result — the
+ * fail-closed empty singleton.
+ */
+@DisplayName("Community: GeneratedRoleRegistryLoader TCK")
+class CommunityGeneratedRoleRegistryLoaderTckTest extends AbstractGeneratedRoleRegistryLoaderTck {
+
+    @Override
+    protected RoleRegistry loadAbsent() {
+        return GeneratedRoleRegistryLoader.empty();
+    }
+
+    @Override
+    protected RoleRegistry loadPresent() {
+        return GeneratedRoleRegistryLoader.load();
+    }
+
+    @Override
+    protected boolean isAllowed(int methodId, PrincipalContext principal, RoleRegistry registry) {
+        return RoleCheckEnforcer.isAllowed(methodId, principal, registry);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRoleMaskPopulationTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityRoleMaskPopulationTckTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.core.security.SecurityInterceptor;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.security.AuthenticationResult;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import eu.exeris.kernel.spi.security.SecurityProvider;
+import eu.exeris.kernel.spi.security.StorageContext;
+import eu.exeris.kernel.tck.contract.security.AbstractRoleMaskPopulationTck;
+import org.junit.jupiter.api.DisplayName;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Community binding for {@link AbstractRoleMaskPopulationTck}.
+ *
+ * <p>Wires a {@code SecurityInterceptor} over a stub success provider that
+ * authenticates to the supplied principal, with the supplied registry, and runs
+ * {@code intercept(...)} so the abstract's handler can observe the bound
+ * {@code PRINCIPAL_CONTEXT} role mask.
+ */
+@DisplayName("Community: role-mask population TCK")
+class CommunityRoleMaskPopulationTckTest extends AbstractRoleMaskPopulationTck {
+
+    @Override
+    protected boolean runIntercept(RoleRegistry registry,
+                                   PrincipalContext principal,
+                                   Runnable handler) {
+        SecurityInterceptor interceptor =
+                new SecurityInterceptor(new StubSuccessProvider(principal), registry);
+        return interceptor.intercept(new NullLoanedBuffer(), handler);
+    }
+
+    private static final class StubSuccessProvider implements SecurityProvider {
+        private final PrincipalContext principal;
+
+        StubSuccessProvider(PrincipalContext principal) {
+            this.principal = principal;
+        }
+
+        @Override public String providerId() { return "stub-mask"; }
+        @Override public String providerName() { return "StubMask"; }
+        @Override public AuthenticationResult authenticate(LoanedBuffer token) {
+            return new AuthenticationResult(principal, ImmutableStorageContext.GLOBAL);
+        }
+        @Override public StorageContext systemStorageContext() { return ImmutableStorageContext.GLOBAL; }
+    }
+
+    private static final class NullLoanedBuffer implements LoanedBuffer {
+        @Override public MemorySegment segment() { return MemorySegment.NULL; }
+        @Override public long size() { return 0L; }
+        @Override public long capacity() { return 0L; }
+        @Override public void setSize(long newSize) { /* no-op: stub buffer holds no backing storage */ }
+        @Override public boolean isAlive() { return true; }
+        @Override public void close() { /* no-op: stub buffer holds no native resources */ }
+        @Override public void retain() { /* no-op: stub buffer uses trivial ref-counting */ }
+        @Override public int refCount() { return 1; }
+        @Override public void addCloseAction(Runnable action) { /* no-op: stub buffer ignores close hooks */ }
+        @Override public LoanedBuffer slice(long offset, long length) { return this; }
+        @Override public LoanedBuffer view() { return this; }
+        @Override public LoanedBuffer peek(long offset, long length) { return this; }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/security/generated/RoleCheckRegistry.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/security/generated/RoleCheckRegistry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.security.generated;
+
+/**
+ * Test fixture mirroring the exact static-accessor shape that
+ * {@code RequiresRoleProcessor} emits for the generated registry (see
+ * {@code RequiresRoleProcessor.writeAccessors}). Lives in the canonical
+ * generated package so {@code GeneratedRoleRegistryLoader} resolves it by FQN
+ * via {@code Class.forName} on the Community test classpath — exercising the
+ * loader's "present" path without running the annotation processor in this
+ * module.
+ *
+ * <p>One ANY method ({@code M_0}) requires {@code ROLE_ADMIN} (canonical system
+ * bit 1), matching the TCK's deterministic expectations.
+ */
+public final class RoleCheckRegistry {
+
+    /** AdminApi.purge() */
+    public static final int M_0 = 0;
+
+    private static final long[] REQUIRED_ANY = {
+            0x2L
+    };
+
+    private static final long[] REQUIRED_ALL = {
+            0x0L
+    };
+
+    private static final boolean[] MATCH_IS_ALL = {
+            false
+    };
+
+    private static final String[] METHOD_NAMES = {
+            "AdminApi.purge()"
+    };
+
+    private static final java.util.Map<String, Integer> ROLE_BITS;
+    static {
+        java.util.HashMap<String, Integer> bits = new java.util.HashMap<>();
+        bits.put("ROLE_ADMIN", 1);
+        bits.put("ROLE_OPERATOR", 2);
+        bits.put("ROLE_SYSTEM", 0);
+        bits.put("ROLE_USER", 3);
+        ROLE_BITS = java.util.Map.copyOf(bits);
+    }
+
+    public static int methodCount() {
+        return 1;
+    }
+
+    public static long requiredAny(int methodId) {
+        return REQUIRED_ANY[methodId];
+    }
+
+    public static long requiredAll(int methodId) {
+        return REQUIRED_ALL[methodId];
+    }
+
+    public static boolean matchIsAll(int methodId) {
+        return MATCH_IS_ALL[methodId];
+    }
+
+    public static String methodName(int methodId) {
+        return METHOD_NAMES[methodId];
+    }
+
+    public static java.util.Set<String> roleNames() {
+        return ROLE_BITS.keySet();
+    }
+
+    public static int roleNameToBit(String role) {
+        Integer bit = ROLE_BITS.get(role);
+        return bit == null ? -1 : bit;
+    }
+
+    private RoleCheckRegistry() {
+        // generated registry — not instantiable
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/GeneratedRoleRegistryLoader.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/GeneratedRoleRegistryLoader.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security;
+
+import eu.exeris.kernel.core.security.jfr.SecurityJfrEvents;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Core: eager, reflective loader that adapts the build-time generated
+ * {@code RoleCheckRegistry} into the {@link RoleRegistry} SPI contract
+ * (ADR-014 §3).
+ *
+ * <h2>Why reflective</h2>
+ * <p>The canonical registry is the source-generated
+ * {@code eu.exeris.kernel.security.generated.RoleCheckRegistry} emitted by
+ * {@code RequiresRoleProcessor}. Core must not declare a compile dependency on
+ * that artifact — it only exists when at least one {@code @RequiresRole} is
+ * compiled somewhere downstream, and a compile edge would reintroduce the
+ * reactor cycle the processor deliberately avoids (build-config is consumed by
+ * SPI as a plugin, not a module dependency). The class is therefore resolved by
+ * <b>string FQN</b> (mirroring {@code RequiresRoleProcessor.GENERATED_CLASS_FQN})
+ * and its five static accessors are bound once to {@link MethodHandle}s.
+ *
+ * <h2>Hot-path discipline</h2>
+ * <p>Reflection happens exactly once, at {@link #load()} time (bootstrap, platform
+ * thread). The per-request accessors ({@code requiredAny} / {@code requiredAll} /
+ * {@code matchIsAll}) invoke the bound handles via {@code invokeExact} — no
+ * {@code Method.invoke}, no boxing, allocation-free.
+ *
+ * <h2>Fail-closed default</h2>
+ * <p>When the generated class is absent (the common case — no {@code @RequiresRole}
+ * compiled anywhere) {@link #load()} returns the {@link #empty()} singleton:
+ * {@code methodCount() == 0}, every required mask is {@code 0L}, {@code matchIsAll}
+ * is {@code false}, and {@code roleNameToBit} returns {@code -1}. This keeps
+ * {@link RoleCheckEnforcer} fail-closed — {@code (mask & 0L) != 0L} is always
+ * {@code false}, so an empty registry denies, it never allows.
+ *
+ * <h2>The Wall</h2>
+ * <p>Imports only {@code exeris-kernel-spi} and the JDK. No driver, no Spring.
+ *
+ * @since 0.8.0
+ * @see RoleRegistry
+ * @see RoleCheckEnforcer
+ */
+public final class GeneratedRoleRegistryLoader {
+
+    /**
+     * Fully-qualified name of the generated registry class. MUST stay in sync
+     * with {@code RequiresRoleProcessor.GENERATED_CLASS_FQN}; referenced by
+     * string literal to avoid a compile dependency on build-config.
+     */
+    public static final String GENERATED_CLASS_FQN =
+            "eu.exeris.kernel.security.generated.RoleCheckRegistry";
+
+    private static final EmptyRoleRegistry EMPTY = new EmptyRoleRegistry();
+
+    private GeneratedRoleRegistryLoader() {
+        // static loader — not instantiable
+    }
+
+    /**
+     * Resolves the generated registry reflectively and adapts it to the
+     * {@link RoleRegistry} SPI. Emits a one-shot bootstrap JFR event recording
+     * the resolved {@code methodCount} and whether the class was found, so
+     * operators can distinguish "no annotations" from "load failed".
+     *
+     * <p>Tries the thread-context classloader first, then this loader's own
+     * classloader. On {@link ClassNotFoundException} (the common case) returns
+     * the {@link #empty()} singleton.
+     *
+     * @return a {@link RoleRegistry} backed by the generated class, or
+     *         {@link #empty()} when no generated class is present
+     */
+    public static RoleRegistry load() {
+        Class<?> generated = resolveGeneratedClass();
+        if (generated == null) {
+            SecurityJfrEvents.emitRoleRegistryLoaded(false, 0);
+            return EMPTY;
+        }
+        try {
+            ReflectiveRoleRegistry registry = ReflectiveRoleRegistry.bind(generated);
+            SecurityJfrEvents.emitRoleRegistryLoaded(true, registry.methodCount());
+            return registry;
+        } catch (ReflectiveOperationException ex) {
+            // Class present but signature mismatch — fail closed, never allow-all.
+            SecurityJfrEvents.emitRoleRegistryLoaded(false, 0);
+            return EMPTY;
+        }
+    }
+
+    /**
+     * Returns the fail-closed empty registry singleton.
+     *
+     * @return the empty {@link RoleRegistry}: {@code methodCount() == 0}, all
+     *         masks {@code 0L}, {@code matchIsAll == false}, {@code roleNameToBit == -1}
+     */
+    public static RoleRegistry empty() {
+        return EMPTY;
+    }
+
+    private static Class<?> resolveGeneratedClass() {
+        ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+        Class<?> resolved = tryResolve(contextLoader);
+        if (resolved != null) {
+            return resolved;
+        }
+        // Fallback to this loader's own classloader — intentional: the generated registry
+        // is typically packaged with the kernel artifacts, not the context CL. We try the
+        // context CL first (UseProperClassLoader), this is the documented fallback.
+        return tryResolve(GeneratedRoleRegistryLoader.class.getClassLoader()); //NOPMD UseProperClassLoader
+    }
+
+    private static Class<?> tryResolve(ClassLoader loader) {
+        if (loader == null) {
+            return null;
+        }
+        try {
+            return Class.forName(GENERATED_CLASS_FQN, false, loader);
+        } catch (ClassNotFoundException _) {
+            return null;
+        }
+    }
+
+    /**
+     * Fail-closed empty registry. A singleton so the no-annotations path is
+     * allocation-free.
+     */
+    private static final class EmptyRoleRegistry implements RoleRegistry {
+        @Override
+        public long requiredAny(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            return false;
+        }
+
+        @Override
+        public int methodCount() {
+            return 0;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            return -1;
+        }
+    }
+
+    /**
+     * {@link RoleRegistry} backed by {@link MethodHandle}s bound once to the
+     * generated class's static accessors. Per-request methods are
+     * {@code invokeExact} — allocation-free, no {@code Method.invoke}.
+     *
+     * <p>{@code invokeExact} declares {@code throws Throwable}; every accessor
+     * therefore re-throws {@link RuntimeException}/{@link Error} unchanged and
+     * wraps any other (impossible for these signatures) {@code Throwable} —
+     * hence the {@code AvoidCatchingGenericException} suppression. This mirrors
+     * the fail-fast catch idiom used by {@code SecurityInterceptor}.
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private static final class ReflectiveRoleRegistry implements RoleRegistry {
+
+        private final MethodHandle requiredAny;
+        private final MethodHandle requiredAll;
+        private final MethodHandle matchIsAll;
+        private final MethodHandle roleNameToBit;
+        private final int methodCount;
+
+        private ReflectiveRoleRegistry(MethodHandle requiredAny,
+                                       MethodHandle requiredAll,
+                                       MethodHandle matchIsAll,
+                                       MethodHandle roleNameToBit,
+                                       int methodCount) {
+            this.requiredAny = requiredAny;
+            this.requiredAll = requiredAll;
+            this.matchIsAll = matchIsAll;
+            this.roleNameToBit = roleNameToBit;
+            this.methodCount = methodCount;
+        }
+
+        /* default */ static ReflectiveRoleRegistry bind(Class<?> generated)
+                throws ReflectiveOperationException {
+            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            MethodHandle anyHandle = lookup.findStatic(generated, "requiredAny",
+                    MethodType.methodType(long.class, int.class));
+            MethodHandle allHandle = lookup.findStatic(generated, "requiredAll",
+                    MethodType.methodType(long.class, int.class));
+            MethodHandle matchHandle = lookup.findStatic(generated, "matchIsAll",
+                    MethodType.methodType(boolean.class, int.class));
+            MethodHandle countHandle = lookup.findStatic(generated, "methodCount",
+                    MethodType.methodType(int.class));
+            MethodHandle bitHandle = lookup.findStatic(generated, "roleNameToBit",
+                    MethodType.methodType(int.class, String.class));
+            int count = invokeCount(countHandle);
+            return new ReflectiveRoleRegistry(anyHandle, allHandle, matchHandle, bitHandle, count);
+        }
+
+        private static int invokeCount(MethodHandle countHandle) throws ReflectiveOperationException {
+            try {
+                return (int) countHandle.invokeExact();
+            } catch (RuntimeException | Error propagate) {
+                throw propagate;
+            } catch (Throwable ex) {
+                throw new ReflectiveOperationException("methodCount() invocation failed", ex);
+            }
+        }
+
+        @Override
+        public long requiredAny(int methodId) {
+            try {
+                return (long) requiredAny.invokeExact(methodId);
+            } catch (RuntimeException | Error propagate) {
+                throw propagate;
+            } catch (Throwable ex) {
+                throw new IllegalStateException("requiredAny invocation failed", ex);
+            }
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            try {
+                return (long) requiredAll.invokeExact(methodId);
+            } catch (RuntimeException | Error propagate) {
+                throw propagate;
+            } catch (Throwable ex) {
+                throw new IllegalStateException("requiredAll invocation failed", ex);
+            }
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            try {
+                return (boolean) matchIsAll.invokeExact(methodId);
+            } catch (RuntimeException | Error propagate) {
+                throw propagate;
+            } catch (Throwable ex) {
+                throw new IllegalStateException("matchIsAll invocation failed", ex);
+            }
+        }
+
+        @Override
+        public int methodCount() {
+            return methodCount;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            try {
+                return (int) roleNameToBit.invokeExact(roleName);
+            } catch (RuntimeException | Error propagate) {
+                throw propagate;
+            } catch (Throwable ex) {
+                throw new IllegalStateException("roleNameToBit invocation failed", ex);
+            }
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/MaskedPrincipal.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/MaskedPrincipal.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security;
+
+import eu.exeris.kernel.spi.security.PrincipalContext;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Core-internal {@link PrincipalContext} decorator that overrides
+ * {@link #roleMask()} with a precomputed bitmask while delegating every other
+ * accessor to the wrapped principal (ADR-014 §5).
+ *
+ * <h2>Why a wrapper, not an SPI field</h2>
+ * <p>The canonical SPI carrier {@code ImmutablePrincipal} keeps the
+ * {@code roleMask()} default of {@code 0L} — adding a mask component to that
+ * record would change the canonical SPI shape and force every
+ * {@code PrincipalContext} producer to know the build-time bit assignment. The
+ * mask is instead resolved at authentication time (when the registry is in
+ * scope) and carried by this thin Core decorator, leaving the SPI record
+ * untouched.
+ *
+ * <h2>Lifecycle</h2>
+ * <p>Created by {@link SecurityInterceptor} immediately before binding
+ * {@code KernelProviders.PRINCIPAL_CONTEXT}, only when the active
+ * {@link eu.exeris.kernel.spi.security.RoleRegistry} actually carries
+ * {@code @RequiresRole} entry points ({@code methodCount() > 0}). When the
+ * registry is empty no wrapper is allocated and the original principal flows
+ * through with its {@code 0L} mask.
+ *
+ * <h2>Valhalla readiness</h2>
+ * <p>A {@code record} with value-safe components and no identity operations.
+ *
+ * @param delegate the wrapped principal (never {@code null})
+ * @param roleMask the precomputed role bitmask aligned with the generated registry
+ *
+ * @since 0.8.0
+ * @see PrincipalContext#roleMask()
+ * @see SecurityInterceptor
+ */
+public record MaskedPrincipal(PrincipalContext delegate, long roleMask) implements PrincipalContext {
+
+    /**
+     * Compact constructor — fail-fast on a {@code null} delegate.
+     */
+    public MaskedPrincipal {
+        Objects.requireNonNull(delegate, "delegate must not be null");
+    }
+
+    @Override
+    public UUID principalId() {
+        return delegate.principalId();
+    }
+
+    @Override
+    public Optional<UUID> tenantId() {
+        return delegate.tenantId();
+    }
+
+    @Override
+    public Set<String> roles() {
+        return delegate.roles();
+    }
+
+    @Override
+    public boolean hasRole(String role) {
+        return delegate.hasRole(role);
+    }
+
+    @Override
+    public boolean hasAnyRole(String... checkRoles) {
+        return delegate.hasAnyRole(checkRoles);
+    }
+
+    @Override
+    public boolean hasAnyRole(String role1) {
+        return delegate.hasAnyRole(role1);
+    }
+
+    @Override
+    public boolean hasAnyRole(String role1, String role2) {
+        return delegate.hasAnyRole(role1, role2);
+    }
+
+    @Override
+    public boolean hasAnyRole(String role1, String role2, String role3) {
+        return delegate.hasAnyRole(role1, role2, role3);
+    }
+
+    @Override
+    public Set<String> scopes() {
+        return delegate.scopes();
+    }
+
+    @Override
+    public boolean hasScope(String scope) {
+        return delegate.hasScope(scope);
+    }
+
+    @Override
+    public boolean hasAnyScope(String... checkScopes) {
+        return delegate.hasAnyScope(checkScopes);
+    }
+
+    @Override
+    public boolean hasAnyScope(String scope1) {
+        return delegate.hasAnyScope(scope1);
+    }
+
+    @Override
+    public boolean hasAnyScope(String scope1, String scope2) {
+        return delegate.hasAnyScope(scope1, scope2);
+    }
+
+    @Override
+    public boolean hasAnyScope(String scope1, String scope2, String scope3) {
+        return delegate.hasAnyScope(scope1, scope2, scope3);
+    }
+
+    @Override
+    public long roleMask() {
+        return roleMask;
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/SecurityInterceptor.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/SecurityInterceptor.java
@@ -15,6 +15,7 @@ import eu.exeris.kernel.spi.exceptions.security.SecurityAuthenticationException;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.security.AuthenticationResult;
 import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
 import eu.exeris.kernel.spi.security.SecurityProvider;
 import eu.exeris.kernel.spi.security.StorageContext;
 
@@ -79,10 +80,16 @@ import java.util.Objects;
 @SuppressWarnings({"java:S6548", "java:S6206"})
 public final class SecurityInterceptor {
 
+    /** Sentinel mask meaning "no registry-resolved roles" — the fail-closed default. */
+    private static final long EMPTY_MASK = 0L;
+
     private final SecurityProvider provider;
+    private final RoleRegistry roleRegistry;
 
     /**
-     * Constructs a {@code SecurityInterceptor} backed by the given provider.
+     * Constructs a {@code SecurityInterceptor} backed by the given provider and
+     * the fail-closed {@linkplain GeneratedRoleRegistryLoader#empty() empty}
+     * role registry.
      *
      * <p>Typically called once during bootstrap, after
      * {@link java.util.ServiceLoader} selects the highest-priority
@@ -94,7 +101,28 @@ public final class SecurityInterceptor {
      *                 must not be {@code null}
      */
     public SecurityInterceptor(SecurityProvider provider) {
+        this(provider, GeneratedRoleRegistryLoader.empty());
+    }
+
+    /**
+     * Constructs a {@code SecurityInterceptor} backed by the given provider and
+     * a build-time {@link RoleRegistry} (ADR-014 §5).
+     *
+     * <p>When {@code roleRegistry.methodCount() > 0} the interceptor resolves
+     * the authenticated principal's role names against the registry and binds a
+     * {@link MaskedPrincipal} carrying the precomputed {@code roleMask()} into
+     * the request scope, so downstream {@code @RequiresRole} checks resolve to a
+     * primitive {@code AND}/{@code EQ}. When the registry is empty (no
+     * {@code @RequiresRole} compiled anywhere) the original principal is bound
+     * unchanged — no allocation, mask stays {@code 0L}, fail-closed.
+     *
+     * @param provider     the security provider; must not be {@code null}
+     * @param roleRegistry the build-time role registry; must not be {@code null}
+     *                     (pass {@link GeneratedRoleRegistryLoader#empty()} when none)
+     */
+    public SecurityInterceptor(SecurityProvider provider, RoleRegistry roleRegistry) {
         this.provider = Objects.requireNonNull(provider, "provider must not be null");
+        this.roleRegistry = Objects.requireNonNull(roleRegistry, "roleRegistry must not be null");
     }
 
     /**
@@ -140,7 +168,7 @@ public final class SecurityInterceptor {
             throw ex;
         }
 
-        PrincipalContext principal = result.principal();
+        PrincipalContext principal = enrichWithRoleMask(result.principal());
         StorageContext   storage   = result.storage();
 
         SecurityJfrEvents.emitPrincipalBound(
@@ -156,6 +184,33 @@ public final class SecurityInterceptor {
                 .run(requestHandler);
 
         return true;
+    }
+
+    /**
+     * Resolves the principal's role names against the registry into a precomputed
+     * {@code roleMask} and wraps the principal in a {@link MaskedPrincipal}.
+     *
+     * <p>When the registry carries no {@code @RequiresRole} entry points
+     * ({@code methodCount() == 0}) the original principal is returned unchanged —
+     * no allocation, mask stays {@code 0L}. A principal that already exposes a
+     * non-zero {@code roleMask()} (e.g. a pre-masked system principal) is left
+     * untouched so it is never double-wrapped or downgraded.
+     *
+     * @param principal the authenticated principal
+     * @return the principal to bind into the request scope
+     */
+    private PrincipalContext enrichWithRoleMask(PrincipalContext principal) {
+        if (roleRegistry.methodCount() == 0 || principal.roleMask() != EMPTY_MASK) {
+            return principal;
+        }
+        long mask = EMPTY_MASK;
+        for (String role : principal.roles()) {
+            mask |= roleRegistry.roleNameToMask(role);
+        }
+        if (mask == EMPTY_MASK) {
+            return principal;
+        }
+        return new MaskedPrincipal(principal, mask);
     }
 
     /**
@@ -253,7 +308,7 @@ public final class SecurityInterceptor {
         );
 
         ScopedValue
-                .where(KernelProviders.PRINCIPAL_CONTEXT, principal)
+                .where(KernelProviders.PRINCIPAL_CONTEXT, enrichWithRoleMask(principal))
                 .where(KernelProviders.STORAGE_CONTEXT, storage)
                 .run(requestHandler);
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/jfr/SecurityJfrEvents.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/jfr/SecurityJfrEvents.java
@@ -217,4 +217,52 @@ public final class SecurityJfrEvents {
         event.hasTenant = hasTenant;
         event.commit();
     }
+
+    // =========================================================================
+    // Event: RoleRegistryLoaded (bootstrap, one-shot)
+    // =========================================================================
+
+    /**
+     * Emitted once at bootstrap when the generated {@code RoleCheckRegistry} is
+     * resolved (or found absent). Lets operators distinguish "no
+     * {@code @RequiresRole} compiled" ({@code found == false}) from "registry
+     * loaded with N methods" ({@code found == true}, {@code methodCount == N}),
+     * and from a load failure (also {@code found == false}). Carries no secrets.
+     */
+    @Name("eu.exeris.kernel.security.RoleRegistryLoaded")
+    @Label("Role Registry Loaded")
+    @Category({"Exeris Kernel", "Security"})
+    @Description("Emitted once at bootstrap when the generated @RequiresRole RoleCheckRegistry is resolved")
+    @StackTrace(false)
+    public static final class RoleRegistryLoadedEvent extends Event {
+
+        @Label("Generated Class Found")
+        @Description("Whether the generated RoleCheckRegistry class was resolved on the classpath")
+        public boolean generatedClassFound;
+
+        @Label("Method Count")
+        @Description("Number of @RequiresRole-annotated entry points compiled into the registry")
+        public int methodCount;
+    }
+
+    /**
+     * Emits a {@link RoleRegistryLoadedEvent}. Single-phase commit — bootstrap
+     * runs on a platform thread, but we still avoid begin()/work/commit()
+     * straddle per the VT-JFR lore.
+     *
+     * @param generatedClassFound whether the generated class was resolved
+     * @param methodCount         number of annotated entry points ({@code 0} when absent)
+     */
+    public static void emitRoleRegistryLoaded(boolean generatedClassFound, int methodCount) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        var event = new RoleRegistryLoadedEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.generatedClassFound = generatedClassFound;
+        event.methodCount = methodCount;
+        event.commit();
+    }
 }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractGeneratedRoleRegistryLoaderTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractGeneratedRoleRegistryLoaderTck.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.security;
+
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TCK: contract for the reflective loader that adapts the build-time generated
+ * {@code RoleCheckRegistry} into the {@link RoleRegistry} SPI (ADR-014 §3).
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li><b>Absent</b> — when no generated class is present the loader returns a
+ *       fail-closed empty registry: {@code methodCount() == 0}, every required
+ *       mask {@code 0L}, {@code matchIsAll == false}, {@code roleNameToBit == -1}.</li>
+ *   <li><b>Present</b> — when a generated class is present its five static
+ *       accessors round-trip through the SPI: {@code methodCount() > 0}, masks
+ *       and {@code roleNameToBit} resolve.</li>
+ *   <li><b>Fail-closed</b> — the empty registry combined with any methodId via
+ *       the binding's enforcer denies (no allow-all).</li>
+ *   <li>The loader never throws at bootstrap, regardless of class presence.</li>
+ * </ul>
+ *
+ * <h2>How to use</h2>
+ * <p>Bindings supply three factories: {@link #loadAbsent()} (loader result when
+ * no generated class is on the classpath), {@link #loadPresent()} (loader result
+ * adapted from a present generated class fixture), and {@link #isAllowed} (the
+ * binding's allocation-free enforcer delegate). The abstract drives the
+ * contract; the binding owns the Core loader and the generated fixture.
+ *
+ * @since 0.8.0
+ */
+public abstract class AbstractGeneratedRoleRegistryLoaderTck {
+
+    /**
+     * Returns the registry the loader yields when <em>no</em> generated
+     * {@code RoleCheckRegistry} is resolvable (the common case). Must be the
+     * fail-closed empty registry.
+     *
+     * @return non-null empty registry
+     */
+    protected abstract RoleRegistry loadAbsent();
+
+    /**
+     * Returns the registry the loader yields when a generated
+     * {@code RoleCheckRegistry} fixture <em>is</em> resolvable. The fixture MUST
+     * declare at least one {@code @RequiresRole} entry point so the accessors
+     * are non-trivial.
+     *
+     * @return non-null registry backed by a present generated class
+     */
+    protected abstract RoleRegistry loadPresent();
+
+    /**
+     * Returns the allocation-free decision routine ({@code RoleCheckEnforcer}).
+     *
+     * @param methodId  compile-time method id
+     * @param principal non-null principal
+     * @param registry  non-null registry
+     * @return {@code true} when permitted
+     */
+    protected abstract boolean isAllowed(int methodId, PrincipalContext principal, RoleRegistry registry);
+
+    @Test
+    @DisplayName("Absent generated class yields the fail-closed empty registry")
+    void absentYieldsEmpty() {
+        RoleRegistry empty = loadAbsent();
+
+        assertThat(empty).as("loader must never return null").isNotNull();
+        assertThat(empty.methodCount()).isZero();
+        assertThat(empty.requiredAny(0)).isZero();
+        assertThat(empty.requiredAll(0)).isZero();
+        assertThat(empty.matchIsAll(0)).isFalse();
+        assertThat(empty.roleNameToBit("ROLE_ADMIN")).isEqualTo(-1);
+        assertThat(empty.roleNameToMask("ROLE_ADMIN")).isZero();
+    }
+
+    @Test
+    @DisplayName("Empty registry + any methodId denies via the enforcer (fail-closed)")
+    void emptyRegistryFailsClosed() {
+        RoleRegistry empty = loadAbsent();
+        PrincipalContext admin = ImmutablePrincipal.system(UUID.randomUUID(), Set.of("ROLE_ADMIN"));
+
+        // ImmutablePrincipal keeps roleMask()==0L; even if it didn't, requiredAny==0L denies.
+        assertThat(isAllowed(0, admin, empty))
+                .as("empty registry must deny — (mask & 0L) != 0L is always false")
+                .isFalse();
+        assertThat(isAllowed(7, admin, empty)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Present generated class round-trips its accessors through the SPI")
+    void presentRoundTrips() {
+        RoleRegistry registry = loadPresent();
+
+        assertThat(registry).isNotNull();
+        assertThat(registry.methodCount())
+                .as("fixture must declare at least one @RequiresRole entry point")
+                .isPositive();
+        // ROLE_ADMIN is a canonical system role at bit 1 in both the processor and
+        // the generated fixture, so the round-trip is deterministic.
+        assertThat(registry.roleNameToBit("ROLE_ADMIN"))
+                .as("ROLE_ADMIN resolves to its canonical system bit")
+                .isEqualTo(1);
+        assertThat(registry.roleNameToMask("ROLE_ADMIN")).isEqualTo(1L << 1);
+        assertThat(registry.roleNameToBit("ROLE_GHOST"))
+                .as("unknown roles surface as -1 so callers fail closed")
+                .isEqualTo(-1);
+        // Method 0 of the fixture requires ROLE_ADMIN (ANY): a principal masked
+        // for ROLE_ADMIN is allowed, an empty-mask principal is denied.
+        PrincipalContext adminMask = maskOnly(registry.roleNameToMask("ROLE_ADMIN"));
+        PrincipalContext noMask = maskOnly(0L);
+        assertThat(isAllowed(0, adminMask, registry)).isTrue();
+        assertThat(isAllowed(0, noMask, registry)).isFalse();
+    }
+
+    private static PrincipalContext maskOnly(long mask) {
+        return new MaskOnlyPrincipal(mask);
+    }
+
+    private record MaskOnlyPrincipal(long maskValue) implements PrincipalContext {
+        @Override
+        public UUID principalId() {
+            return new UUID(0L, 0L);
+        }
+
+        @Override
+        public java.util.Optional<UUID> tenantId() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public Set<String> roles() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> scopes() {
+            return Set.of();
+        }
+
+        @Override
+        public long roleMask() {
+            return maskValue;
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractGeneratedRoleRegistryLoaderTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractGeneratedRoleRegistryLoaderTck.java
@@ -121,12 +121,43 @@ public abstract class AbstractGeneratedRoleRegistryLoaderTck {
         assertThat(registry.roleNameToBit("ROLE_GHOST"))
                 .as("unknown roles surface as -1 so callers fail closed")
                 .isEqualTo(-1);
+        // All five SPI accessors must round-trip through the reflective binding,
+        // not only the ANY/roleName pair. Method 0 of the fixture is an ANY method,
+        // so its ALL mask is 0L and matchIsAll is false — assert both so a binding
+        // that mis-wired the requiredAll/matchIsAll MethodHandles is caught.
+        assertThat(registry.requiredAny(0))
+                .as("ANY mask round-trips to ROLE_ADMIN's single bit")
+                .isEqualTo(1L << 1);
+        assertThat(registry.requiredAll(0))
+                .as("an ANY method has an empty ALL mask")
+                .isZero();
+        assertThat(registry.matchIsAll(0))
+                .as("an ANY method must report matchIsAll == false")
+                .isFalse();
         // Method 0 of the fixture requires ROLE_ADMIN (ANY): a principal masked
         // for ROLE_ADMIN is allowed, an empty-mask principal is denied.
         PrincipalContext adminMask = maskOnly(registry.roleNameToMask("ROLE_ADMIN"));
         PrincipalContext noMask = maskOnly(0L);
         assertThat(isAllowed(0, adminMask, registry)).isTrue();
         assertThat(isAllowed(0, noMask, registry)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Present registry with a method-id out of range fails fast, never allows")
+    void presentRegistryMethodIdOutOfRangeFailsFast() {
+        RoleRegistry registry = loadPresent();
+        int outOfRange = registry.methodCount(); // first index past the compiled table
+
+        // ADVERSARIAL: a method-id beyond the compiled table is a programming/wiring
+        // error. The reflective registry indexes a backing array, so the bound
+        // MethodHandle propagates the ArrayIndexOutOfBoundsException unchanged. The
+        // contract pins fail-FAST (a thrown RuntimeException), never a silent
+        // permissive mask that a fail-open regression might return.
+        PrincipalContext adminMask = maskOnly(registry.roleNameToMask("ROLE_ADMIN"));
+        org.assertj.core.api.Assertions
+                .assertThatThrownBy(() -> isAllowed(outOfRange, adminMask, registry))
+                .as("out-of-range method-id must surface as a thrown error, never an implicit allow")
+                .isInstanceOf(RuntimeException.class);
     }
 
     private static PrincipalContext maskOnly(long mask) {

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRoleMaskPopulationTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRoleMaskPopulationTck.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.security;
+
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.RoleRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TCK: contract for role-mask population at authentication time (ADR-014 §5).
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>When the active {@link RoleRegistry} carries {@code @RequiresRole} entry
+ *       points ({@code methodCount() > 0}), the {@code SecurityInterceptor}
+ *       resolves the authenticated principal's role names into a precomputed
+ *       {@code roleMask()} and binds it into
+ *       {@link KernelProviders#PRINCIPAL_CONTEXT}.</li>
+ *   <li>When the registry is empty, the original principal is bound unchanged —
+ *       {@code roleMask()} stays {@code 0L} and the principal is NOT wrapped.</li>
+ * </ul>
+ *
+ * <h2>How to use</h2>
+ * <p>The binding supplies {@link #runIntercept}: build a {@code SecurityInterceptor}
+ * over a stub success provider returning {@code principal}, with the given
+ * {@code registry}, run its {@code intercept(...)} and invoke {@code handler}
+ * within the authenticated scope. The abstract's handler reads
+ * {@link KernelProviders#PRINCIPAL_CONTEXT} to observe the bound mask.
+ *
+ * @since 0.8.0
+ */
+public abstract class AbstractRoleMaskPopulationTck {
+
+    /** Canonical system bit for {@code ROLE_ADMIN} (mirrors the processor). */
+    protected static final int BIT_ADMIN = 1;
+
+    /**
+     * Builds a {@code SecurityInterceptor} over a stub success provider that
+     * authenticates to {@code principal} with the supplied {@code registry},
+     * runs {@code intercept(...)}, and invokes {@code handler} inside the
+     * authenticated scope (where {@link KernelProviders#PRINCIPAL_CONTEXT} is
+     * bound).
+     *
+     * @param registry  active role registry
+     * @param principal principal returned by the stub provider
+     * @param handler   logic to run in the authenticated scope
+     * @return {@code true} if the handler was invoked
+     */
+    protected abstract boolean runIntercept(RoleRegistry registry,
+                                            PrincipalContext principal,
+                                            Runnable handler);
+
+    @Test
+    @DisplayName("Registry with methods populates roleMask from the principal's role names")
+    void populatesMaskWhenRegistryNonEmpty() {
+        RoleRegistry registry = new SingleMethodAdminRegistry();
+        PrincipalContext principal = ImmutablePrincipal.system(UUID.randomUUID(), Set.of("ROLE_ADMIN"));
+        AtomicReference<PrincipalContext> bound = new AtomicReference<>();
+
+        boolean invoked = runIntercept(registry, principal,
+                () -> bound.set(KernelProviders.PRINCIPAL_CONTEXT.get()));
+
+        assertThat(invoked).isTrue();
+        assertThat(bound.get()).as("a principal must be bound in scope").isNotNull();
+        assertThat(bound.get().roleMask())
+                .as("roleMask must equal the registry's single-bit mask for ROLE_ADMIN")
+                .isEqualTo(1L << BIT_ADMIN);
+        assertThat(bound.get().roles())
+                .as("delegated accessors must still surface the original role names")
+                .containsExactly("ROLE_ADMIN");
+    }
+
+    @Test
+    @DisplayName("Empty registry leaves the principal unwrapped with a 0L mask")
+    void leavesPrincipalUntouchedWhenRegistryEmpty() {
+        RoleRegistry empty = new EmptyRegistry();
+        PrincipalContext principal = ImmutablePrincipal.system(UUID.randomUUID(), Set.of("ROLE_ADMIN"));
+        AtomicReference<PrincipalContext> bound = new AtomicReference<>();
+
+        boolean invoked = runIntercept(empty, principal,
+                () -> bound.set(KernelProviders.PRINCIPAL_CONTEXT.get()));
+
+        assertThat(invoked).isTrue();
+        assertThat(bound.get())
+                .as("empty registry must bind the original principal instance, not a wrapper")
+                .isSameAs(principal);
+        assertThat(bound.get().roleMask()).isZero();
+    }
+
+    /** Registry with a single ANY method requiring {@code ROLE_ADMIN}. */
+    private static final class SingleMethodAdminRegistry implements RoleRegistry {
+        @Override
+        public long requiredAny(int methodId) {
+            return 1L << BIT_ADMIN;
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            return false;
+        }
+
+        @Override
+        public int methodCount() {
+            return 1;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            return "ROLE_ADMIN".equals(roleName) ? BIT_ADMIN : -1;
+        }
+    }
+
+    /** Fail-closed empty registry mirroring the loader's absent-class default. */
+    private static final class EmptyRegistry implements RoleRegistry {
+        @Override
+        public long requiredAny(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public long requiredAll(int methodId) {
+            return 0L;
+        }
+
+        @Override
+        public boolean matchIsAll(int methodId) {
+            return false;
+        }
+
+        @Override
+        public int methodCount() {
+            return 0;
+        }
+
+        @Override
+        public int roleNameToBit(String roleName) {
+            return -1;
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRoleMaskPopulationTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractRoleMaskPopulationTck.java
@@ -86,6 +86,77 @@ public abstract class AbstractRoleMaskPopulationTck {
     }
 
     @Test
+    @DisplayName("Unknown role names contribute 0 to the mask (fail-closed, no -1 garbage)")
+    void unknownRolesContributeZero() {
+        RoleRegistry registry = new SingleMethodAdminRegistry();
+        // ADVERSARIAL: ROLE_GHOST is unknown to the registry (roleNameToBit == -1).
+        // The population loop must OR in its single-bit mask of 0L, never a garbage
+        // bit derived from a -1 shift. The resulting mask must be exactly ADMIN's bit.
+        PrincipalContext principal = ImmutablePrincipal.system(
+                UUID.randomUUID(), Set.of("ROLE_ADMIN", "ROLE_GHOST"));
+        AtomicReference<PrincipalContext> bound = new AtomicReference<>();
+
+        boolean invoked = runIntercept(registry, principal,
+                () -> bound.set(KernelProviders.PRINCIPAL_CONTEXT.get()));
+
+        assertThat(invoked).isTrue();
+        assertThat(bound.get().roleMask())
+                .as("unknown role must contribute 0, leaving only ROLE_ADMIN's bit set")
+                .isEqualTo(1L << BIT_ADMIN);
+    }
+
+    @Test
+    @DisplayName("Masked accessors delegate every field to the wrapped principal")
+    void wrappedPrincipalDelegatesAllAccessors() {
+        RoleRegistry registry = new SingleMethodAdminRegistry();
+        UUID principalId = UUID.randomUUID();
+        UUID tenantId = UUID.randomUUID();
+        // Tenant + scopes populated so a wrapper that only forwarded roleMask()/roles()
+        // but dropped tenantId()/scopes() (broken delegate) is caught.
+        PrincipalContext principal = ImmutablePrincipal.ofTenant(
+                principalId, tenantId, Set.of("ROLE_ADMIN"), Set.of("read:orders", "write:orders"));
+        AtomicReference<PrincipalContext> bound = new AtomicReference<>();
+
+        boolean invoked = runIntercept(registry, principal,
+                () -> bound.set(KernelProviders.PRINCIPAL_CONTEXT.get()));
+
+        assertThat(invoked).isTrue();
+        PrincipalContext masked = bound.get();
+        assertThat(masked)
+                .as("a non-empty registry with resolvable roles must wrap the principal")
+                .isNotSameAs(principal);
+        assertThat(masked.roleMask()).isEqualTo(1L << BIT_ADMIN);
+        assertThat(masked.principalId()).as("principalId must delegate").isEqualTo(principalId);
+        assertThat(masked.tenantId()).as("tenantId must delegate").contains(tenantId);
+        assertThat(masked.roles()).as("roles must delegate").containsExactly("ROLE_ADMIN");
+        assertThat(masked.scopes()).as("scopes must delegate")
+                .containsExactlyInAnyOrder("read:orders", "write:orders");
+    }
+
+    @Test
+    @DisplayName("A pre-masked principal is bound unchanged, never downgraded")
+    void preMaskedPrincipalNeverDowngraded() {
+        RoleRegistry registry = new SingleMethodAdminRegistry();
+        // ADVERSARIAL: principal already carries a precomputed mask (e.g. a trusted
+        // gateway or resumed session). Enrichment must leave it untouched — same
+        // instance, same mask — and never recompute/overwrite it with a smaller value.
+        long preset = (1L << BIT_ADMIN) | (1L << 5);
+        PrincipalContext preMasked = new FixedMaskPrincipal(preset);
+        AtomicReference<PrincipalContext> bound = new AtomicReference<>();
+
+        boolean invoked = runIntercept(registry, preMasked,
+                () -> bound.set(KernelProviders.PRINCIPAL_CONTEXT.get()));
+
+        assertThat(invoked).isTrue();
+        assertThat(bound.get())
+                .as("a pre-masked principal must be bound as the original instance")
+                .isSameAs(preMasked);
+        assertThat(bound.get().roleMask())
+                .as("the pre-existing mask must be preserved bit-for-bit")
+                .isEqualTo(preset);
+    }
+
+    @Test
     @DisplayName("Empty registry leaves the principal unwrapped with a 0L mask")
     void leavesPrincipalUntouchedWhenRegistryEmpty() {
         RoleRegistry empty = new EmptyRegistry();
@@ -100,6 +171,38 @@ public abstract class AbstractRoleMaskPopulationTck {
                 .as("empty registry must bind the original principal instance, not a wrapper")
                 .isSameAs(principal);
         assertThat(bound.get().roleMask()).isZero();
+    }
+
+    /**
+     * Principal carrying a precomputed {@code roleMask()} — the shape a trusted
+     * gateway or resumed session presents. Used to assert the no-downgrade
+     * invariant in {@link #preMaskedPrincipalNeverDowngraded()}.
+     */
+    private record FixedMaskPrincipal(long mask) implements PrincipalContext {
+        @Override
+        public UUID principalId() {
+            return new UUID(0L, 0L);
+        }
+
+        @Override
+        public java.util.Optional<UUID> tenantId() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public Set<String> roles() {
+            return Set.of("ROLE_ADMIN");
+        }
+
+        @Override
+        public Set<String> scopes() {
+            return Set.of();
+        }
+
+        @Override
+        public long roleMask() {
+            return mask;
+        }
     }
 
     /** Registry with a single ANY method requiring {@code ROLE_ADMIN}. */


### PR DESCRIPTION
## What

Wires the compile-time `@RequiresRole` RBAC machinery into runtime (SEC-080). The APT-generated registry, `RoleCheckEnforcer`, and `roleMask()` existed since v0.7 but were **dead code** — the enforcer was invoked nowhere and `roleMask()` was never populated. This lands the loader + population + live enforcement seam.

## Scope (architect-reviewed, deliberately narrowed)

**Landed (fully in-kernel, Wall-safe):**
- **`GeneratedRoleRegistryLoader`** (Core) — resolves `eu.exeris.kernel.security.generated.RoleCheckRegistry` reflectively (`Class.forName` by string FQN — **no compile edge to `exeris-kernel-build-config`**, avoids the reactor cycle the processor deliberately prevents), binds the 5 static accessors to `MethodHandle`s. Fail-closed **EMPTY** singleton when the class is absent (no `@RequiresRole` compiled): `methodCount()==0`, lookups → `0L`/`false`/`-1`, so `RoleCheckEnforcer` denies rather than allows. One-shot `RoleRegistryLoaded` bootstrap JFR event (found-flag + methodCount, single-phase commit, `@StackTrace(false)`).
- **`MaskedPrincipal`** (Core record) — delegating `PrincipalContext` wrapper overriding `roleMask()`. **No change to `ImmutablePrincipal`** / no SPI surface widening.
- **`SecurityInterceptor`** — constructor-injected `RoleRegistry` (default EMPTY); populates `roleMask` from `principal.roles()` in `intercept` / `interceptPreAuthenticated` before binding `PRINCIPAL_CONTEXT`. No-op (no allocation, original principal) when registry empty; never downgrades a pre-masked principal; `runAsSystem` intentionally not enriched.
- Community bootstrap wiring through `CommunityHttpRequestProcessor`.
- **TCK:** `AbstractGeneratedRoleRegistryLoaderTck` + `AbstractRoleMaskPopulationTck` + Community bindings + a generated-class test fixture. Existing `AbstractRequiresRoleTck` (+ZeroAlloc/SecurityInterceptor bindings) stay green.

**Descoped (architect finding — larger than one Core sprint / partly out-of-repo):**
- **NO** URL→methodId routing in `CommunityHttpRequestDispatcher` — it stays scope/path-based. `@RequiresRole` is methodId-based (a compile-time constant per annotated method); the kernel HTTP dispatcher has no method dimension and dispatches to *application-supplied* handlers. Edge auto-enforcement therefore belongs in handler codegen (`exeris-tooling`, cross-repo) or application code holding the generated `M_n` constant — **not** the kernel dispatcher. Recorded in `docs/subsystems/security.md`.
- HOT-081..083 hot-path watch-items remain profile-gated → v0.9.

## Verification
- Core 1088 tests 0F/0E; Community 1114 tests 0F/0E (incl. 2 new bindings + existing RequiresRole/ZeroAlloc/SecurityInterceptor bindings); build-config + SPI RequiresRole tests green.
- Final **PMD + Checkstyle-enabled** `verify` on core + community: 0 violations, BUILD SUCCESS (real findings fixed, not blanket-suppressed).

## Follow-up
- `exeris-tck` to confirm the two new abstract TCKs as canonical contract shape (recommended pre-merge gate).
- Cross-repo: `exeris-tooling` handler/edge codegen to consume the methodId enforcement seam (separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)