### PR TITLE
v0.8 Sprint 8: release-cut prep — notes + CHANGELOG + ROADMAP closeout + POM bump 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,63 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level.
 
-## [Unreleased] — 0.8.0-SNAPSHOT
+## [0.8.0] — 2026-06-03
+
+Production-correctness release. Completes the HTTP body-codec matrix (all four
+{request,response}×{encode,decode} quadrants now have SPI seams), introduces a
+tier-neutral `KernelWebClient` facade in Core, wires compile-time RBAC into the
+runtime decision path, and hardens the Transport / Flow / Graph paths with new
+TCK suites — plus a non-blocking reactor-driven client ingress fix that removes
+the virtual-thread carrier-pinning stall under constrained cores.
+
+See `docs/release/v0.8.0-release-notes.md` for the per-stream narrative, the full
+SPI surface delta, the gate posture, and the carry-over to v0.9. Per-PR detail is
+in the git log. Compare: `v0.7.1...v0.8.0`
+(`https://github.com/exeris-systems/exeris-kernel/compare/v0.7.1...v0.8.0`).
+
+### Added — HTTP body-codec matrix completion (Sprint 6/7, ADR-034 + ADR-036)
+
+- Client-side body codec SPI (ADR-034): `HttpRequestBodyEncoder` (outbound payload
+  encode) and `HttpResponseBodyDecoder` (inbound payload decode), each with a
+  descending-priority `*Registry` and an encode/decode `*Context` record, in
+  `eu.exeris.kernel.spi.http`. With the pre-existing `HttpResponseBodyEncoder`
+  (0.5.0, ADR-009) this closes three of the four codec quadrants.
+- `KernelWebClient` — tier-neutral typed HTTP-verb facade in **Core**
+  (`eu.exeris.kernel.core.http.client`), composing `HttpClientEngine` +
+  request-encoder/response-decoder registries + an `HttpClientRequestEnricher`.
+  Supersedes the ADR-026 `CommunityWebClient` placement so generated client code
+  no longer encodes tier identity in its symbols (ADR-034 §Decision). Its
+  `WebClientException` carries status predicates (`isNotFound`/`isClientError`/
+  `isServerError`/`isConflict`/`isValidationError`/…).
+- Server-side request body decode SPI (ADR-036, Sprint 7 HTTP-138): the fourth and
+  final quadrant — `HttpRequestBodyDecoder` + `HttpRequestBodyDecoderRegistry` +
+  `HttpRequestDecodingContext` (`method, path, headers, allocator`), mirroring the
+  response-decoder triplet. Community driver `CommunityJsonRequestBodyDecoder`
+  keeps Jackson behind the SPI; `JsonBodyCodecs` extracted to dedup the JSON
+  codec helpers. `AbstractHttpRequestBodyDecoderTck` + Community binding,
+  CI-bound. The lockstep `exeris-tooling` generator rewrite (TOOL-139) and the
+  Enterprise stub are snapshot-gated and land in a later consumption cycle.
+- `HttpClientRequestEnricher` SPI (ADR-032, Sprint 6) — implementation-blind
+  `enrich(HttpRequest)` functional interface with `noop()` / `chain(List)`
+  factories, for implicit outbound context propagation (tenant / principal
+  identity; future W3C `traceparent`). Immutable rebuild, zero body interaction,
+  CR/LF/NUL header-value rejection. `AbstractHttpClientRequestEnricherTck`.
+
+### Added — Diagnostics SPI decision (Sprint 6, ADR-033)
+
+- ADR-033 (`KernelDiagnostics` SPI — read-only out-of-process runtime
+  introspection) accepted, driven by RFC-2026-05-18, with the ADR-025 link stub.
+  The SPI itself (`eu.exeris.kernel.spi.diagnostics`), the Community provider and
+  the CLI artefact are scoped to v0.9 — only the decision record lands here.
+
+### Changed — HTTP/2 admission and h2c upgrade conformance (Sprint 5/6)
+
+- HTTP-112: RFC 7540 §5.1.1/§5.1.2 stream-identifier admission on the Community
+  HTTP/2 path (odd-ascending client stream IDs; `PROTOCOL_ERROR` on violations).
+- HTTP-137: cleartext h2c `Upgrade` path now consumes the connection preface,
+  applies the peer `HTTP2-Settings`, and synthesises the original request as
+  stream 1 per RFC 7540 §3.2 — `curl --http2` against a cleartext endpoint no
+  longer fails with `GOAWAY error=1`. Prior-knowledge / ALPN HTTP/2 unaffected.
 
 ### Fixed — Non-blocking client ingress (Sprint 7 TCK-064)
 
@@ -48,6 +104,54 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 - Configurable drain budget on `TransportCarrierPinningTck` (`exeris.tck.transport.drainTimeoutSeconds`) — accommodates constrained CI runners under thread pressure (default 5s for local boxes, override to 30s on 2-vCPU GitHub Actions).
 - New `transport-stress-gate` CI job (`.github/workflows/maven.yml`) bumps VT carrier pool to `parallelism=16 / maxPoolSize=64` — works around blocking-`recv()` pinning in the Panama FFM ingress pump (mid-test jstack diagnosis: client ingress VTs pin carriers on `recv()` syscall; default 2-vCPU CI carrier pool exhausts before all clients connect). Production fix (non-blocking `recv()` + selector wakeup) deferred to Sprint 6 transport hardening.
 - HotSpot `-Xlog:jfr+startup=off` in root POM — suppresses native log stream that bypassed Surefire IO redirect and surfaced as "Corrupted channel" warnings.
+
+### Changed — Production-correctness TCK hardening (Sprint 7 GRAPH-111 + FLOW-110)
+
+- GRAPH-111: bound `ExecutionGraphZeroAllocTck` and `GraphChurnRatioTck` with
+  Community bindings (`CommunityExecutionGraphZeroAllocTckTest`,
+  `CommunityGraphChurnRatioTckIT`); also fixed a latent JDK-26
+  `ObjectAllocationSample` defect in the abstract churn TCK. No SPI change.
+- FLOW-110: added restart-under-load and outcome-correctness (unresolved vs
+  failed vs compensated) Flow TCK suites and made them CI gates. No SPI change.
+
+### Performance — Async telemetry + Kafka decode (Sprint 3)
+
+- PERF-070: `AsyncTelemetrySink` ring migrated from `ArrayBlockingQueue` to an
+  Agrona `MpscArrayQueue` for lock-free multi-producer enqueue.
+- PERF-071: `KafkaEventCodec` zero-copy decode path (decode directly off the
+  consumer record buffer; no intermediate copy).
+
+### Observability — Save/publish JFR + event-queue overflow (Sprint 5)
+
+- JFR-091: publish-side JFR instrumentation plus a non-OCC save-side JFR event on
+  the persistence path.
+- EVENT-111: `CommunityEventQueueOverflowEvent` JFR (single-phase commit,
+  `@StackTrace(false)`) records bounded-queue overflow drops for operator
+  visibility.
+- DOC-090: HikariCP prepared-statement cache defaults documented + Javadoc.
+
+### Changed — Persistence admission tunability forward-port (Sprint 0b, ADR-035)
+
+- Forward-ported the ADR-035 admission-control recalibration from `main` (v0.7.1)
+  onto the 0.8.0 line: operator-tunable `persistence.admission.*` knobs via
+  `CommunityAdmissionConfig`, depth-allowance shedding, and the
+  `PersistenceEngine#canServiceRequest` Javadoc MUST→SHOULD relaxation. Also
+  forward-ported the VT-JFR single-phase-commit fix for the connection-acquire
+  event. See `docs/adr/ADR-035-persistence-admission-control-tunability.md`.
+
+### Internal — Quality / decomposition / CI (Sprint 1/3/6)
+
+- `GodClass` decompositions QA-010..018, one PR per class
+  (`CommunityPersistenceEngine`, `CommunityHttpRequestProcessor`,
+  `Slf4jTelemetrySink`, `NativeTcpCarrier` → `NativeTcpSocketBackend`/`Probe` +
+  `NativeTcpReactor`, `OutboxOrchestrator`, `CommunityHttpClientEngine`,
+  `NativeTcpStream`, `JdbcFlowSnapshotStore` codec extract,
+  `CommunityHttp2SessionProcessor` seams, `SubsystemOrchestrator` +
+  ADR-026 amendment record). Refactor-only — see git log for per-PR detail.
+- Supply chain: `kafka-clients` → 4.0.0 with license stanza (SEC-100/BUILD-101).
+- CI: SNAPSHOT publish to GitHub Packages; JaCoCo per-module + `-Pcoverage`
+  (C-P0-01); revived Kafka integration tests in CI (C-P0-02); plus CI hotfixes.
+
 ## [0.7.1] — 2026-05-30
 
 Patch release. Persistence admission-control recalibration (ADR-035) plus a JFR/virtual-thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 
 ## [0.8.0] — 2026-06-03
 
