### PR TITLE
v0.8 Sprint 7 (TCK-064): non-blocking reactor-driven client ingress — eliminate VT-carrier pinning

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,31 +61,16 @@ jobs:
           cache: maven
 
       - name: Build & Run TCK Verification
-        # Carrier-pool flags: the main verify pass runs every Community TCK that is not
-        # tagged as @Tag("stress"). The single-reactor
-        # CommunityTransportCarrierPinningTckTest is the baseline carrier-pinning
-        # contract — it runs here under the 2-vCPU GitHub Actions runner and would
-        # exhaust the default 2-thread VT carrier pool (FFM-pinned client-ingress VTs,
-        # see Sprint 0a TCK-064) without the same flag triplet that the dedicated
-        # transport-stress-gate job already applies. Mirroring the flags here keeps
-        # the single-reactor baseline green on CI; the multi-reactor variants
-        # (CommunityTransportCarrierPinningMultiReactor{2,4}TckTest) were retagged in
-        # this same PR as @Tag("stress") because their 2-vCPU contention is a true
-        # stress scenario rather than baseline contract verification — they run only
-        # in transport-stress-gate where the higher drain budget already lives.
-        # Local dev runs (no -D flags) keep the strict 5 s default. The proper
-        # production fix is the v0.8 Sprint 7 non-blocking-ingress refactor — once
-        # shipped these workarounds and the stress tagging can be dropped together.
-        #
-        # Drain budget escalation history:
-        #   - 5  s default (v0.7 baseline; passes locally on 12-core dev boxes).
-        #   - 30 s introduced by PR #121 alongside the VT scheduler flags above.
-        #   - 90 s introduced by PR after #124 — baseline CommunityTransportCarrier
-        #     PinningTckTest still exceeded the 30 s drain post-teardown under
-        #     2-vCPU peak schedule pressure (systematic, reproducible across reruns,
-        #     not transient flake). 90 s is ~3× the prior bump to absorb the JDK
-        #     26+35 schedule pressure tail; happy path drain is sub-second so the
-        #     widened budget only kicks in under worst-case CI contention.
+        # v0.8 Sprint 7 (TCK-064 production fix): the VT-scheduler workaround
+        # (parallelism=16 / maxPoolSize=64) was removed once client ingress became
+        # non-blocking and reactor-driven. Previously the single-reactor
+        # CommunityTransportCarrierPinningTckTest exhausted the default 2-thread VT
+        # carrier pool because each client stream ran a VT that blocked in a native
+        # recv() (FFM-pinned the carrier). Client channels now flip to non-blocking
+        # after connect() and register on a dedicated client-side reactor, so no VT
+        # blocks on recv() and the default carrier pool is sufficient. The drain
+        # budget is restored toward the strict 5 s default; happy-path drain is
+        # sub-second.
         #
         # v0.8 Sprint 6 (Coverage C-P0-01): -Pcoverage activates JaCoCo agent +
         # report + per-module <check> rule enforcement. Per-module LINE coverage
@@ -93,10 +78,7 @@ jobs:
         # (ratcheted ~5-9 pp below current baseline).
         run: |
           mvn clean verify -B -e \
-            -P coverage \
-            -Djdk.virtualThreadScheduler.parallelism=16 \
-            -Djdk.virtualThreadScheduler.maxPoolSize=64 \
-            -Dexeris.tck.transport.drainTimeoutSeconds=90
+            -P coverage
 
       - name: Upload TCK JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
@@ -300,40 +282,20 @@ jobs:
           cache: maven
 
       - name: Run transport stress gate
-        # TCK-064 root cause (v0.8 Sprint 0): client ingress VTs in this codebase mount
-        # onto the JDK virtual-thread carrier pool and call a blocking native `recv()`
-        # via Panama FFM (NativeTcpStream.trySocketSeamRead → socketHandles.recv()).
-        # That pins the carrier thread for the duration of the syscall — and on a
-        # 2-vCPU GitHub Actions runner the default carrier pool size is 2, so a
-        # handful of clients trivially exhaust the pool. Server-side echo VTs then
-        # cannot mount, no echo data flows, clients block on `recv()` forever.
-        #
-        # Bumping `jdk.virtualThreadScheduler.parallelism` (steady-state carriers)
-        # and `maxPoolSize` (peak carriers) eliminates the starvation: with 16 baseline
-        # / 64 peak carriers, the same 10 client × 4 server reactor stress passes in
-        # ~0.3 s under taskset -c 0,1. The ROADMAP carry-over for v0.8 transport
-        # hardening (Sprint 6 / non-blocking ingress) is the proper long-term fix —
-        # this knob is the CI-side workaround that lets the gate fire today.
-        #
-        # Drain budget 180 s for the stress-gate specifically — wider than the
-        # 90 s main build-and-verify budget because MultiReactor{2,4} stress
-        # tests deliberately contend for the carrier pool, and 90 s proved
-        # systematically insufficient under 2-vCPU CI peak pressure:
-        #   - PR #125 bumped main + stress from 30 s → 90 s.
-        #   - PR #126 / #127 / #129 build runs all hit
-        #     CommunityTransportCarrierPinningMultiReactor2TckTest at 90 s
-        #     drain on stress-gate; main job at 90 s remained green.
-        #     → Conclusion: the stress-gate tail is consistently wider than
-        #     the baseline single-reactor pinning test.
-        # Local development keeps the strict 5 s default.
+        # v0.8 Sprint 7 (TCK-064 production fix): the VT-scheduler workaround and the
+        # 180 s drain escalation were removed. TCK-064's root cause was client ingress
+        # VTs blocking in a native recv() via Panama FFM, which pinned the carrier
+        # thread; on a 2-vCPU runner (default carrier pool = 2) a handful of clients
+        # exhausted the pool and stalled. The Sprint 7 fix makes client channels
+        # non-blocking after connect() and reactor-driven (no VT blocks on recv()), so
+        # the stress + multi-reactor variants pass at the default carrier pool with the
+        # strict drain budget. The MultiReactor{2,4} variants stay @Tag("stress") and
+        # run here; the single-reactor baseline runs in build-and-verify.
         run: |
           mvn -pl exeris-kernel-community -am install -DskipTests -B -e
           mvn -pl exeris-kernel-community \
             -DincludedGroups=stress \
             -DexcludedGroups= \
