### PR TITLE
v0.8 Sprint 7 (GRAPH-111): bind ExecutionGraphZeroAlloc + ChurnRatio TCKs

### DIFF
--- a/docs/subsystems/graph.md
+++ b/docs/subsystems/graph.md
@@ -212,7 +212,7 @@ connections of user X"). Leaving it at the default 10 prevents runaway traversal
 - **Carrier Pinning:** JFR-based validation that driver I/O does not stall Virtual Threads
   (`CarrierPinnedEvent` must not fire during standard traversal).
 
-> **TCK gap:** `GraphChurnRatioTck` and `ExecutionGraphZeroAllocTck` have no Community-tier concrete bindings in `exeris-kernel-community/src/test/`. Community churn ratio enforcement (`EX-GRPH-5005`) is currently not gated in CI for the Community implementation.
+> **TCK bindings:** Both `ExecutionGraphZeroAllocTck` and `GraphChurnRatioTck` now have Community-tier concrete bindings in `exeris-kernel-community/src/test/`. `CommunityExecutionGraphZeroAllocTckTest` runs in the main `build-and-verify` lane (in-process shortest-path hot path, no database). `CommunityGraphChurnRatioTckIT` is `@Tag("integration")` (live Neo4j via Testcontainers) and runs in the `persistence-rls-gate` CI job — gating Community churn-to-data ratio (`EX-GRPH-5005`) below the documented 20x threshold.
 
 ---
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/graph/CommunityExecutionGraphZeroAllocTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/graph/CommunityExecutionGraphZeroAllocTckTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import eu.exeris.kernel.spi.graph.GraphConfig;
+import eu.exeris.kernel.spi.graph.GraphEngine;
+import eu.exeris.kernel.tck.contract.graph.ExecutionGraphZeroAllocTck;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Community concrete TCK: {@link ExecutionGraphZeroAllocTck} backed by
+ * {@link CommunityGraphEngine}.
+ *
+ * <h2>What this proves for Community tier</h2>
+ * <p>The shortest-path hot path
+ * {@code openSession() → findShortestPath(src, tgt) → close()} stays within the
+ * bounded-allocation budget ({@code maxExerisAllocationsPerIteration() = 10} over
+ * 1 000 iterations). The single-argument
+ * {@link eu.exeris.kernel.spi.graph.GraphSession#findShortestPath(Object, Object)}
+ * overload is fully in-process: distinct {@code src}/{@code tgt} resolve to
+ * {@code PathResult.notFound(...)} without touching the persistence backend, so
+ * this binding needs no database and runs in the main {@code build-and-verify} lane.
+ *
+ * @since 0.5.0
+ */
+@DisplayName("Community: ExecutionGraph zero-allocation TCK")
+class CommunityExecutionGraphZeroAllocTckTest extends ExecutionGraphZeroAllocTck {
+
+    @Override
+    protected GraphEngine createEngine() {
+        return new CommunityGraphProvider()
+                .createEngine(GraphConfig.create("test-graph"));
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/graph/CommunityGraphChurnRatioTckIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/graph/CommunityGraphChurnRatioTckIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.graph;
+
+import eu.exeris.kernel.spi.graph.GraphConfig;
+import eu.exeris.kernel.spi.graph.GraphEngine;
+import eu.exeris.kernel.spi.graph.GraphSession;
+import eu.exeris.kernel.spi.graph.model.GraphEdgeDescriptor;
+import eu.exeris.kernel.tck.contract.graph.GraphChurnRatioTck;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Community concrete TCK: {@link GraphChurnRatioTck} backed by a live Neo4j
+ * Cypher backend via Testcontainers.
+ *
+ * <h2>What this proves for Community tier</h2>
+ * <p>The Community traversal hot path
+ * {@code openSession() → traverseBreadthFirst(1-hop) → close()} stays below the
+ * documented churn-to-data SLO ({@code < 20x} of {@code eu.exeris.*} allocated
+ * bytes per useful data byte). The Cypher backend is used deliberately: it builds
+ * its helper from an explicit {@link CommunityNeo4jClient} passed via
+ * {@link GraphConfig}, so no {@code ScopedValue}-bound persistence engine is
+ * required to drive the traversal (unlike the SQL/PGQ path).
+ *
+ * <h2>Execution</h2>
+ * <p>Tagged {@code integration} and excluded by default. Runs in the
+ * {@code persistence-rls-gate} CI job, which executes all community
+ * integration-tagged tests. Run locally with:
+ * <pre>mvn -pl exeris-kernel-community -DincludedGroups=integration -DexcludedGroups= test</pre>
+ * <p>Skipped automatically when Docker is not available.
+ *
+ * @since 0.5.0
+ */
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community: Graph churn-to-data ratio TCK (live Neo4j)")
+class CommunityGraphChurnRatioTckIT extends GraphChurnRatioTck {
+
+    private static final String ADMIN_PASSWORD = "testpass";
+
+    @Container
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>("neo4j:5-community")
+            .withAdminPassword(ADMIN_PASSWORD);
+
+    private static final GraphEdgeDescriptor FOLLOWS =
+            GraphEdgeDescriptor.create("Person", "FOLLOWS", "Person");
+
+    private final UUID startNode = UUID.randomUUID();
+
+    private GraphConfig neo4jConfig() {
+        return new GraphConfig("neo4j", "churn_ratio_test", false, false, false, false,
+                Map.of(
+                        "neo4j.uri", NEO4J.getBoltUrl(),
+                        "neo4j.user", "neo4j",
+                        "neo4j.password", ADMIN_PASSWORD
+                ));
+    }
+
+    @Override
+    protected GraphEngine createEngine() {
+        CommunityGraphEngine engine = new CommunityGraphEngine(neo4jConfig());
+        // Seed one edge startNode -> target so the measured 1-hop BFS returns a node.
+        try (GraphSession session = engine.openSession()) {
+            session.upsertEdge(FOLLOWS, startNode, UUID.randomUUID(), 1.0, "{}");
+        }
+        return engine;
+    }
+
+    @Override
+    protected UUID startNodeId() {
+        return startNode;
+    }
+
+    @Override
+    protected GraphEdgeDescriptor testEdge() {
+        return FOLLOWS;
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/graph/GraphChurnRatioTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/graph/GraphChurnRatioTck.java
@@ -141,10 +141,25 @@ public abstract class GraphChurnRatioTck {
         });
 
         // Sum allocated bytes from all eu.exeris.* allocation events.
-        // Direct getLong() call — fails fast if the JFR event schema changes or
-        // the "allocationSize" field is missing, preventing silent false negatives.
+        // jdk.ObjectAllocation{InNewTLAB,OutsideTLAB} carry "allocationSize" (exact
+        // bytes for that allocation); jdk.ObjectAllocationSample — the low-overhead
+        // sampler that dominates recordings on modern JDKs — carries no
+        // "allocationSize" but exposes "weight" (the sampler's estimate of total
+        // allocation pressure attributed to that event). Read whichever the event
+        // type provides; fail fast only if neither is present, which would signal a
+        // genuine JFR schema change rather than the expected sampler/TLAB difference.
         long allocatedBytes = result.exerisAllocations().stream()
-                .mapToLong(e -> e.getLong("allocationSize"))
+                .mapToLong(e -> {
+                    if (e.hasField("allocationSize")) {
+                        return e.getLong("allocationSize");
+                    }
+                    if (e.hasField("weight")) {
+                        return e.getLong("weight");
+                    }
+                    throw new AssertionError(
+                            "JFR allocation event has neither 'allocationSize' nor 'weight': "
+                                    + e.getEventType().getName());
+                })
                 .sum();
         double actualRatio    = dataBytes > 0
                 ? (double) allocatedBytes / dataBytes


### PR DESCRIPTION
## Sprint 7 · GRAPH-111 — Graph baseline production hardening

Closes the documented Graph TCK gap (`graph.md`): the two Graph contract TCKs had **zero Community-tier bindings**, so neither was gated in CI. Scope-disciplined per ROADMAP ("avoid broadening beyond practical paths already in use") — **no SPI/Core/`maven.yml` changes**, only bindings + the abstract-TCK bug fix they surfaced.

### Bindings
- **`CommunityExecutionGraphZeroAllocTckTest`** — unit, no DB. The single-arg `GraphSession.findShortestPath(src,tgt)` is fully in-process (distinct ids → `PathResult.notFound`), so the shortest-path hot path is measured in the main `build-and-verify` lane.
  - **Measured: 0 `eu.exeris.*` allocs/iter** (budget 10) over 1000 iters.
- **`CommunityGraphChurnRatioTckIT`** — `@Tag("integration")` + Neo4j Testcontainers, Cypher backend (built from an explicit client via `GraphConfig`, so no `ScopedValue`-bound persistence engine is needed to drive the traversal). Runs automatically in the existing `persistence-rls-gate`.
  - **Measured churn-to-data ratio ~10.2x** against the documented `<20x` Community SLO (baseline ~15x).

### Latent abstract-TCK bug fixed (surfaced by the binding)
`GraphChurnRatioTck` read `allocationSize` unconditionally, but on JDK 26 the recording is dominated by `jdk.ObjectAllocationSample` events, which carry no `allocationSize` (they expose `weight`) — the unconditional `getLong` threw `IllegalArgumentException` before any ratio could be computed. Never caught because the TCK had no concrete binding (exactly the gap GRAPH-111 closes). Fix reads `allocationSize` when present (TLAB), else `weight` (sampler), else fails fast on a genuine schema change. Generic to every binding (incl. Enterprise), so the abstract TCK is the correct home. No threshold/iteration/expected-bytes change.

### CI lanes (verified)
- ZeroAlloc → `build-and-verify` (default lane).
- ChurnRatio → `persistence-rls-gate` (runs all `exeris-kernel-community` `@Tag("integration")` tests).

Exit criterion "Graph baseline TCK passes in CI" met. Remaining Sprint 7 item: FLOW-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)