-Production-correctness release. Completes the HTTP body-codec matrix (all four
-{request,response}×{encode,decode} quadrants now have SPI seams), introduces a
+Production-correctness release. Completes the HTTP body-codec **SPI** matrix (all
+four {request,response}×{encode,decode} quadrants now have SPI seams; the
+server-side generator that consumes the new request decoder is a later cycle),
+introduces a
 tier-neutral `KernelWebClient` facade in Core, wires compile-time RBAC into the
 runtime decision path, and hardens the Transport / Flow / Graph paths with new
 TCK suites — plus a non-blocking reactor-driven client ingress fix that removes
@@ -20,7 +22,7 @@ SPI surface delta, the gate posture, and the carry-over to v0.9. Per-PR detail i
 in the git log. Compare: `v0.7.1...v0.8.0`
 (`https://github.com/exeris-systems/exeris-kernel/compare/v0.7.1...v0.8.0`).
 
-### Added — HTTP body-codec matrix completion (Sprint 6/7, ADR-034 + ADR-036)
+### Added — HTTP body-codec SPI matrix — fourth quadrant (Sprint 6/7, ADR-034 + ADR-036)
 
 - Client-side body codec SPI (ADR-034): `HttpRequestBodyEncoder` (outbound payload
   encode) and `HttpResponseBodyDecoder` (inbound payload decode), each with a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -791,6 +791,8 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 
 **Merge Gate:** Each PR closes at minimum one `GodClass` suppression; cumulative effect must move the main-source suppression count toward the ≤ 100 target. Re-evaluate the target at v0.8 close.
 
+**Status (v0.8):** **DELIVERED** in Sprint 1 / Sprint 3 — all nine decompositions landed (QA-010 `CommunityPersistenceEngine`, QA-011 `CommunityHttpRequestProcessor`, QA-012 `Slf4jTelemetrySink`, QA-013 `NativeTcpCarrier` → `NativeTcpSocketBackend`/`NativeTcpProbe` + `NativeTcpReactor`, QA-014 `OutboxOrchestrator`, QA-015 `CommunityHttpClientEngine`, QA-016 `NativeTcpStream`, QA-017 `JdbcFlowSnapshotStore` codec extract, QA-018 `CommunityHttp2SessionProcessor` four seams + `SubsystemOrchestrator` with ADR-026 amendment record). Refactor-only; per-PR detail in git log.
+
 ---
 
 ### Runtime: Hot-Path Collections Watch-Items (Sprint 8e carry-over)
@@ -807,6 +809,8 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 
 **Merge Gate:** Any adoption must remain Community-internal, keep SPI/Core contracts unchanged, and show measurable benefit under representative profiling — same gate as the parent "Runtime: Hot-Path Collections Review" entry.
 
+**Status (v0.8):** **CARRIED** — each watch-item is gated on a measured profile signal that did not materialise in v0.8 (do-not-implement-speculatively). Re-evaluated at v0.9. (PERF-072 ingress-read elision below is the one allocation win that *was* signalled and landed.)
+
 ---
 
 ### Transport: Zero-Allocation Ingress Read — Elide Per-Read Segment Slice (Sprint 6 PERF-072)
@@ -818,6 +822,8 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 **Resolution:** Guard the slice so it materialises only for a genuine sub-range: `MemorySegment dst = maxBytes == target.byteSize() ? target : target.asSlice(0, maxBytes)`, passing `dst` to the `recv` downcall (length is already a separate argument, so the full segment is safe) and to the NIO-fallback `asByteBuffer()`. The guard is also semantically required on the NIO path — a `ByteBuffer` over the full segment would have `capacity == byteSize`, letting `channel.read()` overrun `maxBytes`; eliding only on equality keeps behaviour identical. Egress `send`/write paths pass a real `(offset, length)` sub-range and are intentionally left unchanged.
 
 **Merge Gate:** Community-internal only — no SPI/Core contract change, ownership and loaned-buffer lifecycle unchanged. Existing transport read/write coverage stays green (`NativeTcpClientServerE2eIntegrationTest`, stream wakeup tests). Validation: a re-run of the constrained `entity-read-by-id` JFR shows `NativeMemorySegmentImpl`/`asSliceNoCheck`/`dup` samples under the ingress read path drop to ~0; a JMH `-prof gc` harness over `readIngress` asserts `gc.alloc.rate.norm ≈ 0 B/op` on the seam-read path.
+
+**Status (v0.8):** **DELIVERED** in Sprint 6 (PERF-072) — the full-slab `asSlice` wrapper is elided on the ingress read path; egress sub-range slices unchanged. Community-internal, no SPI/Core change.
 
 ---
 
@@ -831,6 +837,8 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 
 **Merge Gate:** Bootstrap regression tests pass with autoload; zero-allocation TCK continues to pass on the wired path.
 
+**Status (v0.8):** **DELIVERED** in Sprint 4 (SEC-080, ADR-014 §3) — `GeneratedRoleRegistryLoader` resolves the APT-generated `RoleCheckRegistry` reflectively (FQN, no compile edge), binds its accessors to `MethodHandle`s once at bootstrap as a `RoleRegistry`, fail-closed empty singleton when no `@RequiresRole` is compiled. `SecurityInterceptor` populates `roleMask` via a Core-internal `MaskedPrincipal`; `RoleRegistryLoaded` JFR added. **Descoped:** kernel-edge URL→`methodId` enforcement is an `exeris-tooling` codegen concern (dispatcher is path/scope-based), not `CommunityHttpRequestDispatcher`. New TCKs: `AbstractGeneratedRoleRegistryLoaderTck` + `AbstractRoleMaskPopulationTck`.
+
 ---
 
 ### HTTP/2: Community Lifecycle Hardening
@@ -842,6 +850,8 @@ See also: [Events Subsystem](./subsystems/events.md) — Multi-Provider Strategy
 **Resolution:** Harden stream table ownership, stream lifecycle transitions, GOAWAY/drain behavior, and concurrency controls on the Community transport path.
 
 **Merge Gate:** Lifecycle and shutdown/drain behavior validated by regression/integration tests.
+
+**Status (v0.8):** **PARTIAL** — RFC 7540 §5.1.1/§5.1.2 stream-identifier admission landed in Sprint 5 (HTTP-112, `Http2SessionContextAdmissionTest`) and the h2c upgrade path was fixed (see next entry). Deeper GOAWAY/drain ownership and concurrency-control hardening remain ongoing.
 
 ---
 
@@ -864,6 +874,11 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 3. **TCK — adversarial h2c upgrade scenarios.** Extend `AbstractHttpServerEngineTck` (or `AbstractHttpProviderTck` if more appropriate) with a parameterized h2c upgrade scenario that performs the full `curl --http2`-equivalent flow over an in-process socket: HTTP/1.1 `POST` with `Upgrade: h2c`, `Connection: Upgrade`, `HTTP2-Settings: <base64url>`; expect `101 Switching Protocols`; send preface + (no further frames, the request body already crossed in HTTP/1.1 form); expect response on stream 1 carrying `END_STREAM`. Additional adversarial cases: corrupted preface (`PRI * HTTP/9.9...`), missing preface (TCP close before 24 bytes received), malformed `HTTP2-Settings` payload (odd byte length, unknown setting IDs handled per the existing `Http2SessionContext` rules).
 
 **Merge Gate:** `curl --http2 http://localhost:<port>/...` against a `CommunityHttpServerEngine` returns the expected response (no `GOAWAY error=1`); h2c upgrade TCK scenarios green (positive + adversarial); HTTP/2 prior-knowledge tests remain green (no regression on the unaffected path); stream identifier accounting per RFC 7540 §5.1.1 verified via TCK assertion that stream 3 sent by the client immediately after upgrade is accepted while stream 2 is rejected with `PROTOCOL_ERROR`.