-            -Dexeris.tck.transport.drainTimeoutSeconds=180 \
-            -Djdk.virtualThreadScheduler.parallelism=16 \
-            -Djdk.virtualThreadScheduler.maxPoolSize=64 \
             test -B -e
 
       - name: Upload transport stress JFR recordings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 
 ## [Unreleased] — 0.8.0-SNAPSHOT
 
+### Fixed — Non-blocking client ingress (Sprint 7 TCK-064)
+
+- Production fix for the TCK-064 virtual-thread carrier-pinning stall on the Community TCP **client** ingress path. Previously each outbound stream ran a virtual thread that looped on a **blocking** native `recv()` via Panama FFM: the plain client `SocketChannel` was left in blocking mode after `connect()`, so the seam's `EAGAIN → 0` retry branch was unreachable and the carrier thread was pinned for the syscall duration. On a 2-vCPU runner (default carrier pool = 2) a handful of clients exhausted the pool and deadlocked.
+- `NativeTcpCarrier.connect()` now flips the connected channel to **non-blocking** unconditionally (not just for TLS-FD) before registration, and registers the client channel on a **client-side reactor** — CLIENT/DUAL engines stand up the same reactor model previously reserved for SERVER/DUAL. Client ingress is now reactor-driven (OP_READ) against a non-blocking FD; no virtual thread blocks on `recv()`.
+- Client **egress** is unified onto the reactor key (`requestWriteInterest` → reactor arms OP_WRITE → `flushStream`), matching the server path. The separate per-stream client ingress/writer virtual-thread pumps (`runClientIngressLoop`, `runClientWriterLoop`, `requestClientWriteFlush`) and their `ChannelRuntimeRegistry` thread plumbing were deleted, removing the split-ownership hazard of a writer VT racing the reactor on one FD.
+- CLIENT/DUAL outbound runtime intentionally uses a **single** reactor (server reactor count is unchanged) to avoid spawning surplus reactor platform threads that would oversubscribe constrained cores and re-introduce VT-carrier starvation.
+- Community-internal transport change only — no SPI/Core contract change (The Wall, ADR-006), no admission/ADR-010 interaction.
+- CI: removed the `-Djdk.virtualThreadScheduler.parallelism=16 / maxPoolSize=64` workaround and the escalated `-Dexeris.tck.transport.drainTimeoutSeconds` overrides from both the `build-and-verify` and `transport-stress-gate` jobs in `.github/workflows/maven.yml`. `CommunityTransportCarrierPinningTckTest` (+ MultiReactor2/4 variants) and `NativeTcpTransportStressTest` pass at the default VT carrier pool and the strict default drain budget.
+
 ### Security — @RequiresRole runtime wiring (Sprint 4 SEC-080)
 
 - `eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader` (new, Core) resolves the build-time generated `eu.exeris.kernel.security.generated.RoleCheckRegistry` reflectively (by FQN string — no compile edge on `exeris-kernel-build-config`, preserving the processor's reactor-cycle avoidance) and binds its five static accessors (`requiredAny`/`requiredAll`/`matchIsAll`/`methodCount`/`roleNameToBit`) to `MethodHandle`s once at bootstrap, exposed as a `RoleRegistry`. The per-request accessors use `invokeExact` — no `Method.invoke`, allocation-free. ADR-014 §3.

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -335,7 +335,7 @@ for client IP preservation behind load balancers (HAProxy, NGINX, AWS NLB, GCP L
 - **FFM socket backend selection + validation** — `SocketBackendMode` enum, `SocketBackendSelection` record, PosixHybrid / NIO fallback, `validateServerSocketBootstrap*` / `validateClientSocketBackend*` probes, Windows `bestEffortWsaCleanup`.
 - **Reactor loop** — `ReactorLoop` inner class: `Selector`, `pendingRequests` MPSC queue (PERF-063 — `MpscUnboundedArrayQueue`), `drainPendingRequests`, key dispatch.
 - **Acceptor / connection bootstrap** — `runAcceptorLoop`, `acceptPendingConnections`, `tryReserveConnectionSlot`, `buildAcceptedStream`, `registerAndHandshakeConnection`.
-- **Client-side ingress/writer pumps** — `runClientIngressLoop`, `runClientWriterLoop` Virtual Thread pumps with idle backoff.
+- **Client-side connection bootstrap** — `connect` flips the connected channel to non-blocking and `registerClientChannel` registers it on a single client-side reactor (SERVER/DUAL keep `config.reactorCount()` reactors; CLIENT/DUAL outbound uses one). Client ingress and egress are reactor-driven exactly like accepted server channels — there is no separate client ingress/writer Virtual-Thread pump (removed in v0.8 Sprint 7 / TCK-064, which eliminated the blocking-`recv()` carrier-pinning stall).
 - **PAQS-dispatch read/flush path** — `readIngress`, `flushStream`, `adaptTlsIfNeeded`, `closeKeyStream`.
 
 `NativeTcpStream`:

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -32,8 +32,16 @@
               mvn test -DincludedGroups=flamegraph -DexcludedGroups=
               mvn test -DincludedGroups=stress    -DexcludedGroups=
               mvn test -Dtest=NativeTcpTransportStressTest (targeted-test-run profile)
+
+            transport-pinning-recv (TCK-064 client RECV carrier-pinning regression) is
+            also excluded from the default Surefire execution, but UNLIKE flamegraph/stress
+            it is NOT skipped in CI: it runs in a dedicated forked Surefire execution
+            (id=transport-pinning-recv) below, pinned to the faithful 2-vCPU carrier model
+            (-Djdk.virtualThreadScheduler.parallelism=2 / maxPoolSize=2). It must run in its
+            own fork because the scarce-carrier VT-scheduler args would otherwise distort
+            every other test in the default execution.
         -->
-        <excludedGroups>flamegraph,integration,stress</excludedGroups>
+        <excludedGroups>flamegraph,integration,stress,transport-pinning-recv</excludedGroups>
 
         <!--
             v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Community bundle.
@@ -181,6 +189,38 @@
                     <!-- Exclude @Tag("flamegraph") tests from regular CI runs -->
                     <excludedGroups>${excludedGroups}</excludedGroups>
                 </configuration>
+                <executions>
+                    <!--
+                        TCK-064 regression: the client RECV carrier-pinning test
+                        (CommunityClientIngressCarrierPinningTest, @Tag("transport-pinning-recv"))
+                        must run under the faithful 2-vCPU carrier model so the scarce-carrier
+                        deadlock would re-manifest if a client recv path ever blocks a carrier
+                        again. parallelism=2/maxPoolSize=2 forces exactly two VT carriers; the
+                        client-stream count (32) far exceeds that. Run in its own fork so these
+                        scheduler args never leak into the default test execution.
+                    -->
+                    <execution>
+                        <id>transport-pinning-recv</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>@{coverage.argLine} ${jvm.args} --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Djdk.virtualThreadScheduler.parallelism=2 -Djdk.virtualThreadScheduler.maxPoolSize=2</argLine>
+                            <includes>
+                                <include>**/CommunityClientIngressCarrierPinningTest.java</include>
+                            </includes>
+                            <!--
+                                Re-include the transport-pinning-recv tag here (the plugin-level
+                                ${excludedGroups} excludes it for the default execution). The
+                                other heavy tags stay excluded so this fork runs ONLY the recv
+                                regression class.
+                            -->
+                            <groups>transport-pinning-recv</groups>
+                            <excludedGroups>flamegraph,integration,stress</excludedGroups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/ChannelRuntimeRegistry.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/ChannelRuntimeRegistry.java
@@ -43,8 +43,6 @@ final class ChannelRuntimeRegistry {
         return runtime != null ? runtime.stream() : streamByChannel.get(channel);
     }
 
-    // TooManyMethods: state accessors/mutators stay colocated for atomic channel runtime ownership.
-    @SuppressWarnings("PMD.TooManyMethods")
     static final class ChannelRuntimeState {
 
         private final SocketChannel channel;
@@ -52,8 +50,6 @@ final class ChannelRuntimeRegistry {
         private final String socketBackend;
         private final ConcurrentMap<SocketChannel, NativeTcpReactor> channelOwner;
         private final AtomicReference<NativeTcpReactor> owner = new AtomicReference<>();
-        private final AtomicReference<Thread> clientIngressThread = new AtomicReference<>();
-        private final AtomicReference<Thread> clientWriterThread = new AtomicReference<>();
         private final AtomicBoolean lifecycleCleanup = new AtomicBoolean(false);
 
         private ChannelRuntimeState(SocketChannel channel,
@@ -92,26 +88,6 @@ final class ChannelRuntimeRegistry {
 
         NativeTcpReactor detachOwner() {
             return owner.getAndSet(null);
-        }
-
-        void bindClientIngressThread(Thread thread) {
-            clientIngressThread.set(thread);
-        }
-
-        Thread detachClientIngressThread() {
-            return clientIngressThread.getAndSet(null);
-        }
-
-        void bindClientWriterThread(Thread thread) {
-            clientWriterThread.set(thread);
-        }
-
-        Thread clientWriterThread() {
-            return clientWriterThread.get();
-        }
-
-        Thread detachClientWriterThread() {
-            return clientWriterThread.getAndSet(null);
         }
 
         boolean beginLifecycleCleanup() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.LockSupport;
 
 /**
  * Community native TCP carrier with FD-owner reactor and VT-per-stream dispatch via PAQS.
@@ -65,10 +64,6 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     private static final System.Logger LOG = System.getLogger(NativeTcpCarrier.class.getName());
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
-    private static final long CLIENT_TLS_INGRESS_IDLE_BACKOFF_INITIAL_NANOS = 250_000L;
-    private static final long CLIENT_TLS_INGRESS_IDLE_BACKOFF_MAX_NANOS = 2_000_000L;
-    private static final long CLIENT_WRITER_BACKOFF_INITIAL_NANOS = 250_000L;
-    private static final long CLIENT_WRITER_BACKOFF_MAX_NANOS = 2_000_000L;
     private static final int MIN_LISTENER_BACKLOG = 64;
     private static final int MAX_LISTENER_BACKLOG = 1_024;
 
@@ -158,6 +153,11 @@ public final class NativeTcpCarrier implements TransportEngine {
                 }
                 initPaqs();
                 startServerRuntime();
+            } else {
+                // CLIENT mode: there is no acceptor/PAQS, but outbound channels still need a reactor
+                // to drive non-blocking ingress and egress (TCK-064). Stand up the reactor loop(s)
+                // here so connect() can register channels against them.
+                startClientRuntime();
             }
         } catch (RuntimeException ex) {
             running.set(false);
@@ -211,13 +211,16 @@ public final class NativeTcpCarrier implements TransportEngine {
         try {
             backend.validateClientSocketBackendOnce(allocator, host, port);
             channel = SocketChannel.open();
+            // Connect blocking (avoids OP_CONNECT handling), then flip the connected channel to
+            // non-blocking UNCONDITIONALLY before reactor registration. This is the TCK-064 root
+            // cause fix: a blocking plain client FD makes seamRead's EAGAIN->0 path unreachable, so
+            // native recv() blocks and pins the VT carrier. Non-blocking recv yields cleanly to the
+            // reactor instead. TLS-FD channels were already flipped here; plain channels now are too.
             channel.configureBlocking(true);
             channel.connect(new InetSocketAddress(host, port));
+            channel.configureBlocking(false);
             tlsEngine = createTlsEngineIfEnabled();
             bindTlsFdIfRequired(tlsEngine, channel);
-            if (tlsEngine instanceof eu.exeris.kernel.community.crypto.CommunityTlsEngine) {
-                channel.configureBlocking(false);
-            }
             final SocketChannel connectedChannel = channel;
 
             NativeTcpConnection connection = new NativeTcpConnection(
@@ -232,7 +235,7 @@ public final class NativeTcpCarrier implements TransportEngine {
                     connection,
                     allocator,
                     tlsEngine,
-                    () -> requestClientWriteFlush(connectedChannel),
+                    () -> requestWriteInterest(connectedChannel),
                     () -> onStreamClosed(connectedChannel),
                     backend.socketHandles());
             if (tlsEngine instanceof eu.exeris.kernel.community.crypto.CommunityTlsEngine) {
@@ -241,8 +244,7 @@ public final class NativeTcpCarrier implements TransportEngine {
 
             connection.bindSingleStream(stream);
             ChannelRuntimeRegistry.ChannelRuntimeState runtime = registerRuntime(stream, connectedChannel);
-            startClientIngressPump(runtime);
-            startClientWriterPump(runtime);
+            registerClientChannel(runtime, connectedChannel);
             activeConnections.incrementAndGet();
             activeStreams.incrementAndGet();
             totalAccepted.incrementAndGet();
@@ -348,27 +350,47 @@ public final class NativeTcpCarrier implements TransportEngine {
                 engineName());
     }
 
+    /**
+     * Builds and starts {@code reactorCount} reactor loops, replacing any prior set.
+     * Shared by SERVER/DUAL bootstrap and CLIENT bootstrap so both roles drive the same
+     * non-blocking selector model.
+     */
+    private void startReactors(int reactorCount) throws IOException {
+        reactors.clear();
+        for (int i = 0; i < reactorCount; i++) {
+            reactors.add(new NativeTcpReactor(this, i, Selector.open()));
+        }
+        nextReactorIndex.set(0);
+        for (NativeTcpReactor reactor : reactors) {
+            reactor.start();
+        }
+    }
+
     private void startServerRuntime() {
         try {
             backend.validateServerSocketBootstrapOnce(allocator);
-            int reactorCount = Math.max(1, config.reactorCount());
-            reactors.clear();
-            for (int i = 0; i < reactorCount; i++) {
-                reactors.add(new NativeTcpReactor(this, i, Selector.open()));
-            }
-            nextReactorIndex.set(0);
 
             serverChannel = ServerSocketChannel.open();
             serverChannel.configureBlocking(true);
             serverChannel.bind(new InetSocketAddress(config.bindAddress(), config.port()), listenerBacklog());
 
-            for (NativeTcpReactor reactor : reactors) {
-                reactor.start();
-            }
+            startReactors(Math.max(1, config.reactorCount()));
 
             acceptorThread = Thread.ofPlatform()
                     .name("carrier/native-tcp/acceptor")
                     .start(this::runAcceptorLoop);
+        } catch (IOException e) {
+            throw TransportException.engineStartFailure(engineName(), config.port(), e);
+        }
+    }
+
+    private void startClientRuntime() {
+        try {
+            // CLIENT/DUAL outbound paths multiplex a small number of channels; a single reactor
+            // is sufficient and intentionally avoids spawning surplus reactor platform threads.
+            // Surplus client reactors would oversubscribe constrained cores (2-vCPU CI) and starve
+            // the VT carriers running stream handlers — the same class of stall TCK-064 fixes.
+            startReactors(1);
         } catch (IOException e) {
             throw TransportException.engineStartFailure(engineName(), config.port(), e);
         }
@@ -525,6 +547,24 @@ public final class NativeTcpCarrier implements TransportEngine {
         return true;
     }
 
+    /**
+     * Registers an outbound (client) channel with a reactor exactly like an accepted server
+     * channel: bind the owner, mark registration pending, and enqueue the REGISTER request so the
+     * reactor arms OP_READ (and OP_WRITE when there is already-queued data) on its own thread. This
+     * is the TCK-064 fix — client ingress is now reactor-driven against a non-blocking FD instead of
+     * a blocking native {@code recv()} on a VT (which pinned the carrier). Egress is unified onto the
+     * same key via {@link #requestWriteInterest}: the stream's write callback arms OP_WRITE and the
+     * reactor thread runs {@link #flushStream}. No separate ingress/writer VT survives for either
+     * plain or TLS-FD client channels.
+     */
+    private void registerClientChannel(ChannelRuntimeRegistry.ChannelRuntimeState runtime,
+                                       SocketChannel channel) {
+        NativeTcpReactor owner = selectReactor();
+        runtime.markRegistrationPending();
+        runtime.bindOwner(owner);
+        owner.enqueueRegistration(channel);
+    }
+
     private NativeTcpReactor selectReactor() {
         int size = reactors.size();
         if (size == 0) {
@@ -633,107 +673,12 @@ public final class NativeTcpCarrier implements TransportEngine {
             owner.cancelKey(channel);
         }
 
-        Thread clientIngressThread = runtime.detachClientIngressThread();
-        if (clientIngressThread != null) {
-            interruptAndJoin(clientIngressThread);
-        }
-        Thread clientWriterThread = runtime.detachClientWriterThread();
-        if (clientWriterThread != null) {
-            interruptAndJoin(clientWriterThread);
-        }
-
         streamByChannel.remove(channel, runtime.stream());
         channelOwner.remove(channel);
 
         if (runtime.beginLifecycleCleanup()) {
             activeStreams.decrementAndGet();
             activeConnections.decrementAndGet();
-        }
-    }
-
-    private void requestClientWriteFlush(SocketChannel channel) {
-        ChannelRuntimeRegistry.ChannelRuntimeState runtime = resolveRuntime(channel);
-        if (runtime == null) {
-            return;
-        }
-        Thread writer = runtime.clientWriterThread();
-        if (writer != null) {
-            LockSupport.unpark(writer);
-        }
-    }
-
-    private void startClientIngressPump(ChannelRuntimeRegistry.ChannelRuntimeState runtime) {
-        Thread thread = Thread.ofVirtual()
-                .name("carrier/native-tcp-client-ingress/" + runtime.stream().streamId())
-                .start(() -> runClientIngressLoop(runtime.channel(), runtime.stream()));
-        runtime.bindClientIngressThread(thread);
-    }
-
-    private void startClientWriterPump(ChannelRuntimeRegistry.ChannelRuntimeState runtime) {
-        Thread thread = Thread.ofVirtual()
-                .name("carrier/native-tcp-client-writer/" + runtime.stream().streamId())
-                .start(() -> runClientWriterLoop(runtime.stream()));
-        runtime.bindClientWriterThread(thread);
-    }
-
-    private void runClientIngressLoop(SocketChannel channel, NativeTcpStream stream) {
-        long idleBackoffNanos = CLIENT_TLS_INGRESS_IDLE_BACKOFF_INITIAL_NANOS;
-        while (running.get()) {
-            try {
-                if (stream.isClosed()) {
-                    return;
-                }
-
-                if (stream.usesFdOwnerTls()) {
-                    LoanedBuffer offered = stream.readTlsIngressFromFd();
-                    if (offered != null) {
-                        stream.offerIngress(offered);
-                        idleBackoffNanos = CLIENT_TLS_INGRESS_IDLE_BACKOFF_INITIAL_NANOS;
-                        continue;
-                    }
-                    if (stream.isClosed()) {
-                        return;
-                    }
-                    LockSupport.parkNanos(idleBackoffNanos);
-                    idleBackoffNanos = Math.min(
-                            idleBackoffNanos << 1,
-                            CLIENT_TLS_INGRESS_IDLE_BACKOFF_MAX_NANOS);
-                    continue;
-                }
-
-                readIngress(channel);
-                idleBackoffNanos = CLIENT_TLS_INGRESS_IDLE_BACKOFF_INITIAL_NANOS;
-            } catch (RuntimeException _) {
-                stream.markRemoteClosed();
-                return;
-            }
-        }
-    }
-
-    private void runClientWriterLoop(NativeTcpStream stream) {
-        long writeBackoffNanos = CLIENT_WRITER_BACKOFF_INITIAL_NANOS;
-        while (running.get() && !stream.isClosed()) {
-            try {
-                stream.signalWriteReady();
-                if (stream.hasPendingData()) {
-                    boolean drained = stream.flushPendingWrites();
-                    if (drained) {
-                        writeBackoffNanos = CLIENT_WRITER_BACKOFF_INITIAL_NANOS;
-                        continue;
-                    }
-                    LockSupport.parkNanos(writeBackoffNanos);
-                    writeBackoffNanos = Math.min(writeBackoffNanos << 1, CLIENT_WRITER_BACKOFF_MAX_NANOS);
-                    continue;
-                }
-                writeBackoffNanos = CLIENT_WRITER_BACKOFF_INITIAL_NANOS;
-                LockSupport.park();
-                if (Thread.interrupted() && (!running.get() || stream.isClosed())) {
-                    return;
-                }
-            } catch (RuntimeException _) {
-                stream.close();
-                return;
-            }
         }
     }
 
@@ -754,14 +699,6 @@ public final class NativeTcpCarrier implements TransportEngine {
     private void closeSelectorAndChannels() {
         for (ChannelRuntimeRegistry.ChannelRuntimeState runtime : new ArrayList<>(runtimeByChannel.values())) {
             runtime.stream().close();
-            Thread ingressThread = runtime.detachClientIngressThread();
-            if (ingressThread != null) {
-                ingressThread.interrupt();
-            }
-            Thread writerThread = runtime.detachClientWriterThread();
-            if (writerThread != null) {
-                writerThread.interrupt();
-            }
         }
         runtimeByChannel.clear();
         streamByChannel.clear();
@@ -785,18 +722,6 @@ public final class NativeTcpCarrier implements TransportEngine {
             closeable.close();
         } catch (Exception ignored) {
             // best effort
-        }
-    }
-
-    private static void interruptAndJoin(Thread thread) {
-        thread.interrupt();
-        if (Objects.equals(thread, Thread.currentThread())) {
-            return;
-        }
-        try {
-            thread.join(200L);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
         }
     }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityClientIngressCarrierPinningTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityClientIngressCarrierPinningTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportConfig;
+import eu.exeris.kernel.spi.transport.TransportConnection;
+import eu.exeris.kernel.spi.transport.TransportEngine;
+import eu.exeris.kernel.spi.transport.TransportMode;
+import eu.exeris.kernel.spi.transport.TransportStream;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TCK-064 regression: faithful carrier-pinning verifier for the <em>client RECV</em> hot path.
+ *
+ * <h2>Why this test exists (the coverage gap it closes)</h2>
+ * <p>{@link CommunityTransportCarrierPinningTckTest} (the {@link
+ * eu.exeris.kernel.tck.contract.transport.TransportCarrierPinningTck} binding) only exercises the
+ * <em>write</em> path — {@code queueWrite} on a pre-opened stream. It proves egress never pins a
+ * carrier, but it never makes a client virtual thread actually <em>receive</em> bytes. TCK-064's
+ * root cause was the opposite path: each client stream ran a per-stream VT that issued a blocking
+ * native {@code recv()} through FFM, which <strong>pinned the carrier</strong> for the duration of
+ * the blocking syscall. Under a scarce carrier pool (2-vCPU CI), N&gt;carriers concurrent clients
+ * exhausted the pool and the runtime deadlocked. That defect was only ever observable through
+ * {@link NativeTcpTransportStressTest} (10 clients × N reactors echo), which is {@code @Tag("stress")}
+ * and excluded from the default run — so the default TCK matrix had a blind spot precisely where the
+ * bug lived.
+ *
+ * <h2>What this test asserts</h2>
+ * <p>It stands up a real loopback echo server (single server reactor) and a single client engine,
+ * then fans {@value #CLIENT_COUNT} virtual threads — each one does a full
+ * {@code connect → openStream → write → read(echo) → assert} round-trip through the changed
+ * {@link NativeTcpCarrier} client path (non-blocking FD + client-side reactor). {@code CLIENT_COUNT}
+ * is deliberately far larger than the carrier pool so the scarce-carrier deadlock would re-manifest
+ * if any client RECV ever blocked a carrier again. The test fails if:
+ * <ol>
+ *   <li>any {@code jdk.VirtualThreadPinned} event &gt; {@value #PIN_THRESHOLD_MS} ms is recorded
+ *       (the same fence the {@link eu.exeris.kernel.tck.contract.JfrPinningMonitor} uses), <em>or</em></li>
+ *   <li>the client VTs do not all complete the round-trip within {@value #COMPLETION_TIMEOUT_SECONDS} s
+ *       — i.e. the carrier-starvation deadlock returned.</li>
+ * </ol>
+ *
+ * <h2>Faithful 2-vCPU carrier model</h2>
+ * <p>The defect only manifests when carriers are <em>scarce</em>. A 12-core host hides it: there are
+ * always free carriers even with a few pinned. This class is wired in {@code exeris-kernel-community}
+ * via a dedicated Surefire execution that forks with
+ * {@code -Djdk.virtualThreadScheduler.parallelism=2 -Djdk.virtualThreadScheduler.maxPoolSize=2},
+ * the faithful 2-vCPU carrier model. {@code taskset} is unreliable here because the server-side
+ * {@code PaqsScheduler.close()} 60 s teardown timeout dominates wall-clock under hard core-pinning;
+ * constraining only the VT scheduler reproduces the carrier scarcity without that confound. When run
+ * without those flags (e.g. ad-hoc {@code -Dtest=}), the assertions still hold — they are simply less
+ * adversarial.
+ *
+ * @see CommunityTransportCarrierPinningTckTest
+ * @see NativeTcpTransportStressTest
+ * @since 0.8.0 (TCK-064 client-ingress regression coverage)
+ */
+@Tag("transport-pinning-recv")
+@DisplayName("TCK-064: client RECV round-trip never pins a carrier (scarce-carrier model)")
+class CommunityClientIngressCarrierPinningTest {
+
+    private static final String VT_PINNED_EVENT = "jdk.VirtualThreadPinned";
+    private static final long PIN_THRESHOLD_MS = 20L;
+
+    /** Far larger than the 2-carrier model so the scarce-carrier deadlock would re-surface. */
+    private static final int CLIENT_COUNT = 32;
+    private static final int MESSAGES_PER_CLIENT = 4;
+    private static final int MESSAGE_SIZE = 256;
+    private static final long COMPLETION_TIMEOUT_SECONDS = 60L;
+
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    @DisplayName("N>carriers clients each receive a full echo with zero carrier pinning")
+    void clientRecvRoundTripDoesNotPinCarrier() throws Exception {
+        MemoryAllocator allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        int port = nextFreePort();
+        byte[] payload = new byte[MESSAGE_SIZE];
+        Arrays.fill(payload, (byte) 0x5A);
+
+        NativeTcpTransportProvider provider = new NativeTcpTransportProvider();
+        TransportEngine server = createEngine(provider, allocator, TransportMode.SERVER, port);
+        AtomicInteger serverEchoCount = new AtomicInteger();
+        server.setStreamHandler(stream -> echoUntilClosed(stream, allocator, serverEchoCount));
+
+        // One client engine, one client reactor — N client streams multiplex onto it. This is the
+        // exact production shape the TCK-064 fix targets (no per-stream blocking-recv VT).
+        TransportEngine client = createEngine(provider, allocator, TransportMode.CLIENT, 0);
+
+        Path jfr = Files.createTempFile("tck064-client-recv-pinning-", ".jfr");
+        CountDownLatch done = new CountDownLatch(CLIENT_COUNT);
+        AtomicInteger failures = new AtomicInteger();
+        AtomicInteger completed = new AtomicInteger();
+
+        try (Recording rec = new Recording()) {
+            rec.enable(VT_PINNED_EVENT)
+                    .withThreshold(Duration.ofMillis(PIN_THRESHOLD_MS))
+                    .withStackTrace();
+            rec.setDestination(jfr);
+
+            server.start();
+            client.start();
+            rec.start();
+
+            List<Thread> vts = new ArrayList<>(CLIENT_COUNT);
+            for (int i = 0; i < CLIENT_COUNT; i++) {
+                vts.add(Thread.ofVirtual()
+                        .name("tck064-client-recv-", i)
+                        .start(() -> {
+                            try {
+                                runClientRoundTrips(client, "127.0.0.1", port, allocator, payload);
+                                completed.incrementAndGet();
+                            } catch (RuntimeException ex) {
+                                failures.incrementAndGet();
+                            } finally {
+                                done.countDown();
+                            }
+                        }));
+            }
+
+            boolean allDone = done.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            rec.stop();
+
+            assertThat(allDone)
+                    .withFailMessage(
+                            "TCK-064 REGRESSION: %d/%d client RECV round-trips did not complete within %d s — "
+                                    + "the scarce-carrier deadlock has returned (a client recv path is blocking a carrier).",
+                            completed.get(), CLIENT_COUNT, COMPLETION_TIMEOUT_SECONDS)
+                    .isTrue();
+            assertThat(failures.get())
+                    .withFailMessage("%d client round-trips threw during echo verification", failures.get())
+                    .isZero();
+            assertThat(completed.get()).isEqualTo(CLIENT_COUNT);
+        } finally {
+            client.close();
+            server.close();
+            allocator.close();
+        }
+
+        List<String> pins = readPinningEvents(jfr);
+        Files.deleteIfExists(jfr);
+        assertThat(pins)
+                .withFailMessage(
+                        "TCK-064 REGRESSION: %d carrier-pinning event(s) > %d ms during client RECV:%n%s",
+                        pins.size(), PIN_THRESHOLD_MS, String.join(System.lineSeparator(), pins))
+                .isEmpty();
+    }
+
+    private static void runClientRoundTrips(TransportEngine client,
+                                            String host,
+                                            int port,
+                                            MemoryAllocator allocator,
+                                            byte[] payload) {
+        TransportConnection connection = client.connect(host, port);
+        try (TransportStream stream = connection.openStream()) {
+            for (int msg = 0; msg < MESSAGES_PER_CLIENT; msg++) {
+                try (LoanedBuffer outbound = allocator.allocateNetwork(MESSAGE_SIZE);
+                     LoanedBuffer inbound = allocator.allocateNetwork(MESSAGE_SIZE)) {
+                    outbound.segment().asSlice(0, MESSAGE_SIZE).copyFrom(MemorySegment.ofArray(payload));
+                    outbound.setSize(MESSAGE_SIZE);
+                    stream.write(outbound.segment(), MESSAGE_SIZE);
+
+                    readFully(stream, inbound.segment(), MESSAGE_SIZE);
+                    byte[] echoed = new byte[MESSAGE_SIZE];
+                    inbound.segment().asSlice(0, MESSAGE_SIZE).asByteBuffer().get(echoed);
+                    if (!Arrays.equals(echoed, payload)) {
+                        throw new IllegalStateException("echo payload mismatch");
+                    }
+                }
+            }
+        } finally {
+            connection.close();
+        }
+    }
+
+    private static void echoUntilClosed(TransportStream stream, MemoryAllocator allocator, AtomicInteger echoCount) {
+        try (stream;
+             LoanedBuffer inbound = allocator.allocateNetwork(MESSAGE_SIZE + 1);
+             LoanedBuffer outbound = allocator.allocateNetwork(MESSAGE_SIZE + 1)) {
+            while (true) {
+                int read = stream.read(inbound.segment(), MESSAGE_SIZE);
+                if (read < 0) {
+                    return;
+                }
+                if (read == 0) {
+                    LockSupport.parkNanos(1_000L);
+                    continue;
+                }
+                inbound.setSize(read);
+                outbound.segment().asSlice(0, read).copyFrom(inbound.segment().asSlice(0, read));
+                outbound.setSize(read);
+                stream.write(outbound.segment(), read);
+                echoCount.incrementAndGet();
+            }
+        } catch (RuntimeException _) {
+            // Stream can fail during shutdown; terminal for this handler.
+        }
+    }
+
+    private static void readFully(TransportStream stream, MemorySegment target, int expectedBytes) {
+        int total = 0;
+        while (total < expectedBytes) {
+            int n = stream.read(target.asSlice(total), expectedBytes - total);
+            if (n < 0) {
+                throw new IllegalStateException(
+                        "Stream EOF before full payload arrived: read " + total + "/" + expectedBytes);
+            }
+            if (n == 0) {
+                LockSupport.parkNanos(1_000L);
+                continue;
+            }
+            total += n;
+        }
+    }
+
+    private static TransportEngine createEngine(NativeTcpTransportProvider provider,
+                                                MemoryAllocator allocator,
+                                                TransportMode mode,
+                                                int port) {
+        TransportEngine[] holder = new TransportEngine[1];
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, allocator)
+                .run(() -> holder[0] = provider.createEngine(new TransportConfig(
+                        mode, "127.0.0.1", port, 1, null, null, 1024, 30_000)));
+        return holder[0];
+    }
+
+    private static List<String> readPinningEvents(Path jfr) throws IOException {
+        List<String> pins = new ArrayList<>();
+        if (!Files.exists(jfr)) {
+            return pins;
+        }
+        try (RecordingFile rf = new RecordingFile(jfr)) {
+            while (rf.hasMoreEvents()) {
+                RecordedEvent ev = rf.readEvent();
+                if (!VT_PINNED_EVENT.equals(ev.getEventType().getName())) {
+                    continue;
+                }
+                double ms = ev.getDuration().toNanos() / 1_000_000.0;
+                if (ms < PIN_THRESHOLD_MS) {
+                    continue;
+                }
+                String thread = ev.getThread() != null ? ev.getThread().getJavaName() : "<unknown>";
+                pins.add(String.format(java.util.Locale.ROOT, "  - %s pinned %.2f ms", thread, ms));
+            }
+        }
+        return pins;
+    }
+
+    private static int nextFreePort() {
+        try (ServerSocketChannel server = ServerSocketChannel.open()) {
+            server.bind(new InetSocketAddress("127.0.0.1", 0));
+            return ((InetSocketAddress) server.getLocalAddress()).getPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to allocate free TCP port", e);
+        }
+    }
+}


### PR DESCRIPTION
## What

Removes the VT-carrier-pinning deadlock on the **client** ingress path (TCK-064) by deleting the per-stream blocking-`recv()` ingress/writer VT pumps and folding client I/O into the existing reactor/selector model.

## Root cause

`NativeTcpCarrier` ran a dedicated VT per client stream doing a **blocking native `recv()`** via Panama FFM. FFM downcalls cannot yield, so the blocking syscall **pinned the VT carrier**; the plain client channel was also left in **blocking mode** (`configureBlocking(true)`), making `seamRead`'s EAGAIN→0 branch unreachable. On a 2-vCPU runner (2 carriers) a few client streams exhausted the pool → server echo VTs couldn't mount → deadlock. CI papered over it with `-Djdk.virtualThreadScheduler.parallelism=16 -Djdk.virtualThreadScheduler.maxPoolSize=64`.

## Fix (architect-designed, Wall-safe — Community transport only, no SPI/Core change)

- `connect()`: blocking connect → unconditional `configureBlocking(false)` → register the client channel on a **client-side reactor** (`bindOwner` + `markRegistrationPending` + `enqueueRegistration`), exactly like an accepted server channel.
- **Stand up a client reactor** in CLIENT/DUAL mode (extracted `startReactors`); single outbound reactor (more would oversubscribe cores and relocate the same starvation).
- **Unify egress onto the reactor key** — client write callback `requestClientWriteFlush` → `requestWriteInterest`; **DELETED** `runClientIngressLoop`, `runClientWriterLoop`, `startClient{Ingress,Writer}Pump`, `requestClientWriteFlush`, and the `clientWriterThread` plumbing. (Avoids the split-ownership race of half-migrating.)
- TLS-FD client ingress also folds onto the reactor (single read owner — keeping a separate pump would race with the reactor on `readTlsIngressFromFd`).

## Exit gate — met

Removed the VT-scheduler bump + 180s drain override from **both** maven.yml jobs. All pinning + stress suites pass at **default** VT scheduler parallelism:
- `CommunityTransportCarrierPinningTckTest`, MultiReactor2, MultiReactor4, `NativeTcpTransportStressTest` — green.

## Validation (exeris-tck hardened)

- **New `CommunityClientIngressCarrierPinningTest`** — faithful TCK-064 regression: 32 client VTs (>> carriers) full echo round-trips at forced `parallelism=2/maxPoolSize=2` (the real 2-vCPU carrier model), asserting zero pinning + completion. **Proven faithful**: reverting the carrier to the blocking-recv version makes it FAIL with the exact deadlock signature (0/32 in 60s); the fix makes it pass in ~0.27s. Runs in its own Surefire fork so the scarce-carrier args don't leak into the default suite.
- **TLS-over-carrier path verified covered**: `NativeTcpClientServerE2eIntegrationTest.clientServerTlsRoundTrip` drives a TLS client through the changed carrier (handshake NEED_WRAP → OP_WRITE on the reactor key); confirmed passing with an ephemeral cert (CI supplies its own).
- Full `mvn -pl exeris-kernel-community verify` (PMD + Checkstyle): BUILD SUCCESS, 1118 + 1 tests green.

## Follow-ups (non-blocking)
- MultiReactor{2,4} pinning TCKs still carry `@Tag("stress")` + the dedicated `transport-stress-gate` job — kept conservatively until validated on a real 2-vCPU GitHub runner; un-tagging into the main matrix is a small separate step.
- FLOW-110 (Flow restart-under-load) + GRAPH-111 (Graph baseline) — the other Sprint 7 items — are independent subsystems, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)