### PR TITLE
docs(observability): open-core observability boundary (ADR-039) + decoder de-dup

### DIFF
--- a/docs/adr/ADR-033-kernel-diagnostics-spi.md
+++ b/docs/adr/ADR-033-kernel-diagnostics-spi.md
@@ -9,7 +9,7 @@
 **Scope:** cross-repo (kernel SPI + Community implementation + Community CLI artefact; Enterprise overlay; AI-bridge consumer)
 **Authors:** Arkadiusz Przychocki
 **Driven By:** [RFC-2026-05-18 Kernel Diagnostics SPI](../rfc/RFC-2026-05-18-kernel-diagnostics-spi.md) (ACCEPTED 2026-05-18)
-**Cross-references:** ADR-005 (JFR-first telemetry), ADR-006 (Spring-Free Kernel Boundary — "The Wall"), ADR-007 (Next-Gen Runtime Architecture), ADR-008 (Open-Core Strategy), ADR-018 (Observability Tooling Repo Split), ADR-020 (Open-Core Documentation Boundary), ADR-024 (Capability Composition Model), ADR-025 (AI Agent Bridge)
+**Cross-references:** ADR-005 (JFR-first telemetry), ADR-006 (Spring-Free Kernel Boundary — "The Wall"), ADR-007 (Next-Gen Runtime Architecture), ADR-008 (Open-Core Strategy), ADR-018 (Observability Tooling Repo Split), ADR-020 (Open-Core Documentation Boundary), ADR-024 (Capability Composition Model), ADR-025 (AI Agent Bridge), [ADR-039](ADR-039-open-core-observability-boundary.md) (Open-Core Observability Boundary — the public/open-core anchor for the state/event split)
 
 ## Context
 