+
+**Status (v0.8):** **DELIVERED** in Sprint 6 (HTTP-137) — `CommunityHttpH2cUpgradeDetector` extracts `HTTP2-Settings`; the processor consumes the connection preface, applies peer SETTINGS, and synthesises the original request as stream 1 per RFC 7540 §3.2. Cleartext `curl --http2` no longer fails with `GOAWAY error=1`; prior-knowledge / ALPN paths unaffected.
+
+---
+
 ### Persistence: Latency-Keyed Admission Fairness Gate (ADR-035 follow-up)
 
 **Gap:** ADR-035 recalibrated Community admission so a full pool sheds only once `pendingAcquires > ceil(maxPool × queueDepthAllowanceRatio)` (default ratio `8.0`). Because *all* shed branches in `CommunityPersistenceAdmissionController` — including `REJECT_GUARD_BAND_FAIRNESS` and the early-guard-band check — are gated behind that single queue-depth allowance, the fairness/guard-band machinery (`FairnessTracker.indicatesAdmissionStress`, `shouldRejectEarlyInGuardBand`) is effectively dormant under the default ratio: it only re-arms when an operator lowers `queueDepthAllowanceRatio`, which *also* sheds the small-pool burst the recalibration exists to admit. The two shed signals (depth-based backpressure and fairness) cannot be tuned apart through one scalar knob. See ADR-035 §Consequences ("Fairness/guard-band machinery is intentionally dormant under the default ratio").
@@ -873,6 +888,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 **Resolution:** Gate the fairness/guard-band shed path on an observed wait-time signal (`queueWaitP95`, already computed by `FairnessTracker.computeSnapshot()` and emitted on `AdmissionDecisionEvent`) instead of on `queueDepthAllowance`. This lets sustained fairness inversion shed independently of `queueDepthAllowanceRatio`, so depth-based small-pool availability and latency-based fairness become separately tunable. Keep the decision non-blocking and zero-allocation on the hot path; expose any new threshold as a `persistence.admission.*` key consistent with the ADR-035 tunable surface.
 
 **Merge Gate:** Community admission tests prove fairness sheds under sustained `queueWaitP95` stress while the default `queueDepthAllowanceRatio=8.0` still admits a transient small-pool burst (the constrained-benchmark regression guard stays green). No SPI field added — The Wall unchanged. Enterprise binding obligation per ADR-035 still applies.
+
+**Status (v0.8):** **CARRIED TO v0.9** — Sprint 0b forward-ported the ADR-035 admission **tunability** (`persistence.admission.*`, depth-allowance shedding) from v0.7.1, but the latency-keyed (`queueWaitP95`) fairness/guard-band shed gate described here is not yet implemented; it remains a v0.9 follow-up.
 
 ---
 
@@ -886,6 +903,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 
 **Merge Gate:** Restart/recovery and outcome correctness suites become mandatory CI gates.
 
+**Status (v0.8):** **DELIVERED** in Sprint 7 (FLOW-110) — restart-under-load and outcome-correctness (unresolved vs failed vs compensated) Flow TCK suites added and promoted to mandatory CI gates. No SPI change. Follow-up: the `closeTimeoutNanos` aggregate-bound drain-semantics refinement carries to v0.9.
+
 ---
 
 ### Events: Backpressure and Projection Confidence
@@ -898,6 +917,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 
 **Merge Gate:** Backpressure and projection consistency tests pass at community target load.
 
+**Status (v0.8):** **PARTIAL** — Sprint 5 added bounded-queue overflow visibility (EVENT-111 `CommunityEventQueueOverflowEvent` JFR) and Sprint 6 made the Kafka integration tests a CI gate (C-P0-02). The broader projection-consistency / retry / dead-letter-visibility-under-load hardening remains open and carries forward.
+
 ---
 
 ### Graph: Baseline Production Hardening
@@ -909,6 +930,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 **Resolution:** Prioritize baseline driver stability, correctness tests for exercised PGQ/Bolt paths, resource-usage visibility, and CI coverage for real product scenarios. Avoid broadening Graph scope beyond practical paths already in use.
 
 **Merge Gate:** Baseline Graph correctness/stability tests pass in CI.
+
+**Status (v0.8):** **DELIVERED** in Sprint 7 (GRAPH-111) — `ExecutionGraphZeroAllocTck` and `GraphChurnRatioTck` bound with Community bindings (`CommunityExecutionGraphZeroAllocTckTest`, `CommunityGraphChurnRatioTckIT`); fixed a latent JDK-26 `ObjectAllocationSample` defect in the abstract churn TCK. No SPI change.
 
 ---
 
@@ -923,6 +946,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 - **TOOL-139 `KernelHandlerGenerator` rewrite (cross-repo `exeris-tooling`).** Replace the inline `MAPPER.readValue` path in `buildParseBody` with `requestBodyDecoderRegistry.resolve(type, contentType).decode(body, type, ctx)`, dropping the static Jackson field + `JacksonException` constant from emitted code and letting the decoder consume the off-heap segment directly (eliminates the `byte[] + String` double-allocation on server ingress). Lockstep — a generated-output contract change; lands as a separate `exeris-tooling` PR sequenced after kernel-side SPI publication. Plus e2e fixture update + `docs/adr/ADR-036.link.md` stub. `exeris-kernel-enterprise` gets a one-line `ADR-036.link.md` stub.
 
 **Merge Gate:** SPI triplet + `CommunityJsonRequestBodyDecoder` + `AbstractHttpRequestBodyDecoderTck` Community binding green and CI-bound; ADR-036 reserved in `~/exeris-systems/exeris-docs/adr-index.md` before content (done 2026-06-03); `exeris-tooling` generator PR opened and reviewed (does not block the kernel merge — the generator update lands in a subsequent kernel-snapshot consumption cycle, per the Sprint 6 HTTP-130..136 / TOOL-136 precedent).
