### PR TITLE
docs(config): mark tracingEnabled/region as reserved dormant knobs (OTel drift)

### DIFF
--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/config/ConfigProvider.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/config/ConfigProvider.java
@@ -351,11 +351,21 @@ public interface ConfigProvider {
     /**
      * Telemetry and observability settings.
      *
+     * <p><b>Reserved knobs.</b> {@code tracingEnabled} and {@code region} are <em>dormant</em>:
+     * they are parsed and carried in config, but the kernel has no distributed-tracing /
+     * OTLP emission path yet — there is no {@code TraceContext} carrier, no OTLP sink, and no
+     * span emission in SPI/Core/Community. They are forward placeholders for the kernel tracing
+     * milestone tracked in {@code docs/ROADMAP.md} §"Telemetry: OTLP Metrics Export and
+     * Distributed Tracing" (targeted ~Sprint 0.12 / v0.12 of the consolidated 1.0 GA roadmap).
+     * The only telemetry export shipping today is the Prometheus pull sink (v0.7).
+     *
      * @param jfrEnabled     whether JFR recording is active
-     * @param metricsEnabled whether Prometheus metrics endpoint is active
-     * @param tracingEnabled whether distributed tracing (OTEL) is active
+     * @param metricsEnabled whether the Prometheus metrics endpoint is active
+     * @param tracingEnabled reserved — distributed tracing (OTLP) is not implemented yet; parsed
+     *                       and carried but not acted upon (see the reserved-knobs note above)
      * @param nodeId         unique identifier for this kernel instance
-     * @param region         deployment region for distributed tracing
+     * @param region         reserved — deployment region intended for distributed tracing labels
+     *                       (dormant until the tracing milestone; see the reserved-knobs note above)
      */
     @ValueCandidate
     record TelemetrySettings(


### PR DESCRIPTION
## What

`TelemetrySettings.tracingEnabled` and `region` are **parsed and carried** by `CommunityConfigProvider` but have **no behavioral consumer** anywhere — there is no `TraceContext` carrier, no OTLP sink, no span emission in SPI/Core/Community. The only telemetry export shipping today is the Prometheus pull sink (v0.7).

The prior javadoc — *"whether distributed tracing (OTEL) is active"* — implied a live capability that does not exist. This PR marks both fields as **reserved / dormant** forward placeholders and points at the actual milestone (`docs/ROADMAP.md` §"Telemetry: OTLP Metrics Export and Distributed Tracing", ~Sprint 0.12 / v0.12).

## Why

Surfaced while auditing the Spring-runtime **ADR-031** (OTel Bridge) reservation, which is pinned to *"exeris-kernel 0.8.0 W3C traceparent"* — but 0.8.0 shipped without any tracing logic. This is one half of the fix (the misleading kernel-side knob); the other half (de-pinning the ADR-031 note from 0.8.0) lands in `exeris-docs` separately.

## Scope

- **Javadoc-only.** No SPI record shape change → no TCK churn, no enterprise lockstep break.
- No v0.9 scope change; OTel/OTLP/tracing remains a deferred ROADMAP gap (~v0.12) by conscious decision.
- Clears one orphan-config-knob from the v0.8 audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)