@@ -63,6 +63,16 @@ Each top-level snapshot record carries a `schemaVersion` string field and an `In
 8. **Subsystem-name shape.** `describeSubsystem(String name)` takes a free-form `String` (matches `SubsystemOrchestrator.subsystem(String)` 1:1). Promotion to a closed enum is deferred to kernel 1.0 GA, when the set of subsystems is locked. The Javadoc names today's exhaustive set: `memory`, `crypto`, `persistence`, `graph`, `transport`, `events`, `flow`, `http`, `security`.
 9. **TCK obligation.** `AbstractKernelDiagnosticsTck` ships in `exeris-kernel-tck` with the SPI. It exercises the four-method surface against a known-fixture kernel (records returned shape, `schemaVersion`, `Optional<>` field semantics, snapshot non-atomicity acknowledged). Community provider in `exeris-kernel-community-testkit` runs the TCK in CI; Enterprise provider runs the same TCK plus overlay-specific cases in `exeris-kernel-enterprise` CI (ADR-008 open-core loading symmetry).
 10. **No event surface here.** `KernelDiagnostics` does not expose any "tail events" / "subscribe" / "watch" method. Live event streaming consumers go through JFR (Community) or the Enterprise Glass-Box binary stream over `exeris-telemetry-spec` consumed by `exeris-enterprise-observability` (ADR-018). This is the hybrid model from RFC-2026-05-18 §Option C, locked in.
+
+> **v0.9 implementation guardrail (Obligation 10, structural enforcement).** The state/event separation
+> must be enforced **structurally**, not just in prose: an ArchUnit / boundary rule that the
+> `eu.exeris.kernel.spi.diagnostics.*` package MUST NOT import `eu.exeris.telemetry.spec.*`, JFR
+> `@Event` / `jdk.jfr.Event` types, or any frame / `rawArgs` type. The rule lands **with** the Sprint 1
+> SPI code (the package does not exist yet, so the rule cannot land earlier). It is added as a new
+> `@ArchTest` rule to the existing **live** ArchUnit suite `ExerisArchitectureTest`
+> (`exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/arch/`), which already enforces the SPI-purity
+> rules (`noImplLeaksInSpi`, `noThreadLocal`, `noUnsafe`, …) and runs in CI on JDK 26 GA — no separate
+> harness is needed.
 
 ## Consequences
 

--- a/docs/adr/ADR-039-open-core-observability-boundary.md
+++ b/docs/adr/ADR-039-open-core-observability-boundary.md
@@ -1,0 +1,76 @@
+# ADR-039: Open-Core Observability Boundary — Shared Telemetry Wire Contract & Crash-File Decoder Cut
+
+**Status:** Accepted
+**Date:** 2026-06-07
+**Owner:** kernel/telemetry
+**Visibility:** public
+**Scope:** exeris-kernel (open-core)
+**Authors:** Arkadiusz Przychocki
+**Cross-references:** [ADR-005](ADR-005-jfr-first-telemetry-strategy.md) (JFR-First Telemetry Strategy), [ADR-006](ADR-006.link.md) (Spring-Free Kernel Boundary — "The Wall"), [ADR-008](ADR-008-open-core-strategy-and-commoditization-of-off-heap-tls.md) (Open-Core Strategy), [ADR-033](ADR-033-kernel-diagnostics-spi.md) (`KernelDiagnostics` SPI)
+
+> **Relationship to the enterprise-private tooling split.** A separate, **enterprise-private** decision (ADR-018, *Observability Tooling Repo Split*, `enterprise-private` visibility) governs how the *enterprise* observability tooling is partitioned across repositories. That ADR is not reachable from the public/open-core tree, so this ADR does **not** link to it and does **not** depend on it. ADR-039 is the **open-core counterpart**: it states, on the public side, only what the open-core kernel itself commits to. Any enterprise-side mirror or amendment is a private follow-up owned by the enterprise track.
+
+## Context
+
+v0.9 introduces the `KernelDiagnostics` SPI (ADR-033) — the first open-core surface designed for out-of-process kernel introspection. Landing it forced a question the docs had answered inconsistently: **where does the open-core ↔ enterprise line sit for observability?**
+
+Three observability surfaces are now in play, on two different axes:
+
+1. **Runtime *state*** — `KernelDiagnostics` SPI (ADR-033): provider/capability inventory, bootstrap DAG, subsystem descriptors, read out-of-process over stdio JSON. Open-core.
+2. **Runtime *events*** — the JFR / Glass-Box binary frame pipeline. Every `ExerisKernelException` encodes `rawArgs` primitives into a 64-byte frame (see `docs/subsystems/telemetry.md`). The on-wire layout is codified by the neutral, zero-dependency, publishable spec artifact **`exeris-telemetry-spec`**.
+3. **Decoder tooling** — off-kernel consumers that read frame artifacts (crash-ring files, live streams) and render human-readable reports.
+
+The state surface (1) and the event surface (2) are **orthogonal** and already cleanly separated by ADR-033 Obligation 10 (no event surface on `KernelDiagnostics`). The ambiguity was on the event/tooling side:
+
+- **The wire format was mislabeled as "enterprise."** `exeris-telemetry-spec` was described as the *enterprise* wire format. But `exeris-kernel-core` itself is a producer: the L0 crash buffer (see `docs/subsystems/bootstrap.md`, currently TRL-3 / unimplemented in this repo) writes `kernel-<pid>.ring` files **in the same format**, with no enterprise tier required. The format therefore has **two** producers — one open-core, one enterprise.
+- **The decoder story was duplicated.** Kernel docs described a kernel-core-bundled `exeris-decoder` that "reuses the schema registry to decode crash frames" — functionally the same tool as the already-existing off-kernel decoder. Two decoders for one wire format is exactly the offset-drift risk a single neutral spec exists to prevent.
+
+## 🏁 The Decision
+
+**`exeris-telemetry-spec` is a shared open wire contract with two producers. There is exactly one canonical decoder per wire format. The open/enterprise cut is: crash-FILE decode = open-core, LIVE-stream decode = enterprise. The kernel is producer-only and ships no decoder.**
+
+### Concrete decisions
+
+1. **Shared open wire contract.** `exeris-telemetry-spec` is an open, publishable, zero-dependency wire contract — **not** enterprise-only. It has two producers: the open-core `exeris-kernel-core` L0 crash buffer, and the enterprise live-stream / crash-ring emitter. The open-core producer emits `kernel-<pid>.ring` files in this format. The canonical crash-file extension is **`.ring`** (already used by the spec artifact and the decoder tooling; the prior `.bin` references in kernel docs were drift and have been corrected).
+
+2. **Single canonical decoder per wire format.** There is exactly one decoder for the `.ring` crash-file format. The kernel does **not** ship a second, kernel-local decoder, and there is **no kernel-owned schema-registry fork** — the kernel shares the `rawArgs` binary layout with the decoder only via `exeris-telemetry-spec`.
+
+3. **The decoder cut — file = open-core, live = enterprise.**
+   - **Crash-FILE decode is open-core-eligible.** Decoding a `.ring` crash file is decoding an artifact an *open-core* kernel produces. The crash-file decode path — frame decode, frame validation, and crash-ring file reading / scanning / timeline reconstruction — operates only on the neutral `exeris-telemetry-spec` schema and is open by nature. This matches the spec's stated intent of enabling third-party decoders: a third party decoding an open-core crash file is the intended model.
+   - **LIVE-stream decode is enterprise.** The live telemetry stream is emitted only by an enterprise producer; its client (and the corresponding tooling verbs) are intrinsically enterprise. No open-core producer emits this stream.
+
+4. **State / event separation is structural (reinforces ADR-033).** Runtime *state* is read through `KernelDiagnostics` (ADR-033); *events* stay on the JFR / Glass-Box / `exeris-telemetry-spec` path. The `eu.exeris.kernel.spi.diagnostics.*` package MUST NOT import `eu.exeris.telemetry.spec.*`, JFR `@Event` / `jdk.jfr.Event` types, or any frame / `rawArgs` type. This is enforced by a boundary rule landing with the Sprint 1 SPI code (see ADR-033 Obligation 10 follow-up note).
+
+## Obligations
+
+1. **No open-core deep-links into enterprise-private docs.** Open-core kernel documentation describes the boundary self-containedly. It refers to the enterprise-private tooling-split decision descriptively, never via a path that would dead-link in the public tree.
+2. **Naming discipline.** `.ring` is the canonical crash-file extension across kernel docs, `exeris-telemetry-spec`, and the decoder tooling. Any change to crash-file naming or the L0 frame layout must keep the open-core producer aligned with the shared `exeris-telemetry-spec` contract.
+3. **No physical code move in v0.9.** This ADR records *intent*. The open subset of the existing decoder tooling is not physically re-homed in v0.9 — the open-core L0 crash-buffer producer is still TRL-3 / unimplemented, so there is no `.ring` file to decode yet. The physical re-split (publishing the file-decode subset as open, keeping live-stream tooling enterprise) follows once the open-core producer ships.
+4. **Single schema source of truth.** The `rawArgs` binary layout is owned by the kernel Error Code Registry (`docs/subsystems/telemetry.md`) and expressed on the wire only through `exeris-telemetry-spec`. No second registry.
+
+## Consequences
+
+### ✅ Positive Outcomes
+
+- **[+] The boundary is stated once, on the open side.** Open-core readers get a reachable, self-contained answer to "what is open vs enterprise for observability" without chasing a private ADR.
+- **[+] One decoder, one wire format.** The duplicate kernel-local `exeris-decoder` narrative is retired; offset-drift risk across an uncoordinated third decoder is removed.
+- **[+] The wire spec's open promise is honored.** Treating `exeris-telemetry-spec` as a shared open contract makes third-party crash-file decoders a first-class, intended use.
+- **[+] State / event separation is now structurally enforceable.** The diagnostics SPI cannot accrete an event surface by accident.
+
+### ⚠️ Trade-offs
+
+- **[-] Intent precedes implementation.** The file=open / live=enterprise cut is recorded before the open-core L0 producer exists; the physical re-split is deferred and must be tracked.
+- **[-] Two ADRs for one boundary.** The open-core (this ADR) and enterprise-private (ADR-018) sides are recorded separately. This is deliberate — it keeps the public tree free of dead links — but it means the full picture spans a public and a private document.
+
+### 📋 What is NOT in scope
+
+- **Enterprise tooling internals.** How the enterprise live-stream tooling is partitioned is an enterprise-private concern (ADR-018), not governed here.
+- **Physically moving decoder code.** Deferred (Obligation 3).
+- **The `KernelDiagnostics` SPI shape itself.** Owned by ADR-033; this ADR only reinforces its event-free boundary.
+
+## Engineering Protocol
+
+1. **Kernel docs aligned in this change set:** `docs/subsystems/telemetry.md` and `docs/subsystems/bootstrap.md` — `.ring` naming, single-canonical-decoder narrative, kernel-as-producer-only, and cross-references to this ADR.
+2. **ADR-033 follow-up note** records the structural ArchUnit ban (state/event separation) that lands with the Sprint 1 SPI package, added as a new `@ArchTest` rule to the existing live `ExerisArchitectureTest` suite in `exeris-kernel-tck` (runs in CI on JDK 26 GA alongside the current SPI-purity rules).
+3. **Registry:** reserved as ADR-039 in `exeris-docs/adr-index.md` (public) before this content landed.
+4. **Deferred follow-up (not v0.9):** physical publication of the open crash-file decode subset, once the open-core L0 crash-buffer producer is implemented.

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -484,11 +484,11 @@ kernel guarantees durability of written bytes even on a hard JVM crash.
 
 | Property        | Value                                                                                               |
 |:----------------|:----------------------------------------------------------------------------------------------------|
-| **Default path** | `/tmp/exeris-crash/kernel-<pid>.bin`                                                               |
+| **Default path** | `/tmp/exeris-crash/kernel-<pid>.ring`                                                              |
 | **Override ENV** | `EXERIS_CRASH_DIR` — if set, replaces `/tmp/exeris-crash/`                                        |
 | **File size**    | Fixed-size, pre-allocated at L0 boot (default: 4 MB). Never grown dynamically.                    |
 | **Format**       | Binary Glass-Box frames (same layout as `GlassBoxSerializer` ring buffer — see `telemetry.md`)    |
-| **Lifecycle**    | Created at L0 init, closed (and optionally renamed to `kernel-<pid>-<timestamp>.bin`) on graceful shutdown. Survives JVM crash. |
+| **Lifecycle**    | Created at L0 init, closed (and optionally renamed to `kernel-<pid>-<timestamp>.ring`) on graceful shutdown. Survives JVM crash. |
 | **Permissions**  | Owner read/write only (`0600`). File is not rotated — a new PID gets a new file.                  |
 
 ### Durability Contract
@@ -505,16 +505,22 @@ may be lost. Operators requiring power-loss durability must ensure OS-level jour
 For graceful JVM crashes (`SIGSEGV`, uncaught exception), the OS signal handler will typically flush
 dirty pages before process termination — but this is a best-effort OS behaviour, not a contract.
 
-The operator recovery tool (`exeris-decoder`) is designed to tolerate partial frames at the end of the
+The canonical open crash-file decoder is designed to tolerate partial frames at the end of the
 crash buffer (ring-wrap corruption) and skip undecodable frames silently.
 
 ### Operator Recovery
 
-The `exeris-decoder` CLI tool reads the binary `kernel-<pid>.bin` file and decodes each Glass-Box frame
-into human-readable error reports using the `rawArgs` binary layout defined in `telemetry.md`.
+The kernel is producer-only here: the L0 buffer writes `.ring` files in the shared `exeris-telemetry-spec`
+wire format. Decoding is done by the **single canonical open decoder** — the open subset of the
+`exeris-enterprise-observability` decoder/forensics path (`FrameDecoder`, `FrameValidator`,
+`CrashBufferReader`), which reads the binary `kernel-<pid>.ring` file and decodes each Glass-Box frame into
+human-readable error reports using the `rawArgs` binary layout defined in `telemetry.md`. The kernel ships
+no duplicate decoder. The file=open / live=enterprise decoder cut is recorded in
+[ADR-039](../adr/ADR-039-open-core-observability-boundary.md) (Open-Core Observability Boundary); the
+state-vs-event split (state via `KernelDiagnostics`, events via this binary format) is recorded in ADR-033.
 
 ```
