### PR TITLE
v0.8 Sprint 7 (FLOW-110): restart-under-load + outcome-correctness TCK suites

### DIFF
--- a/docs/subsystems/flow.md
+++ b/docs/subsystems/flow.md
@@ -22,6 +22,7 @@
 
 > **Note:** `FlowOutcome.COMPLETE` provides a direct short-circuit path: a step can return `COMPLETE` to transition the flow immediately to `FlowState.COMPLETED` without executing any remaining steps.
 > **Note:** `FlowBootstrapSelectedEvent` is emitted by `FlowBootstrap.loadWithProvider()` before `start()`. `FlowEngine.close()` emits `FlowEngineShutdownEvent` after runtime close and its bounded shutdown join, so the JFR payload reflects the stable shutdown counter view captured when `close()` completes. Promptly interrupted workers may still finalize snapshots afterward without changing that counter snapshot.
+> **Note (shutdown semantics):** `close()` is **not** an unbounded graceful drain — it interrupts in-flight flows and joins each worker within a bounded per-thread deadline (`CoreFlowRuntime.interruptAndJoinRunningThreads`, currently 5s/thread). PARKED checkpoints persisted before `close()` survive for restart recovery (see `AbstractSagaRecoveryTck.RestartUnderLoad`); in-flight RUNNING progress past the last checkpoint may be lost. **Known constraint:** the per-thread join is iterated sequentially, so the aggregate worst case is N×5s under wedged-interrupt, not 5s. A future `closeTimeoutNanos` config (aggregate-bounded join) is a candidate follow-up — not yet implemented. A durability/shutdown-cost JMH benchmark is deferred to `exeris-benchmarks` (backlog).
 
 ## Boundaries
 
@@ -178,10 +179,10 @@ The same defaults apply to the outbox-orchestrator pump and the RLS-interceptor 
 
 | TCK Suite | Module | Description |
 |:---------|:-------|:------------|
-| `AbstractFlowEngineTck` | `exeris-kernel-tck` | Full flow lifecycle: submit, run, park, wake, complete, compensate; JFR shutdown event (TCK-062), restart-aware semantics (TCK-063), saga timeout enforcement (DIST-303) |
+| `AbstractFlowEngineTck` | `exeris-kernel-tck` | Full flow lifecycle: submit, run, park, wake, complete, compensate; JFR shutdown event (TCK-062), restart-aware semantics (TCK-063), saga timeout enforcement (DIST-303), per-outcome transition correctness incl. thrown-exception FAIL path + `FAILED_ROLLEDBACK` terminal idempotency (FLOW-110, `OutcomeTransitions`) |
 | `AbstractFlowSchedulerTck` | `exeris-kernel-tck` | Scheduler contract: schedule, cancel, peek parked, drain |
 | `AbstractFlowChoreographyTck` | `exeris-kernel-tck` | Choreography mapper registration and event-driven wake |
