### PR TITLE
fix(persistence): SPI unwrap seam so JDBC compat bridge survives request-session wrapping (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level.
 
+## [0.8.1] — 2026-06-08
+
+Patch release. Backwards-compatible SPI addition; no contract removals.
+
+### Added — tier-blind connection unwrap seam (ADR-017 JDBC bridge)
+
+- `PersistenceConnection.unwrap(Class<T>)` — a default, implementation-blind seam
+  (`java.sql.Wrapper` idiom, but the SPI names no driver type) returning
+  `Optional<T>`. Lets integration bridges reach a provider-specific backing object
+  without the SPI referencing JDBC. The Community JDBC connection unwraps to
+  `java.sql.Connection`; the per-request forwarding wrapper delegates the unwrap to
+  its backing connection so the seam survives request-session wrapping.
+
+### Fixed
+
+- Request-session `PersistenceConnection` (the non-owning forwarding wrapper bound
+  by the HTTP dispatcher) is now reachable by the JDBC compatibility bridge: it
+  forwards `unwrap(Class)` to the backing connection instead of opaquely hiding it.
+  Previously the bridge could not obtain the underlying `java.sql.Connection`
+  whenever a request session was active.
+- `KernelStart` JFR now reports the real artifact version. The bootstrap version
+  stamp is sourced from a Maven-filtered `exeris-kernel.properties`
+  (`kernel.version=${project.version}`) instead of a hand-maintained constant that
+  had drifted to `0.7.0-SNAPSHOT`; falls back to `unknown` outside a Maven build.
+
 ## [0.8.0] — 2026-06-03
 
 Production-correctness release. Completes the HTTP body-codec **SPI** matrix (all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ Patch release. Backwards-compatible SPI addition; no contract removals.
 ### Fixed
 
 - Request-session `PersistenceConnection` (the non-owning forwarding wrapper bound
-  by the HTTP dispatcher) is now reachable by the JDBC compatibility bridge: it
-  forwards `unwrap(Class)` to the backing connection instead of opaquely hiding it.
-  Previously the bridge could not obtain the underlying `java.sql.Connection`
-  whenever a request session was active.
+  by the HTTP dispatcher) now forwards `unwrap(Class)` to its backing connection
+  instead of opaquely hiding it. This is the kernel-side SPI enablement: a
+  forwarding wrapper no longer severs the unwrap seam, so a provider-specific
+  backing object remains reachable while a request session is active. (End-to-end
+  JDBC-bridge wiring is completed by the corresponding `exeris-spring-runtime`
+  consumer; this release ships only the kernel SPI surface.)
 - `KernelStart` JFR now reports the real artifact version. The bootstrap version
   stamp is sourced from a Maven-filtered `exeris-kernel.properties`
   (`kernel.version=${project.version}`) instead of a hand-maintained constant that

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.8.0</version>
+		<version>0.8.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community-kafka</artifactId>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PersistenceSessionBox.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PersistenceSessionBox.java
@@ -16,6 +16,7 @@ import eu.exeris.kernel.spi.persistence.QueryResult;
 import eu.exeris.kernel.spi.persistence.TransactionIsolation;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Lazy per-request persistence session holder for {@code ScopedValue} binding.
@@ -235,12 +236,12 @@ public final class PersistenceSessionBox {
         }
 
         @Override
-        public <T> java.util.Optional<T> unwrap(Class<T> type) {
+        public <T> Optional<T> unwrap(Class<T> type) {
             // Forward the unwrap seam to the backing connection so integration
             // bridges (e.g. the JDBC compat bridge, ADR-017) survive request-scope
             // wrapping. The wrapper itself takes precedence when assignable.
             if (type.isInstance(this)) {
-                return java.util.Optional.of(type.cast(this));
+                return Optional.of(type.cast(this));
             }
             return delegate.unwrap(type);
         }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PersistenceSessionBox.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PersistenceSessionBox.java
@@ -235,6 +235,17 @@ public final class PersistenceSessionBox {
         }
 
         @Override
+        public <T> java.util.Optional<T> unwrap(Class<T> type) {
+            // Forward the unwrap seam to the backing connection so integration
+            // bridges (e.g. the JDBC compat bridge, ADR-017) survive request-scope
+            // wrapping. The wrapper itself takes precedence when assignable.
+            if (type.isInstance(this)) {
+                return java.util.Optional.of(type.cast(this));
+            }
+            return delegate.unwrap(type);
+        }
+
+        @Override
         public boolean isOpen() {
             return delegate.isOpen();
         }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -219,9 +220,12 @@ public final class JdbcPersistenceConnection implements PersistenceConnection {
      * @since 0.8.1
      */
     @Override
-    public <T> java.util.Optional<T> unwrap(Class<T> type) {
+    public <T> Optional<T> unwrap(Class<T> type) {
+        // Exact match only: a request for java.sql.Connection reaches the backing driver
+        // connection. Supertype requests (Wrapper, AutoCloseable) intentionally fall through
+        // to the default, which resolves to the wrapper itself — never the raw connection.
         if (type == Connection.class) {
-            return java.util.Optional.of(type.cast(conn));
+            return Optional.of(type.cast(conn));
         }
         return PersistenceConnection.super.unwrap(type);
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
@@ -204,6 +204,29 @@ public final class JdbcPersistenceConnection implements PersistenceConnection {
     // =========================================================================
 
     /**
+     * Unwraps to the backing {@link Connection} for the JDBC compatibility bridge.
+     *
+     * <p>SPI seam (ADR-017): exposes the underlying {@code java.sql.Connection}
+     * via the tier-blind {@link PersistenceConnection#unwrap(Class)} contract,
+     * so integration bridges can reach the driver connection even through
+     * request-scoped forwarding wrappers — without the SPI naming JDBC.
+     * Falls back to the default behaviour ({@code this} when assignable) for
+     * any other requested type.
+     *
+     * <p>Ownership is not transferred: the returned {@link Connection} stays
+     * owned by this instance; callers MUST NOT close it directly.
+     *
+     * @since 0.8.1
+     */
+    @Override
+    public <T> java.util.Optional<T> unwrap(Class<T> type) {
+        if (type == Connection.class) {
+            return java.util.Optional.of(type.cast(conn));
+        }
+        return PersistenceConnection.super.unwrap(type);
+    }
+
+    /**
      * Returns the raw JDBC {@link Connection} backing this instance.
      *
      * <p><strong>Community infrastructure use only.</strong> Approved callers:

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/PersistenceSessionBoxTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/PersistenceSessionBoxTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+import eu.exeris.kernel.community.persistence.jdbc.JdbcPersistenceConnection;
+import eu.exeris.kernel.spi.persistence.PersistenceConnection;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import eu.exeris.kernel.spi.persistence.TransactionIsolation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * L1 Unit: {@link PersistenceSessionBox} request-scoped connection wrapping.
+ *
+ * <p>Pins the ADR-017 JDBC-bridge regression: the per-request forwarding wrapper
+ * ({@code NonOwningPersistenceConnection}) MUST forward
+ * {@link PersistenceConnection#unwrap(Class)} to its backing connection, so the
+ * JDBC compatibility bridge can reach the underlying {@code java.sql.Connection}
+ * even when the dispatcher has bound a request session. Closing the wrapper must
+ * stay a no-op (lifecycle owned by {@link PersistenceSessionBox#release()}).
+ *
+ * @since 0.8.1
+ */
+@DisplayName("L1 Unit: PersistenceSessionBox request-scoped wrapping")
+@ExtendWith(MockitoExtension.class)
+class PersistenceSessionBoxTest {
+
+    @Mock
+    PersistenceEngine engine;
+
+    @Mock
+    Connection backingJdbcConnection;
+
+    private PersistenceConnection requestScoped(PersistenceConnection backing) {
+        PersistenceSessionBox box = new PersistenceSessionBox(
+                engine, TransactionIsolation.READ_COMMITTED, false);
+        RequestPersistenceSession session = box.getOrAcquire(() -> backing);
+        return box.requestScopedConnection(session);
+    }
+
+    @Nested
+    @DisplayName("unwrap forwarding through the request-scoped wrapper")
+    class UnwrapForwarding {
+
+        @Test
+        @DisplayName("unwrap(Connection.class) reaches the backing JDBC connection")
+        void unwrapReachesBackingJdbcConnection() {
+            JdbcPersistenceConnection backing =
+                    new JdbcPersistenceConnection(backingJdbcConnection);
+
+            PersistenceConnection scoped = requestScoped(backing);
+
+            assertThat(scoped).isNotInstanceOf(JdbcPersistenceConnection.class);
+            assertThat(scoped.unwrap(Connection.class)).containsSame(backingJdbcConnection);
+        }
+
+        @Test
+        @DisplayName("unwrap of an unsupported type returns empty (no leak)")
+        void unwrapUnsupportedTypeReturnsEmpty() {
+            JdbcPersistenceConnection backing =
+                    new JdbcPersistenceConnection(backingJdbcConnection);
+
+            PersistenceConnection scoped = requestScoped(backing);
+
+            assertThat(scoped.unwrap(String.class)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("non-owning lifecycle")
+    class NonOwningLifecycle {
+
+        @Test
+        @DisplayName("close() on the request-scoped wrapper does not close the backing")
+        void wrapperCloseIsNoOp() {
+            JdbcPersistenceConnection backing =
+                    new JdbcPersistenceConnection(backingJdbcConnection);
+
+            PersistenceConnection scoped = requestScoped(backing);
+            scoped.close();
+
+            assertThat(backing.isOpen()).isTrue();
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnectionTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnectionTest.java
@@ -555,6 +555,31 @@ class JdbcPersistenceConnectionTest {
         }
     }
 
+    @Nested
+    @DisplayName("unwrap(Class) — SPI JDBC seam (ADR-017)")
+    class Unwrap {
+
+        @Test
+        @DisplayName("unwrap(Connection.class) returns the backing JDBC connection")
+        void unwrapConnectionReturnsBacking() {
+            assertThat(connection.unwrap(Connection.class)).containsSame(mockConn);
+        }
+
+        @Test
+        @DisplayName("unwrap(PersistenceConnection.class) returns this connection")
+        void unwrapSelfTypeReturnsThis() {
+            assertThat(connection.unwrap(
+                    eu.exeris.kernel.spi.persistence.PersistenceConnection.class))
+                    .containsSame(connection);
+        }
+
+        @Test
+        @DisplayName("unwrap of an unrelated type returns empty")
+        void unwrapUnrelatedTypeReturnsEmpty() {
+            assertThat(connection.unwrap(String.class)).isEmpty();
+        }
+    }
+
     private static void await(CountDownLatch latch) {
         try {
             latch.await();

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 
@@ -79,6 +79,23 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Filter only the version stamp; keep all other resources unfiltered (no binary corruption). -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>exeris-kernel.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>exeris-kernel.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java
@@ -77,8 +77,15 @@ import java.util.function.Supplier;
 })
 public final class KernelBootstrap {
 
-    /** Kernel artifact version — emitted in JFR events for traceability. */
-    private static final String KERNEL_VERSION = "0.7.0-SNAPSHOT";
+    /**
+     * Kernel artifact version — emitted in JFR events for traceability.
+     *
+     * <p>Sourced from the Maven-filtered {@code exeris-kernel.properties}
+     * ({@code kernel.version=${project.version}}) so the stamp never drifts from
+     * the POM. Falls back to {@code "unknown"} if the resource is absent or its
+     * placeholder was not filtered (e.g. classes loaded outside a Maven build).
+     */
+    private static final String KERNEL_VERSION = KernelVersion.current();
 
     private final SubsystemOrchestrator.FailurePolicy failurePolicy;
     private final BootstrapSelector                   selector;

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelVersion.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelVersion.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.bootstrap;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Resolves the kernel artifact version from the Maven-filtered
+ * {@code exeris-kernel.properties} resource ({@code kernel.version=${project.version}}),
+ * so the version stamp emitted in JFR never drifts from the POM.
+ *
+ * <p>Resolved once at class-init and cached. Returns {@code "unknown"} when the
+ * resource is missing or its placeholder was not filtered (e.g. classes loaded
+ * outside a Maven build).
+ */
+final class KernelVersion {
+
+    private static final String RESOURCE = "/exeris-kernel.properties";
+    private static final String UNKNOWN = "unknown";
+    private static final String CURRENT = load();
+
+    private KernelVersion() {
+    }
+
+    /** Returns the kernel artifact version, or {@code "unknown"} if unavailable. */
+    /* default */ static String current() {
+        return CURRENT;
+    }
+
+    private static String load() {
+        try (InputStream stream = KernelVersion.class.getResourceAsStream(RESOURCE)) {
+            if (stream == null) {
+                return UNKNOWN;
+            }
+            Properties props = new Properties();
+            props.load(stream);
+            String version = props.getProperty("kernel.version", "");
+            // Guard against an unfiltered placeholder leaking through.
+            return version.isBlank() || version.startsWith("${") ? UNKNOWN : version;
+        } catch (IOException _) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/resources/exeris-kernel.properties
+++ b/exeris-kernel-core/src/main/resources/exeris-kernel.properties
@@ -1,0 +1,3 @@
+# Build-time version stamp — filtered by Maven (see exeris-kernel-core/pom.xml <resources>).
+# Read once at bootstrap and emitted in KernelStart JFR for traceability.
+kernel.version=${project.version}

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/KernelVersionTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/KernelVersionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.bootstrap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * L1 Unit: {@link KernelVersion} reads the Maven-filtered version stamp.
+ *
+ * <p>The build filters {@code kernel.version=${project.version}} into
+ * {@code target/classes/exeris-kernel.properties}, so within the test classpath
+ * the resolved version must be the real POM version — never the literal
+ * placeholder and never the {@code "unknown"} fallback.
+ *
+ * @since 0.8.1
+ */
+@DisplayName("L1 Unit: KernelVersion (POM-sourced version stamp)")
+class KernelVersionTest {
+
+    @Test
+    @DisplayName("current() resolves the filtered POM version, not the fallback or placeholder")
+    void currentResolvesFilteredVersion() {
+        String version = KernelVersion.current();
+
+        assertThat(version)
+                .isNotBlank()
+                .isNotEqualTo("unknown")
+                .doesNotContain("${")
+                // Maven semantic version: major.minor.patch with optional -QUALIFIER.
+                .matches("\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?");
+    }
+}

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/persistence/PersistenceConnection.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/persistence/PersistenceConnection.java
@@ -50,6 +50,7 @@ import eu.exeris.kernel.spi.exceptions.persistence.PersistenceProviderException;
  * @see QueryResult
  * @since 0.5.0
  */
+@SuppressWarnings("PMD.TooManyMethods") // SPI contract surface — method count is intrinsic
 public interface PersistenceConnection extends AutoCloseable {
 
     // =========================================================================
@@ -176,6 +177,44 @@ public interface PersistenceConnection extends AutoCloseable {
      */
     default java.util.Optional<BulkInserter> openBulkInserter(String table) {
         return java.util.Optional.empty(); // Community default: no COPY support
+    }
+
+    // =========================================================================
+    // Implementation Access (tier-blind unwrap)
+    // =========================================================================
+
+    /**
+     * Unwraps this connection to an implementation-specific facility, if supported.
+     *
+     * <p>This is the SPI-level seam for integration bridges that must reach a
+     * provider-specific backing object without the SPI naming any driver type.
+     * It follows the {@link java.sql.Wrapper} idiom but stays
+     * <strong>implementation-blind</strong>: the SPI does not reference JDBC,
+     * off-heap buffers, or any tier-specific class. Each provider decides what,
+     * if anything, it exposes.
+     *
+     * <p><b>Community:</b> The JDBC-backed connection unwraps to
+     * {@code java.sql.Connection} (consumed by the JDBC compatibility bridge —
+     * see ADR-017). Request-scoped forwarding wrappers delegate the unwrap to
+     * their backing connection so the seam survives per-request session wrapping.
+     * <p><b>Enterprise:</b> May unwrap to a wire-protocol session handle, or
+     * return {@link java.util.Optional#empty()} when no compatible facility exists.
+     *
+     * <p>The default implementation returns this connection when it is itself an
+     * instance of {@code type}, and {@link java.util.Optional#empty()} otherwise.
+     * Unwrapping never transfers ownership: the returned object's lifecycle stays
+     * bound to this connection — callers MUST NOT close it directly.
+     *
+     * @param type the requested facility type; never {@code null}
+     * @param <T>  the facility type
+     * @return an {@link java.util.Optional} holding the unwrapped instance, or
+     *         empty if this provider exposes no such facility
+     * @since 0.8.1
+     */
+    default <T> java.util.Optional<T> unwrap(Class<T> type) {
+        return type.isInstance(this)
+                ? java.util.Optional.of(type.cast(this))
+                : java.util.Optional.empty();
     }
 
     // =========================================================================

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/persistence/AbstractPersistenceEngineTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/persistence/AbstractPersistenceEngineTck.java
@@ -445,4 +445,54 @@ public abstract class AbstractPersistenceEngineTck {
             }
         }
     }
+
+    // =========================================================================
+    // unwrap() seam contract (tier-blind — no driver type named here)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("unwrap(Class) seam contract")
+    class UnwrapSeamContract {
+
+        /** A type no PersistenceConnection should ever be assignable to. */
+        private interface UnrelatedFacility {
+        }
+
+        @Test
+        @DisplayName("unwrap(PersistenceConnection.class) returns a present, self-assignable instance")
+        void unwrapToAssignableTypeIsPresent() {
+            try (PersistenceConnection conn = engine.openConnection()) {
+                java.util.Optional<PersistenceConnection> unwrapped =
+                        conn.unwrap(PersistenceConnection.class);
+                assertThat(unwrapped)
+                        .as("default contract: unwrap to an assignable type yields a value")
+                        .isPresent();
+                assertThat(unwrapped.get()).isInstanceOf(PersistenceConnection.class);
+            }
+        }
+
+        @Test
+        @DisplayName("unwrap of an unrelated type returns empty (never null)")
+        void unwrapToUnrelatedTypeIsEmpty() {
+            try (PersistenceConnection conn = engine.openConnection()) {
+                java.util.Optional<UnrelatedFacility> unwrapped = conn.unwrap(UnrelatedFacility.class);
+                assertThat(unwrapped)
+                        .as("default contract: unwrap to an unsupported type is empty, not null")
+                        .isNotNull()
+                        .isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("unwrap() is side-effect-free — does not transfer ownership or close the connection")
+        void unwrapDoesNotTransferOwnership() {
+            try (PersistenceConnection conn = engine.openConnection()) {
+                conn.unwrap(PersistenceConnection.class);
+                conn.unwrap(UnrelatedFacility.class);
+                assertThat(conn.isOpen())
+                        .as("unwrap must not consume or close the connection")
+                        .isTrue();
+            }
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
## Problem

When `CommunityHttpRequestDispatcher.handleWithinRequestSession` binds a per-request `PersistenceSessionBox`, `PersistenceEngine.openConnection()` returns a `NonOwningPersistenceConnection` (private forwarding wrapper). It is **not** `instanceof JdbcPersistenceConnection` and exposed no SPI/public way to reach the underlying `java.sql.Connection`. `ExerisDataSource` (JDBC compat bridge, ADR-017) therefore failed with *"does not provide JDBC connections"* on every request.

Repro: benchmark `exeris-spring-runtime-app-comp` (`web.mode=compatibility` + `compat-datasource.enabled=true`) → `GET /db/ping` → 500.

## Fix — tier-blind SPI unwrap seam (option **a**)

A `java.sql.Wrapper`-style seam, but the **SPI names no driver type** (The Wall intact):

- `PersistenceConnection.unwrap(Class<T>) → Optional<T>` — default, implementation-blind (`@since 0.8.1`). Returns `this` when assignable, else empty.
- `JdbcPersistenceConnection.unwrap` returns the raw `java.sql.Connection`.
- `ForwardingPersistenceConnection` (`NonOwningPersistenceConnection`) **forwards** the unwrap to its backing connection, so the seam survives request-session wrapping. `close()` stays a no-op (lifecycle owned by `PersistenceSessionBox.release()`).

Engine stays swappable — Enterprise connections may unwrap to a wire handle or return empty; the SPI never references JDBC.

### Scope (kernel-only)

This is the **kernel-side SPI enablement**. The consuming change in `exeris-spring-runtime` — `ExerisDataSource.assertJdbcBacked()` `instanceof` + `rawJdbcConnection()` → `conn.unwrap(java.sql.Connection.class).orElseThrow(...)` — is a **paired follow-up PR in that repo**. The repro 500 clears only once both land.

## Drive-by: version stamp from POM

`KernelStart` JFR reported a hand-maintained `KERNEL_VERSION` that had drifted to `0.7.0-SNAPSHOT`. Now sourced from a Maven-filtered `exeris-kernel.properties` (`kernel.version=${project.version}`) via a small `KernelVersion` helper; falls back to `unknown` outside a Maven build. Reactor cut to release **0.8.1**.

## Tests

- `JdbcPersistenceConnectionTest$Unwrap` (3) — Connection / self-type / empty.
- `PersistenceSessionBoxTest` (3, new) — pins the regression: request-scoped wrapper forwards `unwrap(Connection.class)` to backing, unsupported type → empty, `close()` no-op.
- `KernelVersionTest` (1, new) — resolves filtered POM version, not placeholder/fallback.
- Full persistence suite: 93 run, 0 failures. Checkstyle + PMD clean on spi/community/core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