+
+**Status (v0.8):** **DELIVERED** in Sprint 7 (HTTP-138, ADR-036) — `HttpRequestBodyDecoder` + `HttpRequestBodyDecoderRegistry` + `HttpRequestDecodingContext` landed in `eu.exeris.kernel.spi.http`, completing the fourth (and final) body-codec quadrant. Community driver `CommunityJsonRequestBodyDecoder` keeps Jackson behind the SPI; `JsonBodyCodecs` extracted for dedup. `AbstractHttpRequestBodyDecoderTck` + Community binding CI-bound. The Wall held. **Lockstep CARRIED TO v0.9 (snapshot-gated):** the `exeris-tooling` `KernelHandlerGenerator` rewrite (TOOL-139, #67) and the `exeris-kernel-enterprise` ADR-036 stub (#30) consume the published SPI in a later snapshot cycle.
 
 ---
 
@@ -1003,6 +1028,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 - **TOOL-136 `KernelClientGenerator` emission update (cross-repo `exeris-tooling`).** Update `exeris-tooling/exeris-codegen-java/src/main/java/eu/exeris/tooling/codegen/java/kernel/KernelClientGenerator.java` to emit `UriTemplate.of("/api/v1/widgets/{id}").resolve("id", id)` in place of `BASE_PATH + "/" + id` (lines 107, 173, 185 in current source) and `QueryParams.empty().add("page", page).add("size", size).render()` in place of `BASE_PATH + "?page=" + page + "&size=" + size` (line 131). Generator's `WEB_CLIENT` `ClassName` constant already migrated to `CommunityWebClient` via ADR-026 amendment; this change pins the emitted code to the new SPI primitives without touching that import. Lands as a separate PR in `exeris-tooling`, sequenced after the kernel-side SPI publication.
 
 **Merge Gate:** All three new SPI primitives have abstract TCKs + Community bindings green; `CommunityWebClientIntegrationTest` covers four-arg-constructor with enricher; ADR-032 registered in `~/exeris-systems/exeris-docs/adr-index.md` before content lands; `exeris-tooling/KernelClientGenerator` PR opened and reviewed (does not block kernel merge — generator update lands in a subsequent kernel-snapshot consumption cycle).
+
+**Status (v0.8):** **PARTIAL** — Delivered in Sprint 6: HTTP-133 `HttpClientRequestEnricher` SPI + `AbstractHttpClientRequestEnricherTck` + **ADR-032**; HTTP-132 `WebClientException` status predicates (`isNotFound`/`isClientError`/`isServerError`/`isConflict`/`isValidationError`/…). The verb facade itself was re-placed by **ADR-034** as the tier-neutral `KernelWebClient` in **Core** (`eu.exeris.kernel.core.http.client`), superseding the ADR-026 `CommunityWebClient` placement, and ships alongside the client-side body-codec SPI (`HttpRequestBodyEncoder` / `HttpResponseBodyDecoder` + registries + contexts). **CARRIED TO v0.9:** HTTP-130 `UriTemplate` SPI and HTTP-131 `QueryParams` SPI were **not** implemented (no such types in the source tree), and the HTTP-134 `CommunityKernelContextEnricher` default-bundled enricher did not land (only the enricher SPI + TCK). The TOOL-136 generator emission update follows the same snapshot-gated lockstep.
 
 ---
 
@@ -1088,6 +1115,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 
 **Merge Gate:** `mvn verify` in the default CI job fails when any module drops below its declared threshold; per-module XML report + aggregate XML are uploaded as CI artifacts; thresholds documented in `docs/quality/coverage-gates.md`.
 
+**Status (v0.8):** **DELIVERED** in Sprint 6 (Coverage C-P0-01) — `-Pcoverage` activates the JaCoCo agent + per-module `<check>` rule enforcement in the default `build-and-verify` job (`.github/workflows/maven.yml`); per-module LINE floors live in each module's `<jacoco.line.minimum>`.
+
 ---
 
 ### Test Coverage: Kafka Integration CI Gate (v0.8 Fast-Win #2)
@@ -1100,6 +1129,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 
 **Merge Gate:** Job is required on PR merge for `exeris-kernel-community-kafka` paths; first green run includes all 3 Kafka ITs visible in CI logs; broken-choreography canary regression (simulated by reverting a `CrossEngineFlow` snapshot store change) fails the gate as expected.
 
+**Status (v0.8):** **DELIVERED** in Sprint 6 (Coverage C-P0-02) — `kafka-integration-gate` job added to `.github/workflows/maven.yml`, mirroring `persistence-rls-gate`; runs all three `exeris-kernel-community-kafka` `@Tag("integration")` Testcontainers tests and uploads JFR recordings.
+
 ---
 
 ### Test Coverage: Core Integration CI Gate / OpenSSL TLS Loopback IT in Default CI (v0.8 Fast-Win #3)
@@ -1111,6 +1142,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 **Resolution:** Add a `core-integration-gate` GitHub Actions job that mirrors `persistence-rls-gate` for `exeris-kernel-core` module — `mvn -pl exeris-kernel-core -DincludedGroups=integration -DexcludedGroups= test`. Linux-only via the existing `@EnabledOnOs(LINUX)` + `@EnabledIfSystemProperty(named="exeris.tls.testOpenssl", matches="true")` (or equivalent) gating already present on the test class. Upload JFR recordings to artifact retention same as the other gates. Alternative implementation (no new job): drop the `@Tag("integration")` tag from `OffHeapTlsEngineLoopbackIT` and rely on the existing environment-gate annotations to skip it where OpenSSL is unavailable — this lets the existing `build-and-verify` job pick it up.
 
 **Merge Gate:** OpenSSL TLS 1.3 loopback test runs and passes on every PR; a deliberate `SSL_VERIFY_PEER` regression (canary revert) fails the gate; JFR `TlsHandshakeEvent` and `TlsBindingEvent` records are present in the uploaded artifact.
+
+**Status (v0.8):** **CARRIED TO v0.9** — no `core-integration-gate` job exists in `.github/workflows/maven.yml` and `OffHeapTlsEngineLoopbackIT` still carries `@Tag("integration")`, so the OpenSSL TLS 1.3 loopback IT runs nowhere in default CI. Fast-Win #3 not yet absorbed.
 
 ---
 

--- a/docs/release/v0.8.0-release-notes.md
+++ b/docs/release/v0.8.0-release-notes.md
@@ -136,12 +136,12 @@ There is no breaking-change framing. v0.8 is an **additive minor** in the pre-1.
 
 ## 9. Release-cut checklist (to verify before tagging)
 
-Operator-side steps to complete *after* this PR merges into `development/0.8.0` and before the cut into `main`. The bracketed marker notes whether this Sprint-8 documentation PR satisfies the step.
+Operator-side steps to complete *after* this PR merges into `development/0.8.0` and before the cut into `main`. The bracketed marker notes whether this Sprint-8 release-cut PR (docs + POM bump) satisfies the step.
 
 1. **[this PR]** `CHANGELOG.md` `[Unreleased] — 0.8.0-SNAPSHOT` heading renamed to `[0.8.0] — 2026-06-03` with the notable/observable entries grouped under Keep-a-Changelog headers and the per-PR detail folded.
 2. **[this PR]** `docs/release/v0.8.0-release-notes.md` authored (this document).
 3. **[this PR]** `docs/ROADMAP.md` v0.8 entries annotated with `**Status (v0.8):**` (DELIVERED / PARTIAL / CARRIED TO v0.9).
-4. **[deferred — author]** Bump root `pom.xml` and all module poms from `0.8.0-SNAPSHOT` to `0.8.0` across the 10 modules for the tag commit; restore `0.9.0-SNAPSHOT` on `development/0.9.0` after the tag. **Not touched by this docs-only PR.**
+4. **[this PR]** Bump root `pom.xml` and all module poms from `0.8.0-SNAPSHOT` to `0.8.0` across the 10 modules — done here (full `mvn install -DskipTests` green at `0.8.0`). *Post-tag (deferred — author):* restore the next `-SNAPSHOT` (`0.9.0-SNAPSHOT` or `0.8.1-SNAPSHOT`) on the trunk after the tag.
 5. **[deferred — author]** Verify branch protection on `main` requires status checks for build, test, PMD/Checkstyle, TCK aggregate, plus the new coverage / Kafka-IT gates.
 6. **[deferred — author]** Verify the CI matrix passes on the `development/0.8.0` tip after Sprint 8 merges (full reactor, including Testcontainers + Kafka gates).
 7. **[deferred — author]** Open the release PR `development/0.8.0` → `main`; tag `v0.8.0` on the merge commit.

--- a/docs/release/v0.8.0-release-notes.md
+++ b/docs/release/v0.8.0-release-notes.md
@@ -3,13 +3,13 @@
 > Status: **release-readiness candidate** — Sprint 8 closeout pending merge to `main`.
 > Authoring date: 2026-06-03. Author: Arkadiusz Przychocki.
 > Visibility: **public**.
-> Companion docs: `CHANGELOG.md` (terse summary); `docs/ROADMAP.md` (per-gap status); `docs/local-only/v0.8-sprint-and-implementation-map.md` (LOCAL/untracked execution plan).
+> Companion docs: `CHANGELOG.md` (terse summary); `docs/ROADMAP.md` (per-gap status).
 
 ## 1. Headline
 
 v0.8.0 is the **production-correctness** release. Three architectural arcs land together:
 
-1. **The HTTP body-codec matrix is completed.** The codec surface is a 2×2 matrix — {request, response} × {encode, decode}. Three quadrants already had SPI seams (`HttpResponseBodyEncoder` since 0.5.0; `HttpRequestBodyEncoder` + `HttpResponseBodyDecoder` from the client-side ADR-034 work). v0.8 adds the fourth — server-side request-body **decode** (`HttpRequestBodyDecoder`, ADR-036) — and introduces the tier-neutral `KernelWebClient` facade in Core so generated client code no longer encodes tier identity in its symbols.
+1. **The HTTP body-codec matrix gains its fourth SPI seam.** The codec surface is a 2×2 matrix — {request, response} × {encode, decode}. Three quadrants already had SPI seams (`HttpResponseBodyEncoder` since 0.5.0; `HttpRequestBodyEncoder` + `HttpResponseBodyDecoder` from the client-side ADR-034 work). v0.8 adds the fourth — server-side request-body **decode** (`HttpRequestBodyDecoder`, ADR-036) — as a published SPI contract: the seam, the `CommunityJsonRequestBodyDecoder` driver, the registry, and the abstract TCK all ship in 0.8.0. The *consumer* side — the `exeris-tooling` handler generator rewritten to resolve the registry instead of inlining Jackson (TOOL-139) — is **not** in this release; it consumes the published seam in a later snapshot cycle, so generated handlers in 0.8.0 keep their existing inline-Jackson decode until then (see §10). v0.8 also introduces the tier-neutral `KernelWebClient` facade in Core (ADR-034) so generated *client* code no longer encodes tier identity in its symbols.
 2. **Compile-time RBAC becomes a live runtime decision.** The ADR-014 `@RequiresRole` machinery shipped in v0.7 as compile-time-only scaffolding; v0.8 wires the APT-generated registry into the runtime so the enforcer's inputs are populated (`GeneratedRoleRegistryLoader` + `roleMask` population), fail-closed by construction.
 3. **Transport / Flow / Graph move from exploratory evidence to production-candidate confidence.** A non-blocking reactor-driven client ingress fix removes the virtual-thread carrier-pinning stall under constrained cores (TCK-064); Graph and Flow gain mandatory TCK gates (GRAPH-111, FLOW-110).
 
@@ -69,7 +69,7 @@ The single source of truth for individual deliverables is `CHANGELOG.md` §[0.8.
 
 This is the most important section for downstream consumers. The following SPI types or members are **new** in v0.8. All are implementation-blind by design; bindings are Community where applicable, Enterprise obligations are out-of-repo. **The Wall held throughout** — no Jackson, no driver, and no native types appear in any SPI signature (codec drivers keep `ObjectMapper` confined to `exeris-kernel-community`).
 
-HTTP body-codec matrix — now **complete** (`eu.exeris.kernel.spi.http`):
+HTTP body-codec matrix — the **SPI surface** now spans all four quadrants (`eu.exeris.kernel.spi.http`). (Seams + drivers + TCKs are published here; the `exeris-tooling` generator that consumes the new server-side decoder is a later snapshot cycle — see §10.):
 
 - `HttpRequestBodyEncoder` + `HttpRequestBodyEncoderRegistry` + `HttpRequestEncodingContext` (ADR-034, client sends).
 - `HttpResponseBodyDecoder` + `HttpResponseBodyDecoderRegistry` + `HttpResponseDecodingContext` (ADR-034, client reads).
@@ -113,7 +113,7 @@ New JFR event classes (Core/Community; `@StackTrace(false)` + single-phase-commi
 
 - **TCK hardening:** GRAPH-111 (`ExecutionGraphZeroAllocTck`, `GraphChurnRatioTck`) and FLOW-110 (restart-under-load, outcome-correctness) suites bound with Community bindings and promoted to mandatory CI gates. The TCK-064 carrier-pinning + transport-stress TCKs now pass at the **default** VT carrier pool and the strict default drain budget (CI workarounds removed).
 - **Coverage gates:** JaCoCo per-module wired with `-Pcoverage` enabled in the default CI path (C-P0-01); Kafka integration tests revived in CI (C-P0-02).
-- **Codec matrix completeness:** all four `{request,response}×{encode,decode}` quadrants have an SPI seam + Community binding + abstract TCK.
+- **Codec matrix — SPI coverage:** all four `{request,response}×{encode,decode}` quadrants have an SPI seam + Community binding + abstract TCK in 0.8.0. End-to-end consumption of the new server-side decoder by generated handlers awaits the `exeris-tooling` TOOL-139 rewrite (not in this release — §10).
 - **The Wall:** no Jackson/driver/native types in any SPI signature across the new codec and enricher surface — verified by inspection; ArchUnit posture per the standing repo audit (note: the broader ArchTest gate hardening is a separate v0.8 documentation-truthfulness / CI item, not claimed closed here).
 - **Branch protection / CI gates verification:** see §9 — tracked as a release-cut step.
 
@@ -127,8 +127,8 @@ Rationale: every sprint in the v0.8 plan landed on the `development/0.8.0` line 
 
 For any **internal** consumer of the open-core SPI (there are no external consumers at TRL-3):
 
-- **HTTP codec registries:** providers may now register request/response body encoders/decoders via the new registries; existing handlers that do not register one are unaffected (resolution returns empty and the generated handler keeps its current status mapping — decode failure → `400`, unresolved decoder → `5xx`; no `415` negotiation yet).
-- **`KernelWebClient` (not `CommunityWebClient`):** code that referenced the ADR-026 `CommunityWebClient` should move to `eu.exeris.kernel.core.http.client.KernelWebClient`. Generated client code is regenerated by `exeris-tooling`; the tier symbol no longer appears in emitted user code.
+- **HTTP codec registries:** the request/response body encoder/decoder registries + the server-side `HttpRequestBodyDecoder` seam are now available for providers to register against. **No behaviour change for existing handlers in 0.8.0:** the generated handlers shipped/regenerated against this release still decode request bodies inline (Jackson, decode failure → `400`) and do **not** yet resolve the request-decoder registry — that consumption arrives with the `exeris-tooling` TOOL-139 rewrite (the registry-resolved status mapping it introduces — decode failure → `400`, unresolved decoder → `5xx`, no `415` negotiation — is documented in ADR-036 §2 but is **not** the behaviour of 0.8.0-generated handlers).
+- **`KernelWebClient` (not `CommunityWebClient`):** code that referenced the ADR-026 `CommunityWebClient` should move to `eu.exeris.kernel.core.http.client.KernelWebClient`. The `exeris-tooling` *client* generator FQN swap (ADR-034 / TOOL-136) already landed, so regenerated client code carries `KernelWebClient` and the tier symbol no longer appears in emitted user code.
 - **`@RequiresRole`:** still opt-in. Methods without the annotation take no behaviour change. When **any** `@RequiresRole` is compiled, the runtime now populates `roleMask` and enforces it; when none is compiled, the fail-closed empty registry leaves behaviour unchanged.
 - **Admission tunables:** `persistence.admission.queueDepthAllowanceRatio` defaults to `8.0`; set `0` to restore strict pre-035 shedding.
 
@@ -152,7 +152,7 @@ Operator-side steps to complete *after* this PR merges into `development/0.8.0` 
 
 Tracked in `docs/ROADMAP.md` under "Known Gaps / Future Work planned for v0.9":
 
-- **Lockstep tooling / enterprise (snapshot-gated):** TOOL-139 — the `exeris-tooling/KernelHandlerGenerator` rewrite consuming `HttpRequestBodyDecoder` (`exeris-tooling` PR #67); the `exeris-kernel-enterprise` ADR-036 link-stub / overlay (#30). Both consume the published 0.8.0 SPI in a later snapshot cycle.
+- **Lockstep tooling / enterprise (snapshot-gated):** TOOL-139 — the `exeris-tooling` handler-generator rewrite that resolves `HttpRequestBodyDecoder` instead of inlining Jackson — and the Enterprise-overlay ADR-036 stub. Both consume the published 0.8.0 SPI in a later snapshot cycle; neither gates this release.
 - **`KernelDiagnostics` SPI (ADR-033):** the SPI package, `CommunityKernelDiagnosticsProvider`, and the `exeris-kernel-diagnostics-cli` artefact — unblocks `exeris-ai-bridge` 0.4.0's `kernel:*` tool family.
 - **Client gen-support primitives:** `UriTemplate` (HTTP-130) and `QueryParams` (HTTP-131) SPI primitives, and the `CommunityKernelContextEnricher` default-bundled enricher (HTTP-134), plus the symmetric multi-binding body-codec and the retry/backoff policy SPI — all deferred from v0.8.
 - **`IdentityProvider` SPI RFC track (#153):** the WebClient/outbound touchpoint scope extension feeds the v0.9 IDP RFC track ahead of the v0.10 SPI + first driver.
@@ -161,4 +161,4 @@ Tracked in `docs/ROADMAP.md` under "Known Gaps / Future Work planned for v0.9":
 
 ## 11. Acknowledgements
 
-v0.8 was implemented as a solo project with PR-per-deliverable cadence and reviewer-driven follow-up rounds, with sprint planning and architectural reasoning recorded in `docs/local-only/v0.8-sprint-and-implementation-map.md` (LOCAL/untracked) and ADR-032 / ADR-033 / ADR-034 / ADR-035 / ADR-036 (tracked).
+v0.8 was implemented as a solo project with PR-per-deliverable cadence and reviewer-driven follow-up rounds. The architectural decisions are recorded in ADR-032 / ADR-033 / ADR-034 / ADR-035 / ADR-036.

--- a/docs/release/v0.8.0-release-notes.md
+++ b/docs/release/v0.8.0-release-notes.md
@@ -1,0 +1,164 @@
+# Exeris Kernel v0.8.0 — Release Notes
+
+> Status: **release-readiness candidate** — Sprint 8 closeout pending merge to `main`.
+> Authoring date: 2026-06-03. Author: Arkadiusz Przychocki.
+> Visibility: **public**.
+> Companion docs: `CHANGELOG.md` (terse summary); `docs/ROADMAP.md` (per-gap status); `docs/local-only/v0.8-sprint-and-implementation-map.md` (LOCAL/untracked execution plan).
+
+## 1. Headline
+
+v0.8.0 is the **production-correctness** release. Three architectural arcs land together:
+
+1. **The HTTP body-codec matrix is completed.** The codec surface is a 2×2 matrix — {request, response} × {encode, decode}. Three quadrants already had SPI seams (`HttpResponseBodyEncoder` since 0.5.0; `HttpRequestBodyEncoder` + `HttpResponseBodyDecoder` from the client-side ADR-034 work). v0.8 adds the fourth — server-side request-body **decode** (`HttpRequestBodyDecoder`, ADR-036) — and introduces the tier-neutral `KernelWebClient` facade in Core so generated client code no longer encodes tier identity in its symbols.
+2. **Compile-time RBAC becomes a live runtime decision.** The ADR-014 `@RequiresRole` machinery shipped in v0.7 as compile-time-only scaffolding; v0.8 wires the APT-generated registry into the runtime so the enforcer's inputs are populated (`GeneratedRoleRegistryLoader` + `roleMask` population), fail-closed by construction.
+3. **Transport / Flow / Graph move from exploratory evidence to production-candidate confidence.** A non-blocking reactor-driven client ingress fix removes the virtual-thread carrier-pinning stall under constrained cores (TCK-064); Graph and Flow gain mandatory TCK gates (GRAPH-111, FLOW-110).
+
+It also discharges the v0.7 review tail — the QA-010..018 `GodClass` decompositions, the supply-chain `kafka-clients` 4.0.0 bump, the CI coverage and Kafka-IT gates — so the v0.7 → v0.8 backlog is empty going into v0.9.
+
+The pre-1.0 SPI stance (TRL-3, no external SPI consumers, no breaking-change framing) is unchanged; v0.8 adds new SPI surface and behavior, not a stability declaration. New SPI members are additive minor changes in the pre-1.0 contract.
+
+## 2. What landed (by stream)
+
+The single source of truth for individual deliverables is `CHANGELOG.md` §[0.8.0]. This section frames them by sprint theme so reviewers can see the architectural arc.
+
+### 2.1 Stream A — Quality, decomposition, supply chain (Sprint 1 + Sprint 3)
+
+- **QA-010..018:** the nine remaining `GodClass` decompositions carried from v0.7, one PR per class — `CommunityPersistenceEngine`, `CommunityHttpRequestProcessor`, `Slf4jTelemetrySink`, `NativeTcpCarrier` (extracted `NativeTcpSocketBackend` / `NativeTcpProbe` / `NativeTcpReactor`), `OutboxOrchestrator`, `CommunityHttpClientEngine`, `NativeTcpStream`, `JdbcFlowSnapshotStore` (codec extract), `CommunityHttp2SessionProcessor` (four seams), `SubsystemOrchestrator` (with the ADR-026 amendment record).
+- **Supply chain:** `kafka-clients` → 4.0.0 with the license stanza (SEC-100 / BUILD-101).
+- **Performance follow-ups:** PERF-070 (`AsyncTelemetrySink` `ArrayBlockingQueue` → Agrona `MpscArrayQueue`), PERF-071 (`KafkaEventCodec` zero-copy decode).
+
+### 2.2 Stream B — Security / compile-time RBAC wiring (Sprint 4, SEC-080, ADR-014)
+
+- `GeneratedRoleRegistryLoader` (Core) resolves the APT-generated `RoleCheckRegistry` reflectively by FQN (no compile edge on `exeris-kernel-build-config`), binds its five static accessors to `MethodHandle`s once at bootstrap, and exposes them as a `RoleRegistry`. Per-request accessors use `invokeExact` — allocation-free.
+- When no `@RequiresRole` is compiled anywhere (the common case), the loader returns a **fail-closed empty registry** singleton — never allow-all; a `ClassNotFoundException` or signature mismatch falls through to the same fail-closed singleton.
+- `SecurityInterceptor` gains a `(SecurityProvider, RoleRegistry)` constructor and, when `methodCount() > 0`, binds a Core-internal `MaskedPrincipal` carrying the precomputed `roleMask()`. `runAsSystem(...)` is left untouched.
+- New one-shot `RoleRegistryLoaded` JFR event distinguishes "no annotations" from "load failed".
+- **Descoped (Sprint 4 finding):** the kernel HTTP dispatcher remains scope/path-based; kernel-edge URL→`methodId` enforcement for path-routed handlers is a **codegen** concern owned by `exeris-tooling` (the dispatcher routes by path/scope, while `@RequiresRole` is `methodId`-based), not by `CommunityHttpRequestDispatcher`. See `docs/subsystems/security.md`. No SPI change — Sprint 4 only makes the enforcer's inputs live.
+
+### 2.3 Stream C — Observability (Sprint 5)
+
+- **JFR-091:** publish-side JFR instrumentation plus a non-OCC save-side JFR event on the persistence path.
+- **EVENT-111:** `CommunityEventQueueOverflowEvent` JFR (single-phase commit, `@StackTrace(false)`) records bounded-queue overflow drops.
+- **DOC-090:** HikariCP prepared-statement cache defaults documented + Javadoc.
+- **ADR-032 record** backfilled alongside the Sprint 5 observability docs.
+
+### 2.4 Stream D — HTTP codec SPI + client gen-support (Sprint 6, ADR-032 / ADR-033 / ADR-034)
+
+- **Client-side body codec SPI (ADR-034):** `HttpRequestBodyEncoder` + `HttpResponseBodyDecoder` with their registries and encode/decode context records. `KernelWebClient` — the tier-neutral typed verb facade — lands in **Core** (`eu.exeris.kernel.core.http.client`), composing the engine, the codec registries, and an `HttpClientRequestEnricher`. ADR-034 **supersedes** ADR-026's `CommunityWebClient` placement so generated client code references an implementation-blind symbol. `KernelWebClient.WebClientException` carries the status predicates (`isNotFound` / `isClientError` / `isServerError` / `isConflict` / `isValidationError` / …).
+- **`HttpClientRequestEnricher` SPI (ADR-032):** implementation-blind `enrich(HttpRequest)` with `noop()` / `chain(List)` factories; immutable rebuild, zero `LoanedBuffer` interaction, CR/LF/NUL header-value rejection (CWE-93 outbound symmetry). `AbstractHttpClientRequestEnricherTck` green.
+- **`KernelDiagnostics` SPI decision (ADR-033):** the read-only out-of-process introspection SPI is **decided** (ADR-033 Accepted, driven by RFC-2026-05-18, with the ADR-025 link stub) but **not yet implemented** — the SPI package, the Community provider, and the CLI artefact are scoped to v0.9. Only the decision record lands in v0.8.
+- **HTTP/2 conformance:** HTTP-112 (RFC 7540 §5.1.1/§5.1.2 stream-identifier admission) and HTTP-137 (cleartext h2c `Upgrade` preface-consume + peer `HTTP2-Settings` apply + stream-1 synthesis per §3.2).
+- **CI coverage:** JaCoCo per-module + `-Pcoverage` (C-P0-01); revived Kafka integration tests in CI (C-P0-02).
+
+> Scope note (drift correction against the planned Sprint 6 backlog): the HTTP-130 `UriTemplate` and HTTP-131 `QueryParams` SPI primitives, and the HTTP-134 `CommunityKernelContextEnricher` default-bundled enricher, **did not land in v0.8** — no such types exist in the source tree. What landed from the HTTP-130..136 cluster is HTTP-132 (`WebClientException` predicates, now on `KernelWebClient`) and HTTP-133 (`HttpClientRequestEnricher` SPI + ADR-032). The remaining client gen-support primitives carry to v0.9. The ROADMAP entry is annotated **PARTIAL** accordingly.
+
+### 2.5 Stream E — Production correctness: Transport / Flow / Graph (Sprint 7)
+
+- **TCK-064 (transport, the headline fix):** `NativeTcpCarrier.connect()` now flips the connected client channel to non-blocking unconditionally and registers it on a client-side reactor; CLIENT/DUAL engines stand up the same reactor model previously reserved for SERVER/DUAL. The per-stream client ingress/writer virtual-thread pumps were deleted, removing the split-ownership writer-vs-reactor hazard. Client ingress is now reactor-driven (OP_READ) against a non-blocking FD — no virtual thread blocks on `recv()`. CI dropped the VT-scheduler `parallelism=16 / maxPoolSize=64` and drain-budget workarounds; the pinning + stress TCKs pass at the default VT carrier pool. Community-internal — no SPI/Core contract change (The Wall, ADR-006).
+- **GRAPH-111:** bound `ExecutionGraphZeroAllocTck` and `GraphChurnRatioTck` with Community bindings; fixed a latent JDK-26 `ObjectAllocationSample` defect in the abstract churn TCK. No SPI change.
+- **FLOW-110:** restart-under-load and outcome-correctness (unresolved vs failed vs compensated) Flow TCK suites added and promoted to mandatory CI gates. No SPI change.
+- **HTTP-138 / ADR-036 (server request body decode):** the fourth codec quadrant — `HttpRequestBodyDecoder` + `HttpRequestBodyDecoderRegistry` + `HttpRequestDecodingContext`, mirroring the response-decoder triplet. Community driver `CommunityJsonRequestBodyDecoder` keeps Jackson behind the SPI; `JsonBodyCodecs` extracted to dedup the JSON helpers. `AbstractHttpRequestBodyDecoderTck` + Community binding, CI-bound.
+
+### 2.6 Stream F — Forward-port from `main` (Sprint 0b)
+
+- Forward-ported the ADR-035 admission-control recalibration (operator-tunable `persistence.admission.*`, depth-allowance shedding, `canServiceRequest` Javadoc MUST→SHOULD) and the VT-JFR single-phase-commit fix for the connection-acquire event from v0.7.1 (`main`) onto the 0.8.0 line.
+- PERF-072: zero-allocation ingress read — elides the per-read full-slab `asSlice` wrapper. Community-internal.
+- ADR-022 persistence SPI extensions (`PersistenceStatement.bindInstant`, `RowCursor.getInstant`) supporting the Flow snapshot-store wiring (Sprint 0b).
+
+## 3. SPI surface delta
+
+This is the most important section for downstream consumers. The following SPI types or members are **new** in v0.8. All are implementation-blind by design; bindings are Community where applicable, Enterprise obligations are out-of-repo. **The Wall held throughout** — no Jackson, no driver, and no native types appear in any SPI signature (codec drivers keep `ObjectMapper` confined to `exeris-kernel-community`).
+
+HTTP body-codec matrix — now **complete** (`eu.exeris.kernel.spi.http`):
+
+- `HttpRequestBodyEncoder` + `HttpRequestBodyEncoderRegistry` + `HttpRequestEncodingContext` (ADR-034, client sends).
+- `HttpResponseBodyDecoder` + `HttpResponseBodyDecoderRegistry` + `HttpResponseDecodingContext` (ADR-034, client reads).
+- `HttpRequestBodyDecoder` + `HttpRequestBodyDecoderRegistry` + `HttpRequestDecodingContext` (ADR-036, server reads — the fourth quadrant).
+- (`HttpResponseBodyEncoder` + registry + `HttpResponseEncodingContext` are pre-existing since 0.5.0 — the server-sends quadrant.)
+
+Client facade and propagation:
+
+- `KernelWebClient` — tier-neutral typed verb facade in `eu.exeris.kernel.core.http.client` (**Core**, not a driver tier). Carries the `WebClientException` status predicates. Supersedes ADR-026 `CommunityWebClient` placement.
+- `HttpClientRequestEnricher` (`eu.exeris.kernel.spi.http`, ADR-032) — `enrich(HttpRequest)` with `noop()` / `chain(List)`. Wired into `KernelWebClient`.
+- `HttpProvider` / `HttpKernelProviders` gain the request-body-decoder and request/response codec-registry accessors and `ScopedValue` slots (ADR-034 / ADR-036 wiring).
+
+Security:
+
+- `RoleRegistry` (`eu.exeris.kernel.spi.security`) is the contract the `GeneratedRoleRegistryLoader` exposes; `MaskedPrincipal` is **Core-internal** (`eu.exeris.kernel.core.security`), not SPI. ADR-014's `@RequiresRole` / `PrincipalContext.roleMask()` / `RoleCheckEnforcer` are unchanged — v0.8 only populates the enforcer's inputs.
+
+Persistence (ADR-022, additive):
+
+- `PersistenceStatement.bindInstant(int, Instant)` and `RowCursor.getInstant(int)`.
+
+**Decided but not yet implemented (carries to v0.9):** `KernelDiagnostics` (ADR-033) — the SPI package `eu.exeris.kernel.spi.diagnostics`, the Community provider, and the CLI artefact are not in the v0.8 source tree. **Planned but not delivered in v0.8:** `UriTemplate` / `QueryParams` SPI primitives (HTTP-130/131) — not present in source; carried to v0.9.
+
+The pre-1.0 SemVer caveat applies: minor-version SPI additions are not "breaking" in the v1.0+ sense because there are no external SPI consumers yet (TRL-3).
+
+## 4. Configuration surface delta
+
+- `persistence.admission.*` (`CommunityAdmissionConfig`) — forward-ported from v0.7.1 (ADR-035): `queueDepthAllowanceRatio` (default `8.0`) and the strict pre-035 mode (`STRICT`).
+- HikariCP prepared-statement cache defaults documented (DOC-090); no new key, documentation + Javadoc only.
+- No new client-codec configuration keys — codec selection is registry/priority-driven at composition time, not config-driven.
+
+## 5. Telemetry / JFR delta
+
+New JFR event classes (Core/Community; `@StackTrace(false)` + single-phase-commit discipline preserved, per the VT-JFR carrier-pinning lesson):
+
+- `RoleRegistryLoaded` (Core, Sprint 4) — one-shot; records whether the generated `RoleCheckRegistry` was found and its `methodCount`.
+- `CommunityEventQueueOverflowEvent` (Community, Sprint 5 EVENT-111) — bounded-queue overflow drops.
+- JFR-091 (Sprint 5) — publish-side instrumentation + a non-OCC save-side JFR event on the persistence path.
+- Forward-ported (Sprint 0b): the connection-acquire JFR event now commits **single-phase**, avoiding the carrier-bound `EventWriter` SIGSEGV when a virtual thread unmounts mid-event.
+
+## 6. Quality and gate posture
+
+- **TCK hardening:** GRAPH-111 (`ExecutionGraphZeroAllocTck`, `GraphChurnRatioTck`) and FLOW-110 (restart-under-load, outcome-correctness) suites bound with Community bindings and promoted to mandatory CI gates. The TCK-064 carrier-pinning + transport-stress TCKs now pass at the **default** VT carrier pool and the strict default drain budget (CI workarounds removed).
+- **Coverage gates:** JaCoCo per-module wired with `-Pcoverage` enabled in the default CI path (C-P0-01); Kafka integration tests revived in CI (C-P0-02).
+- **Codec matrix completeness:** all four `{request,response}×{encode,decode}` quadrants have an SPI seam + Community binding + abstract TCK.
+- **The Wall:** no Jackson/driver/native types in any SPI signature across the new codec and enricher surface — verified by inspection; ArchUnit posture per the standing repo audit (note: the broader ArchTest gate hardening is a separate v0.8 documentation-truthfulness / CI item, not claimed closed here).
+- **Branch protection / CI gates verification:** see §9 — tracked as a release-cut step.
+
+## 7. Release-split decision
+
+**Single `0.8.0` cut.**
+
+Rationale: every sprint in the v0.8 plan landed on the `development/0.8.0` line with green gates; the one item that interacts with `main` (ADR-035 admission tunability + the VT-JFR fix) was forward-ported in Sprint 0b rather than carried as a separate patch. The cross-repo lockstep items (TOOL-139 generator rewrite; the Enterprise ADR-036 stub) are snapshot-gated and do **not** gate the kernel cut — they consume the published 0.8.0 SPI in a later cycle, per the Sprint 6 HTTP-130..136 / TOOL-136 precedent. Single-release simplifies BOM coordination and CHANGELOG bookkeeping.
+
+## 8. Migration / upgrade notes (v0.7.x → v0.8.0)
+
+For any **internal** consumer of the open-core SPI (there are no external consumers at TRL-3):
+
+- **HTTP codec registries:** providers may now register request/response body encoders/decoders via the new registries; existing handlers that do not register one are unaffected (resolution returns empty and the generated handler keeps its current status mapping — decode failure → `400`, unresolved decoder → `5xx`; no `415` negotiation yet).
+- **`KernelWebClient` (not `CommunityWebClient`):** code that referenced the ADR-026 `CommunityWebClient` should move to `eu.exeris.kernel.core.http.client.KernelWebClient`. Generated client code is regenerated by `exeris-tooling`; the tier symbol no longer appears in emitted user code.
+- **`@RequiresRole`:** still opt-in. Methods without the annotation take no behaviour change. When **any** `@RequiresRole` is compiled, the runtime now populates `roleMask` and enforces it; when none is compiled, the fail-closed empty registry leaves behaviour unchanged.
+- **Admission tunables:** `persistence.admission.queueDepthAllowanceRatio` defaults to `8.0`; set `0` to restore strict pre-035 shedding.
+
+There is no breaking-change framing. v0.8 is an **additive minor** in the pre-1.0 contract.
+
+## 9. Release-cut checklist (to verify before tagging)
+
+Operator-side steps to complete *after* this PR merges into `development/0.8.0` and before the cut into `main`. The bracketed marker notes whether this Sprint-8 documentation PR satisfies the step.
+
+1. **[this PR]** `CHANGELOG.md` `[Unreleased] — 0.8.0-SNAPSHOT` heading renamed to `[0.8.0] — 2026-06-03` with the notable/observable entries grouped under Keep-a-Changelog headers and the per-PR detail folded.
+2. **[this PR]** `docs/release/v0.8.0-release-notes.md` authored (this document).
+3. **[this PR]** `docs/ROADMAP.md` v0.8 entries annotated with `**Status (v0.8):**` (DELIVERED / PARTIAL / CARRIED TO v0.9).
+4. **[deferred — author]** Bump root `pom.xml` and all module poms from `0.8.0-SNAPSHOT` to `0.8.0` across the 10 modules for the tag commit; restore `0.9.0-SNAPSHOT` on `development/0.9.0` after the tag. **Not touched by this docs-only PR.**
+5. **[deferred — author]** Verify branch protection on `main` requires status checks for build, test, PMD/Checkstyle, TCK aggregate, plus the new coverage / Kafka-IT gates.
+6. **[deferred — author]** Verify the CI matrix passes on the `development/0.8.0` tip after Sprint 8 merges (full reactor, including Testcontainers + Kafka gates).
+7. **[deferred — author]** Open the release PR `development/0.8.0` → `main`; tag `v0.8.0` on the merge commit.
+8. **[deferred — author]** Close the `v0.8.0` GitHub milestone (if used).
+9. **[deferred — author]** Maven Central staging remains scoped out of TRL-3 (snapshot-only on GitHub Packages).
+
+## 10. Carry-over to v0.9
+
+Tracked in `docs/ROADMAP.md` under "Known Gaps / Future Work planned for v0.9":
+
+- **Lockstep tooling / enterprise (snapshot-gated):** TOOL-139 — the `exeris-tooling/KernelHandlerGenerator` rewrite consuming `HttpRequestBodyDecoder` (`exeris-tooling` PR #67); the `exeris-kernel-enterprise` ADR-036 link-stub / overlay (#30). Both consume the published 0.8.0 SPI in a later snapshot cycle.
+- **`KernelDiagnostics` SPI (ADR-033):** the SPI package, `CommunityKernelDiagnosticsProvider`, and the `exeris-kernel-diagnostics-cli` artefact — unblocks `exeris-ai-bridge` 0.4.0's `kernel:*` tool family.
+- **Client gen-support primitives:** `UriTemplate` (HTTP-130) and `QueryParams` (HTTP-131) SPI primitives, and the `CommunityKernelContextEnricher` default-bundled enricher (HTTP-134), plus the symmetric multi-binding body-codec and the retry/backoff policy SPI — all deferred from v0.8.
+- **`IdentityProvider` SPI RFC track (#153):** the WebClient/outbound touchpoint scope extension feeds the v0.9 IDP RFC track ahead of the v0.10 SPI + first driver.
+- **FLOW-110 follow-up:** the `closeTimeoutNanos` aggregate-bound drain-semantics refinement.
+- **Durability JMH:** Flow durability/recovery benchmarks land in `exeris-benchmarks` (not a kernel merge gate).
+
+## 11. Acknowledgements
+
+v0.8 was implemented as a solo project with PR-per-deliverable cadence and reviewer-driven follow-up rounds, with sprint planning and architectural reasoning recorded in `docs/local-only/v0.8-sprint-and-implementation-map.md` (LOCAL/untracked) and ADR-032 / ADR-033 / ADR-034 / ADR-035 / ADR-036 (tracked).

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.8.0-SNAPSHOT</version>
+		<version>0.8.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community-kafka</artifactId>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.8.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.8.0</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
## Sprint 8 — release-cut preparation for v0.8.0

Final Sprint of v0.8.0. Documentation + version bump; the release PR (development/0.8.0 → main) + tag `v0.8.0` follow once this lands.

### What's here
- **`docs/release/v0.8.0-release-notes.md`** (new, tracked) — by-stream summary mirroring v0.7.0: quality/decomposition + supply chain, security/RBAC wiring (SEC-080), observability (JFR-091 / EVENT-111 / DOC-090), HTTP codec SPI + client gen-support (ADR-034 `KernelWebClient` + the now-**complete** request/response × encode/decode body-codec matrix incl. ADR-036/HTTP-138, ADR-032 enricher), production correctness (TCK-064, FLOW-110, GRAPH-111). Includes SPI-surface delta, JFR delta, migration notes, carry-over to v0.9.
- **`CHANGELOG.md`** — `[Unreleased]` → `[0.8.0] — 2026-06-03`; notable SPI/observable entries added; QA-0xx decompositions + CI hotfixes folded to one Internal line (refactor-only → git log).
- **`docs/ROADMAP.md`** — 15 `Status (v0.8)` closeout lines (DELIVERED / PARTIAL / CARRIED TO v0.9).
- **POM** — `0.8.0-SNAPSHOT` → `0.8.0` across all 10 modules.

### Grounded against landed code (drift caught)
The release docs were verified against the actual tree, not the sprint plan: **UriTemplate / QueryParams (HTTP-130/131)** and **CommunityKernelContextEnricher (HTTP-134)** did **not** land — carried to v0.9; **ADR-033 KernelDiagnostics** is decision-only (SPI deferred). Only HTTP-132 (predicates) + HTTP-133 (`HttpClientRequestEnricher` SPI) shipped from the client-gen cluster. ROADMAP entries annotated accordingly (PARTIAL, not DELIVERED).

### Verification
Full `mvn install -DskipTests` green at version `0.8.0` (architecture gates pass). Docs + POM only — no source change.

### Remaining after merge
Release PR `development/0.8.0` → `main` + tag `v0.8.0`; then bump trunk to the next `-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)