-$ exeris-decoder /tmp/exeris-crash/kernel-12345.bin
+$ exeris-decode /tmp/exeris-crash/kernel-12345.ring
 [0000ns] EX-BOOT-0001: DAG cycle detected — cycleMembers=[Security, Flow]
 [0042ns] EX-MEM-1002: Arena leak detected — segmentAddress=0x7f3a00000000, segmentByteSize=65536
 ```

--- a/docs/subsystems/telemetry.md
+++ b/docs/subsystems/telemetry.md
@@ -403,47 +403,55 @@ memory-mapped file. Full contract is defined in `docs/subsystems/bootstrap.md#l0
 - The crash buffer uses the **same binary frame format** as `GlassBoxSerializer` (see Binary Struct Mapping above).
 - Frames written to the mapped buffer use `VarHandle.releaseFence()` — not `msync` — to remain on the zero-syscall path.
   The OS page-dirty mechanism handles durability asynchronously.
-- The `exeris-decoder` CLI reuses the `GlassBoxSerializer` schema registry to decode both in-process JFR
-  events and post-crash binary frames — single source of truth for the `rawArgs` layout table.
+- The crash buffer produces `.ring` files in the **shared `exeris-telemetry-spec` wire format**; the canonical
+  open crash-file decoder (the open subset of the `exeris-enterprise-observability` decoder/forensics path)
+  reads them — the kernel does not ship a second, kernel-local decoder. See the `Crash-file decoding` section below.
 - **This is a hard TRL-4 requirement.** Exeris deployments without crash buffer support are limited to TRL-3 certification.
 
 ---
 