-| `AbstractSagaRecoveryTck` | `exeris-kernel-tck` | Crash-recovery replay semantics from snapshot store |
+| `AbstractSagaRecoveryTck` | `exeris-kernel-tck` | Crash-recovery replay semantics from snapshot store; restart-under-load (N=16 concurrent parked instances survive force-close, resume, no re-exec/orphans, counter reset) (FLOW-110, `RestartUnderLoad`) |
 | `AbstractIdempotencyGuardTck` | `exeris-kernel-tck` | Step-level deduplication contract for `IdempotencyGuard` |
 | `FlowZeroAllocTck` | `exeris-kernel-tck` | Zero-allocation assertion on hot flow scheduling path |
 | `FlowCarrierPinningTck` | `exeris-kernel-tck` | Flow orchestration does not pin Virtual Thread carrier |

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/FlowEngine.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/flow/FlowEngine.java
@@ -27,7 +27,10 @@ import java.util.Collection;
  *   <li>{@link FlowProvider#createEngine} — created by the bootstrapper (no I/O, no threads).</li>
  *   <li>{@link #start()} — initialises all components (allocates resources, pre-warms slab pools).</li>
  *   <li>Runtime — subsystems call {@link #plans()}, {@link #scheduler()}, etc.</li>
- *   <li>{@link #close()} — graceful shutdown (drains pending flows, releases memory).</li>
+ *   <li>{@link #close()} — interrupts in-flight flows and joins them within a bounded
+ *       per-thread deadline, then releases memory. PARKED checkpoints persisted before
+ *       {@code close()} survive for restart recovery; in-flight RUNNING progress past the
+ *       last checkpoint may be lost.</li>
  * </ol>
  *
  * <h2>Tier Behaviour</h2>
@@ -132,7 +135,10 @@ public interface FlowEngine extends AutoCloseable {
     void start();
 
     /**
-     * Gracefully shuts down the engine, draining pending flows and releasing off-heap memory.
+     * Shuts down the engine: interrupts in-flight flows and joins each worker within a
+     * bounded per-thread deadline, then releases off-heap memory. This is not an unbounded
+     * graceful drain — PARKED checkpoints persisted before {@code close()} survive for
+     * restart recovery, but in-flight RUNNING progress past the last checkpoint may be lost.
      * Emits a {@code FlowEngineShutdownEvent} JFR event.
      */
     @Override

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowEngineTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowEngineTck.java
@@ -486,6 +486,219 @@ public abstract class AbstractFlowEngineTck {
         }
     }
 
+    // =========================================================================
+    // FLOW-110 — Outcome transition correctness (CONTINUE / COMPLETE / FAIL / throw)
+    // =========================================================================
+
+    /**
+     * FLOW-110: per-{@link FlowOutcome} transition correctness, asserted purely through
+     * observable engine state — {@code engine.stats()} lifecycle counters and step-execution
+     * counters. No new SPI: the resolved/unresolved classification uses a <b>test-local</b>
+     * helper ({@link #isResolved(FlowState)}), not an SPI predicate.
+     *
+     * <p>Coverage focuses on the genuinely new ground; ordering of compensation is already
+     * fixed by {@code AbstractSagaRecoveryTck.SagaCompensationTest} and is referenced, not
+     * duplicated. The two primary new obligations are:
+     * <ul>
+     *   <li>a <b>thrown {@link RuntimeException}</b> from a step (distinct from an explicit
+     *       {@link FlowOutcome#FAIL}) drives the same FAIL → COMPENSATING → FAILED_ROLLEDBACK
+     *       path and emits {@code eu.exeris.kernel.flow.StepFailed};</li>
+     *   <li><b>terminal idempotency for {@code FAILED_ROLLEDBACK}</b> — re-scheduling a
+     *       rolled-back context re-runs no step and does not leave the terminal state
+     *       (the existing terminal-idempotency test fences only {@code COMPLETED}).</li>
+     * </ul>
+     */
+    @Nested
+    @DisplayName("FlowEngine outcome-transition correctness")
+    class OutcomeTransitions {
+
+        private static final String STEP_FAILED_EVENT = "eu.exeris.kernel.flow.StepFailed";
+
+        @BeforeEach
+        void startEngine() {
+            engine.start();
+        }
+
+        /**
+         * Test-local terminal classification — NOT an SPI predicate. Unresolved states
+         * ({@code RUNNING}, {@code PARKED}, {@code COMPENSATING}) may still transition;
+         * resolved states ({@code COMPLETED}, {@code FAILED_ROLLEDBACK}) are terminal.
+         */
+        private boolean isResolved(FlowState state) {
+            return state == FlowState.COMPLETED || state == FlowState.FAILED_ROLLEDBACK;
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("CONTINUE advances to the next step (non-terminal mid-flight, then COMPLETED)")
+        void continueAdvancesToNextStep() {
+            AtomicInteger step0 = new AtomicInteger();
+            AtomicInteger step1 = new AtomicInteger();
+
+            FlowDefinition def = engine.plans().newDefinition("continue-flow")
+                    .step("first",  _ -> { step0.incrementAndGet(); return FlowOutcome.CONTINUE; }, null)
+                    .step("second", _ -> { step1.incrementAndGet(); return FlowOutcome.CONTINUE; }, null)
+                    .transition(0, 1)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            engine.scheduler().schedule(plan, TestFlowContexts.create(
+                    UUID.randomUUID().toString(), "continue-flow"));
+
+            assertThat(awaitCondition(() -> engine.stats().completedFlows() >= 1L, 5))
+                    .as("CONTINUE must advance step 0 → step 1 and reach COMPLETED")
+                    .isTrue();
+            assertThat(step0.get()).as("step 0 executes once").isEqualTo(1);
+            assertThat(step1.get())
+                    .as("CONTINUE from step 0 MUST advance to and execute step 1")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("COMPLETE short-circuits: immediate COMPLETED, downstream step never runs")
+        void completeShortCircuitsDownstream() {
+            AtomicInteger downstream = new AtomicInteger();
+
+            FlowDefinition def = engine.plans().newDefinition("complete-flow")
+                    .step("short-circuit", _ -> FlowOutcome.COMPLETE, null)
+                    .step("never-runs",    _ -> { downstream.incrementAndGet(); return FlowOutcome.CONTINUE; }, null)
+                    .transition(0, 1)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            engine.scheduler().schedule(plan, TestFlowContexts.create(
+                    UUID.randomUUID().toString(), "complete-flow"));
+
+            assertThat(awaitCondition(() -> engine.stats().completedFlows() >= 1L, 5))
+                    .as("COMPLETE MUST transition immediately to COMPLETED (flow.md:23 short-circuit)")
+                    .isTrue();
+            // Give any erroneous downstream dispatch time to manifest.
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200L));
+            assertThat(downstream.get())
+                    .as("COMPLETE MUST short-circuit — the downstream step counter MUST stay 0")
+                    .isZero();
+            assertThat(engine.stats().failedFlows())
+                    .as("COMPLETE is a success outcome — no failed flow recorded")
+                    .isZero();
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("FlowOutcome.FAIL drives FAILED_ROLLEDBACK via COMPENSATING (ordering: see SagaCompensationTest)")
+        void explicitFailDrivesRollback() {
+            AtomicInteger compensated = new AtomicInteger();
+
+            FlowDefinition def = engine.plans().newDefinition("explicit-fail-flow")
+                    .step("do",  _ -> FlowOutcome.CONTINUE,
+                            _ -> { compensated.incrementAndGet(); return FlowOutcome.CONTINUE; })
+                    .step("boom", _ -> FlowOutcome.FAIL, null)
+                    .transition(0, 1)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            engine.scheduler().schedule(plan, TestFlowContexts.create(
+                    UUID.randomUUID().toString(), "explicit-fail-flow"));
+
+            assertThat(awaitCondition(() -> engine.stats().failedFlows() >= 1L, 5))
+                    .as("Explicit FAIL MUST drive the flow to FAILED_ROLLEDBACK")
+                    .isTrue();
+            assertThat(compensated.get())
+                    .as("FAIL MUST run the upstream compensation (reverse ordering covered by "
+                            + "AbstractSagaRecoveryTck.SagaCompensationTest)")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("NEW: thrown RuntimeException (not FlowOutcome.FAIL) follows the FAIL path and emits StepFailed")
+        void thrownExceptionDrivesFailPathAndEmitsStepFailed() throws Exception {
+            CountDownLatch stepFailedReceived = new CountDownLatch(1);
+            AtomicInteger compensated = new AtomicInteger();
+
+            try (RecordingStream rs = new RecordingStream()) {
+                rs.enable(STEP_FAILED_EVENT);
+                rs.onEvent(STEP_FAILED_EVENT, _ -> stepFailedReceived.countDown());
+                rs.startAsync();
+
+                FlowDefinition def = engine.plans().newDefinition("thrown-exception-flow")
+                        .step("reserve", _ -> FlowOutcome.CONTINUE,
+                                _ -> { compensated.incrementAndGet(); return FlowOutcome.CONTINUE; })
+                        // A thrown RuntimeException, NOT an explicit FlowOutcome.FAIL.
+                        .step("explode", _ -> { throw new IllegalStateException("boom-from-step"); }, null)
+                        .transition(0, 1)
+                        .build();
+                FlowExecutionPlan plan = engine.plans().compile(def);
+
+                engine.scheduler().schedule(plan, TestFlowContexts.create(
+                        UUID.randomUUID().toString(), "thrown-exception-flow"));
+
+                assertThat(awaitCondition(() -> engine.stats().failedFlows() >= 1L, 5))
+                        .as("A thrown step exception MUST drive the flow to FAILED_ROLLEDBACK, "
+                                + "identically to an explicit FlowOutcome.FAIL")
+                        .isTrue();
+                assertThat(stepFailedReceived.await(3, TimeUnit.SECONDS))
+                        .as("A thrown step exception MUST emit eu.exeris.kernel.flow.StepFailed (flow.md:85)")
+                        .isTrue();
+                assertThat(compensated.get())
+                        .as("A thrown step exception MUST drive COMPENSATING — upstream compensation runs")
+                        .isEqualTo(1);
+            }
+        }
+
+        @Test
+        @Timeout(value = 10, unit = TimeUnit.SECONDS)
+        @DisplayName("NEW: terminal idempotency for FAILED_ROLLEDBACK — re-schedule re-runs nothing, stays terminal")
+        void failedRolledBackIsTerminalIdempotent() {
+            AtomicInteger stepExec    = new AtomicInteger();
+            AtomicInteger compExec    = new AtomicInteger();
+
+            FlowDefinition def = engine.plans().newDefinition("terminal-idem-fail-flow")
+                    .step("charge", _ -> {
+                        stepExec.incrementAndGet();
+                        return FlowOutcome.FAIL;
+                    }, _ -> { compExec.incrementAndGet(); return FlowOutcome.CONTINUE; })
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(def);
+            FlowContext ctx = TestFlowContexts.create(
+                    UUID.randomUUID().toString(), "terminal-idem-fail-flow");
+
+            engine.scheduler().schedule(plan, ctx);
+            assertThat(awaitCondition(() -> engine.stats().failedFlows() >= 1L, 5))
+                    .as("First schedule MUST reach FAILED_ROLLEDBACK")
+                    .isTrue();
+            int stepAfterFirst = stepExec.get();
+            int compAfterFirst = compExec.get();
+            long failedAfterFirst = engine.stats().failedFlows();
+
+            // Re-schedule the SAME terminal (FAILED_ROLLEDBACK) context — duplicate replay.
+            engine.scheduler().schedule(plan, ctx);
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(300L));
+
+            assertThat(stepExec.get())
+                    .as("Re-scheduling a FAILED_ROLLEDBACK context MUST NOT re-run the step")
+                    .isEqualTo(stepAfterFirst);
+            assertThat(compExec.get())
+                    .as("Re-scheduling a FAILED_ROLLEDBACK context MUST NOT re-run compensation")
+                    .isEqualTo(compAfterFirst);
+            assertThat(engine.stats().failedFlows())
+                    .as("Re-scheduling a terminal FAILED_ROLLEDBACK context MUST NOT mint a new failure "
+                            + "(state stays resolved/terminal)")
+                    .isEqualTo(failedAfterFirst);
+        }
+
+        @Test
+        @DisplayName("Test-local terminal classification helper — resolved vs unresolved (no SPI predicate)")
+        void terminalClassificationHelperIsTestLocal() {
+            // Documents the resolved/unresolved partition without leaking a predicate into the SPI.
+            assertThat(isResolved(FlowState.RUNNING)).isFalse();
+            assertThat(isResolved(FlowState.PARKED)).isFalse();
+            assertThat(isResolved(FlowState.COMPENSATING)).isFalse();
+            assertThat(isResolved(FlowState.COMPLETED)).isTrue();
+            assertThat(isResolved(FlowState.FAILED_ROLLEDBACK)).isTrue();
+        }
+    }
+
     private static boolean awaitCondition(BooleanSupplier condition, int timeoutSeconds) {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
         while (System.nanoTime() < deadline) {

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -98,6 +100,17 @@ public abstract class AbstractSagaRecoveryTck {
      * Must be the same store used by both {@link #createEngine()} and {@link #rebuildEngine()}.
      */
     protected abstract FlowSnapshotStore snapshotStore();
+
+    /**
+     * Number of concurrent flow instances driven through the restart-under-load
+     * scenario ({@link RestartUnderLoad}). Mirrors
+     * {@code AbstractFlowSchedulerTck.avalancheScheduleCount()} so bindings can tune N.
+     *
+     * <p>The default ({@value} ) MUST stay deterministic on a 2-vCPU runner — larger N
+     * is a benchmark, not a contract gate. Enterprise ring-buffer-bounded bindings may
+     * override down, never up for the always-on unit lane.
+     */
+    protected int restartLoadCount() { return 16; }
 
     // =========================================================================
     // Lifecycle
@@ -201,6 +214,182 @@ public abstract class AbstractSagaRecoveryTck {
             assertThat(step0Exec.get())
                     .as("step0 (validate) MUST NOT re-execute after resume — idempotency guard")
                     .isEqualTo(1);
+        }
+    }
+
+    // =========================================================================
+    // FLOW-110 — Restart under load (N concurrent contexts survive force-close)
+    // =========================================================================
+
+    /**
+     * FLOW-110: the mid-saga kill contract scaled to N concurrent instances on a single
+     * definition. Half are driven to {@link FlowState#PARKED} mid-flow, half are left
+     * {@link FlowState#RUNNING} at a no-op continue step at the moment of force-close.
+     *
+     * <p>The scenario asserts, in one batch:
+     * <ul>
+     *   <li>every PARKED snapshot survives {@code close()} and is loadable at its park step;</li>
+     *   <li>the rebuilt engine resumes every parked instance to {@link FlowState#COMPLETED};</li>
+     *   <li><b>idempotency fence</b> — the pre-park step does not re-execute after resume;</li>
+     *   <li><b>counter reset</b> — the rebuilt engine's {@code stats()} starts a fresh
+     *       generation at zero;</li>
+     *   <li><b>no orphans</b> — no generation-1 worker virtual thread survives into
+     *       generation-2 (the {@code close()} interrupt+join completed).</li>
+     * </ul>
+     *
+     * <p>N is bounded by {@link #restartLoadCount()} (default 16) and MUST stay deterministic
+     * on a 2-vCPU runner — TCK-064 deadlocked a transport stress gate under thread pressure
+     * on exactly such a runner; this gate keeps N small on purpose.
+     */
+    @Nested
+    @DisplayName("Restart under load — N concurrent flows survive force-close and resume")
+    class RestartUnderLoad {
+
+        private static final String DEF_NAME = "restart-under-load-saga";
+        private static final String WORKER_THREAD_PREFIX = "exeris-flow-";
+
+        @Test
+        @Timeout(value = 30, unit = TimeUnit.SECONDS)
+        @DisplayName("N parked snapshots survive close(); all resume to COMPLETED; no re-exec, no orphans, counters reset")
+        void parkedFleetSurvivesForceCloseAndResumes() {
+            int n = restartLoadCount();
+            assertThat(n).as("restartLoadCount() must be positive").isGreaterThan(0);
+
+            // Per-instance execution counters keyed by instance UUID-most.
+            java.util.Map<Long, AtomicInteger> step0Exec = new java.util.concurrent.ConcurrentHashMap<>();
+            java.util.Map<Long, AtomicInteger> step2Exec = new java.util.concurrent.ConcurrentHashMap<>();
+            // Instances selected to PARK at step 1 (the rest fall through CONTINUE at step 1).
+            java.util.Set<Long> parkSet = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+            FlowStepAction step0 = ctx -> {
+                step0Exec.computeIfAbsent(ctx.instanceIdMost(), _ -> new AtomicInteger()).incrementAndGet();
+                return FlowOutcome.CONTINUE;
+            };
+            // Step 1 is the divergence point: parked half PARKs, running half falls through.
+            FlowStepAction step1 = ctx ->
+                    parkSet.contains(ctx.instanceIdMost()) ? FlowOutcome.PARK : FlowOutcome.CONTINUE;
+            FlowStepAction step2 = ctx -> {
+                step2Exec.computeIfAbsent(ctx.instanceIdMost(), _ -> new AtomicInteger()).incrementAndGet();
+                return FlowOutcome.CONTINUE;
+            };
+
+            FlowDefinition def = engine.plans().newDefinition(DEF_NAME)
+                    .step("validate", step0, null)
+                    .step("gate",     step1, null)
+                    .step("ship",     step2, null)
+                    .transition(0, 1)
+                    .transition(1, 2)
+                    .build();
+
+            FlowExecutionPlan plan = engine.plans().compile(def);
+
+            List<FlowContext> all       = new ArrayList<>(n);
+            List<FlowContext> parked    = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                FlowContext ctx = TestFlowContexts.create(
+                        UUID.randomUUID().toString(), DEF_NAME);
+                all.add(ctx);
+                if ((i & 1) == 0) {          // ~half driven to PARK
+                    parkSet.add(ctx.instanceIdMost());
+                    parked.add(ctx);
+                }
+            }
+
+            for (FlowContext ctx : all) {
+                engine.scheduler().schedule(plan, ctx);
+            }
+
+            // Wait until the whole parked fleet has checkpointed.
+            assertThat(awaitCondition(() -> parked.stream().allMatch(this::parkedAtStep1), 10))
+                    .as("All %d PARKED instances MUST checkpoint at step 1 before force-close", parked.size())
+                    .isTrue();
+
+            // Force-close generation 1 — simulates JVM kill. The interrupt+bounded join
+            // must complete (no generation-1 worker survives into generation 2).
+            engine.close();
+            engine = null;
+
+            // (a) every parked snapshot survived and is at its park step.
+            for (FlowContext ctx : parked) {
+                Optional<FlowSnapshot> snap = loadSnapshot(ctx);
+                assertThat(snap)
+                        .as("PARKED checkpoint for %s MUST survive force-close", ctx.instanceIdMost())
+                        .isPresent();
+                assertThat(snap.get().currentStep())
+                        .as("Checkpoint for %s MUST be at step 1 (gate)", ctx.instanceIdMost())
+                        .isEqualTo(1);
+                assertThat(snap.get().state())
+                        .as("Checkpoint for %s MUST be PARKED", ctx.instanceIdMost())
+                        .isEqualTo(FlowState.PARKED);
+            }
+
+            // (e) no orphan generation-1 worker VT survives the close() join. close() joins
+            // synchronously, but VT teardown after join-return is racy by a few microseconds —
+            // assert it settles to zero rather than sampling a single instant.
+            assertThat(awaitCondition(() -> liveWorkerThreadCount() == 0L, 5))
+                    .as("No generation-1 flow worker VT (%s*) may survive close()", WORKER_THREAD_PREFIX)
+                    .isTrue();
+
+            // Rebuild generation 2 on the same store, recompile the definition, wake the fleet.
+            engine = rebuildEngine();
+            engine.start();
+
+            // (d) counter reset — a fresh generation starts at zero.
+            assertThat(engine.stats().completedFlows())
+                    .as("Rebuilt engine completedFlows MUST start at 0 (new lifecycle generation)")
+                    .isZero();
+            assertThat(engine.stats().activeFlows())
+                    .as("Rebuilt engine activeFlows MUST start at 0")
+                    .isZero();
+
+            engine.plans().compile(def);
+            for (FlowContext ctx : parked) {
+                engine.scheduler().wake(ctx);
+            }
+
+            // (b) every parked instance resumes and reaches COMPLETED. In unbounded-catalog
+            // mode (the TCK default) the durable snapshot is DELETED on complete(), so the
+            // observable terminal proof is twofold: the rebuilt-generation completedFlows
+            // counter reaches the parked fleet size AND the checkpoint disappears from the store.
+            int expectedCompleted = parked.size();
+            assertThat(awaitCondition(
+                    () -> engine.stats().completedFlows() >= expectedCompleted, 15))
+                    .as("Rebuilt engine MUST drive all %d resumed instances to COMPLETED", expectedCompleted)
+                    .isTrue();
+
+            for (FlowContext ctx : parked) {
+                assertThat(loadSnapshot(ctx))
+                        .as("COMPLETED checkpoint for %s MUST be reclaimed from the store on complete()",
+                                ctx.instanceIdMost())
+                        .isEmpty();
+            }
+
+            // (c) idempotency fence — step0 (pre-park) executed exactly once per parked
+            // instance across BOTH generations; the post-park step2 ran exactly once.
+            for (FlowContext ctx : parked) {
+                long key = ctx.instanceIdMost();
+                assertThat(step0Exec.getOrDefault(key, new AtomicInteger()).get())
+                        .as("step0 (validate) MUST NOT re-execute after resume for %s — idempotency fence", key)
+                        .isEqualTo(1);
+                assertThat(step2Exec.getOrDefault(key, new AtomicInteger()).get())
+                        .as("step2 (ship) MUST execute exactly once after wake for %s", key)
+                        .isEqualTo(1);
+            }
+        }
+
+        private boolean parkedAtStep1(FlowContext ctx) {
+            Optional<FlowSnapshot> snap = loadSnapshot(ctx);
+            return snap.isPresent()
+                    && snap.get().state() == FlowState.PARKED
+                    && snap.get().currentStep() == 1;
+        }
+
+        private static long liveWorkerThreadCount() {
+            return Thread.getAllStackTraces().keySet().stream()
+                    .filter(Thread::isAlive)
+                    .map(Thread::getName)
+                    .filter(name -> name != null && name.startsWith(WORKER_THREAD_PREFIX))
+                    .count();
         }
     }
 


### PR DESCRIPTION
## Sprint 7 · FLOW-110 — Flow Production Correctness Hardening

Closes the last open Sprint 7 item. **No SPI signature change**; reuses the existing TCK bases (no new orphan `Abstract*Tck`) so both suites inherit the live Core + Community bindings. Architect-framed: drain = interrupt + bounded per-thread join + clear (not graceful completion); deliverable is observable-behavior tests, not a contract change.

### Suites (both in the default `build-and-verify` unit lane, heap snapshot store — deterministic, no Testcontainers, no 2-vCPU stress hazard)
- **`AbstractSagaRecoveryTck.RestartUnderLoad`** (`@Nested`, N=`restartLoadCount()`=16): N concurrent contexts with a PARK step → `close()` mid-flight → `rebuildEngine().start()` → wake the parked set. Asserts PARKED snapshots survive close + resume to COMPLETED, pre-park **idempotency fence** (step exec == 1), **counter reset** on the new generation, and **no generation-1 worker VT survives** close (orphan-free at scale). `@Timeout(30s)`, N bounded for a 2-vCPU gate.
- **`AbstractFlowEngineTck.OutcomeTransitions`** (`@Nested`, 6 cases): CONTINUE advance; COMPLETE short-circuit (downstream counter stays 0); explicit `FlowOutcome.FAIL` rollback; **new** — a thrown `RuntimeException` (not `FAIL`) drives the same COMPENSATING→FAILED_ROLLEDBACK path + emits `StepFailed`; **new** — FAILED_ROLLEDBACK is terminal-idempotent. Classification via a test-local helper — no `FlowState` predicate added to the SPI.

### Verification
`@Nested` cases confirmed executing in **both** tiers (Core + Community: RestartUnderLoad=1 / OutcomeTransitions=6 each; no silent surefire drop — the GRAPH-111 trap avoided). PMD + Checkstyle clean.

### Doc-truth + recorded follow-ups
- `FlowEngine.close()` Javadoc reworded to match the interrupt + bounded per-thread join reality (was "graceful drain"; `flow.md:24` was already accurate).
- `flow.md` records the per-thread join's **N×5s aggregate** worst case as a known constraint, with a deferred `closeTimeoutNanos` (aggregate-bounded join) follow-up.
- Durability JMH benchmark **deferred** to `exeris-benchmarks` (benchmarks never become merge gates).

With this, **Sprint 7 is complete** (TCK-064 #155, GRAPH-111 #156, ADR-036/HTTP-138 #157, FLOW-110). Next: Sprint 8 release-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)