-## `exeris-decoder` CLI — Crash Buffer Analysis Tool
+## Crash-file decoding — Canonical Open Decoder
 
-> **Status: Planned, Not Yet Wired Into This Repo**
-> The `exeris-decoder` tool and its Maven plugin goal are part of the TRL-4 roadmap.
-> Neither the standalone JAR nor the `exeris-kernel-build-config:decode` plugin goal exist in the
-> current codebase. Do not attempt to reference them in build pipelines until the TRL-4 implementation lands.
+> **Status: Planned / TRL-4**
+> The open-core **L0 crash-buffer producer** is not yet implemented in this repo — when it lands it will
+> write `.ring` files in the shared `exeris-telemetry-spec` wire format. Do not reference a decode step in
+> build pipelines until the producer ships.
 
-`exeris-decoder` decodes Glass-Box binary crash buffer files (`kernel-<pid>.bin`) into human-readable
-error reports using the `rawArgs` binary layout defined in the Error Code Registry above.
+There is **exactly one canonical crash-file decoder** for the shared `.ring` wire format, and the kernel
+does **not** ship a second, kernel-local implementation. The crash-FILE decode path is the **open** subset
+of the `exeris-enterprise-observability` decoder/forensics tooling — `FrameDecoder`, `FrameValidator`, and
+`CrashBufferReader` / scanner / timeline-reconstructor — consuming the neutral `exeris-telemetry-spec`
+schema. The **live**-stream decode path is the Enterprise side. This file=open /
+live=enterprise cut is recorded in [ADR-039](../adr/ADR-039-open-core-observability-boundary.md)
+(Open-Core Observability Boundary).
 
-### Distribution
+The kernel's role is producer-only: the L0 crash buffer emits `.ring` files in the shared format, and the
+canonical open decoder reads them. The kernel shares the `rawArgs` binary layout (Error Code Registry
+above) with that decoder via `exeris-telemetry-spec` — there is no kernel-owned schema registry fork.
 
-`exeris-decoder` is planned to be distributed as:
-- A **standalone executable JAR** bundled in `exeris-kernel-core` → `target/exeris-decoder.jar`
-- A **Maven plugin goal** (`exeris-kernel-build-config:decode`) for integration with build pipelines
+State vs events: live runtime *state* is read out-of-process through the `KernelDiagnostics` SPI
+(ADR-033); crash *frames* / events stay in this binary Glass-Box format over `exeris-telemetry-spec`.
+The two surfaces do not overlap.
 
-It has zero runtime dependencies beyond JDK 26.
+### Optional build-time decode goal
+
+If a Maven decode goal is desired for build pipelines, it MUST **wrap** the canonical open decoder rather
+than reimplement it — it does not exist in the current codebase and is not part of the kernel reactor.
 
 ### Usage
 
 ```bash
-# Decode a crash buffer file
-java -jar exeris-decoder.jar /tmp/exeris-crash/kernel-12345.bin
+# Decode a crash-buffer file with the canonical open decoder (exeris-enterprise-observability CLI)
+exeris-decode /tmp/exeris-crash/kernel-12345.ring
 
 # Decode with verbose rawArgs layout
-java -jar exeris-decoder.jar --verbose /tmp/exeris-crash/kernel-12345.bin
+exeris-decode --verbose /tmp/exeris-crash/kernel-12345.ring
 
-# Decode from Windows crash directory
-java -jar exeris-decoder.jar %TEMP%\exeris-crash\kernel-12345.bin
+# Decode from a Windows crash directory
+exeris-decode %TEMP%\exeris-crash\kernel-12345.ring
 
 # Filter by error domain
-java -jar exeris-decoder.jar --filter EX-MEM /tmp/exeris-crash/kernel-12345.bin
-
-# Decode a live JFR recording (same schema)
-java -jar exeris-decoder.jar --jfr boot.jfr
+exeris-decode --filter EX-MEM /tmp/exeris-crash/kernel-12345.ring
 ```
 
 ### Output Format
@@ -495,7 +503,7 @@ completes. This creates a deliberate gap: L0 subsystems cannot emit JFR events t
 
 **L0 failure observability:** Any `ExerisKernelException` thrown during L0 (Config, Memory, Exceptions init)
 is written to the pre-allocated Glass-Box in-RAM ring buffer. If JVM crashes before L1 completes, this
-buffer is only durable if the TRL-4 memory-mapped crash buffer is active (`/tmp/exeris-crash/kernel-<pid>.bin`).
+buffer is only durable if the TRL-4 memory-mapped crash buffer is active (`/tmp/exeris-crash/kernel-<pid>.ring`).
 Without it, L0 crash data is lost on a hard JVM crash.
 
 ---


### PR DESCRIPTION
## Summary

Cheap, open-core documentation guardrails for the observability open↔enterprise boundary, landing **before** v0.9 Sprint 1 (`KernelDiagnostics` SPI, ADR-033). Documentation-only — no code moved, no runtime change.

Pre-implementation analysis (architect review) found the `KernelDiagnostics` **state** SPI is orthogonal to the JFR/Glass-Box **event** pipeline (clean per ADR-033 Obligation 10), but the *event/tooling* side carried two drifts this PR fixes.

## What changed

- **New `docs/adr/ADR-039-open-core-observability-boundary.md`** (public, open-core). Records, on the open side:
  - `exeris-telemetry-spec` is a **shared open wire contract** with **two producers** — the open-core `exeris-kernel-core` L0 crash buffer **and** the enterprise live-stream/crash-ring — not an "enterprise-only" format.
  - Exactly **one canonical decoder** per wire format; kernel is **producer-only** (no kernel-local decoder, no schema-registry fork).
  - Decoder cut: **crash-file decode = open-core, live-stream decode = enterprise** (founder decision).
  - It is a **standalone public ADR** so open-core docs never deep-link the `enterprise-private` ADR-018 (a dead link in the public tree). ADR-018 is referred to descriptively only.
- **`telemetry.md` / `bootstrap.md`** — crash-file naming aligned `.bin` → **`.ring`** (canon used by `exeris-telemetry-spec` + decoder tooling); `exeris-decoder` narrative rewritten to a single canonical open decoder.
- **`ADR-033`** — Obligation-10 follow-up note: the state/event separation is enforced **structurally** by a new `@ArchTest` rule (`spi.diagnostics.*` must not import `telemetry.spec.*` / JFR `@Event` / frame types), added to the **live** `ExerisArchitectureTest` suite in `exeris-kernel-tck`, landing with the Sprint 1 SPI code. Plus an ADR-039 cross-reference.

## Registry

Reserved as **ADR-039** in `exeris-docs/adr-index.md` (register-before-claiming) on branch `adr/039-open-core-observability-boundary` — separate PR to `exeris-docs`.

## Out of scope (deferred)

- Enterprise-side amendment/mirror of ADR-018 — enterprise-private follow-up, not open-core scope.
- Physical re-split of the decoder tooling — deferred until the open-core L0 crash buffer (still TRL-3) actually produces a `.ring` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)