### PR TITLE
feat(transport): pin TransportStream.read maxBytes<=0 → return 0 contract + TCK Bounds (v0.9 #182)

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -190,10 +190,11 @@ final class NativeTcpStream implements TransportStream {
         if (target == null) {
             throw new IllegalArgumentException("target must not be null");
         }
-        if (maxBytes < 0 || maxBytes > target.byteSize()) {
+        if (maxBytes > target.byteSize()) {
             throw new IllegalArgumentException("maxBytes out of range for target segment");
         }
-        if (maxBytes == 0) {
+        if (maxBytes <= 0) {
+            // SPI contract: non-positive maxBytes is a no-op (no I/O, no state change).
             return 0;
         }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -194,7 +194,6 @@ final class NativeTcpStream implements TransportStream {
             throw new IllegalArgumentException("maxBytes out of range for target segment");
         }
         if (maxBytes <= 0) {
-            // SPI contract: non-positive maxBytes is a no-op (no I/O, no state change).
             return 0;
         }
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -63,6 +63,11 @@ public interface TransportStream extends AutoCloseable {
      * from a (possibly drained) budget. Implementations MUST NOT throw on
      * non-positive {@code maxBytes}.
      *
+     * <p>The no-op takes precedence over closed state: a non-positive request returns
+     * {@code 0} even after this stream has been closed, rather than raising the
+     * {@code IllegalStateException} that a positive-{@code maxBytes} read on a closed
+     * stream throws.
+     *
      * <h2>Zero-Copy</h2>
      * <p>Enterprise implementations fill the target segment directly from the
      * native asynchronous I/O completion buffer (zero intermediate copy). Community

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -53,6 +53,16 @@ public interface TransportStream extends AutoCloseable {
      * Returns the number of bytes actually read, or {@code -1} if the stream
      * has been cleanly closed by the remote peer (EOF).
      *
+     * <h2>Non-positive {@code maxBytes}</h2>
+     * <p>A {@code maxBytes <= 0} request returns {@code 0} immediately: no I/O is
+     * performed and no stream state changes (the stream remains readable, and a
+     * remote-close / EOF that has not yet been observed is <em>not</em> consumed —
+     * a subsequent positive-{@code maxBytes} read still reports it). This makes a
+     * zero/negative request a pure no-op rather than a blocking call, an error, or
+     * an EOF probe, so it is safe in a hot read loop that computes its request size
+     * from a (possibly drained) budget. Implementations MUST NOT throw on
+     * non-positive {@code maxBytes}.
+     *
      * <h2>Zero-Copy</h2>
      * <p>Enterprise implementations fill the target segment directly from the
      * native asynchronous I/O completion buffer (zero intermediate copy). Community
@@ -60,8 +70,9 @@ public interface TransportStream extends AutoCloseable {
      * connection.
      *
      * @param target   off-heap segment to read into (from {@link LoanedBuffer#segment()})
-     * @param maxBytes maximum number of bytes to read (must be ≤ {@code target.byteSize()})
-     * @return number of bytes read, or {@code -1} on EOF
+     * @param maxBytes maximum number of bytes to read (must be ≤ {@code target.byteSize()});
+     *                 a value {@code <= 0} is a no-op that returns {@code 0}
+     * @return number of bytes read, {@code 0} if {@code maxBytes <= 0}, or {@code -1} on EOF
      * @throws eu.exeris.kernel.spi.exceptions.transport.TransportException on I/O failure
      * @throws IllegalStateException if this stream has been closed
      */

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
@@ -183,6 +183,20 @@ public abstract class AbstractTransportStreamTck {
                 }
             }
         }
+
+        @Test
+        @DisplayName("read(target, 0) on a closed stream returns 0 (no-op takes precedence over closed-state)")
+        @Timeout(value = 5, unit = TimeUnit.SECONDS)
+        void nonPositiveMaxBytesOnClosedStreamReturnsZero() {
+            TransportStream reader = streams.reader();
+            reader.close();
+            try (LoanedBuffer recvBuf = allocator.allocate(AllocationHint.MICRO)) {
+                assertThat(reader.read(recvBuf.segment(), 0))
+                        .as("read(target, 0) on a closed stream MUST return 0, not throw — "
+                                + "the no-op contract takes precedence over the closed-state rejection")
+                        .isZero();
+            }
+        }
     }
 
     // =========================================================================

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
@@ -142,6 +142,50 @@ public abstract class AbstractTransportStreamTck {
     }
 
     // =========================================================================
+    // read() bounds — non-positive maxBytes contract
+    // =========================================================================
+
+    @Nested
+    @DisplayName("read() bounds")
+    class ReadBounds {
+
+        @Test
+        @DisplayName("read(target, 0) and read(target, -1) return 0 without consuming pending data")
+        @Timeout(value = 5, unit = TimeUnit.SECONDS)
+        void nonPositiveMaxBytesIsNoOp() {
+            // Arrange: put a payload in flight so the reader genuinely has data pending.
+            try (LoanedBuffer sendBuf = allocator.allocate(AllocationHint.SMALL)) {
+                MemorySegment seg = sendBuf.segment();
+                seg.set(ValueLayout.JAVA_LONG, 0, 0xFEEDFACE_CAFEBEEFL);
+                int length = Long.BYTES;
+                streams.writer().write(seg, length);
+
+                TransportStream reader = streams.reader();
+
+                try (LoanedBuffer recvBuf = allocator.allocate(AllocationHint.SMALL)) {
+                    MemorySegment recvSeg = recvBuf.segment();
+
+                    // Act + Assert: non-positive maxBytes is a no-op (no I/O, no throw, returns 0).
+                    assertThat(reader.read(recvSeg, 0))
+                            .as("read(target, 0) MUST return 0 immediately (no-op contract)")
+                            .isZero();
+                    assertThat(reader.read(recvSeg, -1))
+                            .as("read(target, -1) MUST return 0 immediately (no-op contract)")
+                            .isZero();
+
+                    // Assert: the stream remains readable and the pending payload was not consumed.
+                    int bytesRead = reader.read(recvSeg, length);
+                    assertThat(bytesRead)
+                            .as("a no-op read MUST NOT consume pending data — the payload is still readable")
+                            .isEqualTo(length);
+                    assertThat(recvSeg.get(ValueLayout.JAVA_LONG, 0))
+                            .isEqualTo(0xFEEDFACE_CAFEBEEFL);
+                }
+            }
+        }
+    }
+
+    // =========================================================================
     // queueWrite() ownership transfer
     // =========================================================================
 


### PR DESCRIPTION
## What

Closes the `TransportStream.read` contract gap surfaced in `exeris-kernel-enterprise` PR #52: the SPI was silent on non-positive `maxBytes`, so enterprise's `maxBytes <= 0 → return 0` guard was enterprise-local behavior. A `read(.., 0)` that blocks vs. returns 0 vs. throws is observable, so the contract is now pinned at the SPI (CONTRACT_EXTENSION).

### Changes
- **SPI** (`TransportStream.read` javadoc): `maxBytes <= 0` → returns `0` immediately — no I/O, no state change, does **not** consume a not-yet-observed EOF (stream stays readable). Implementations MUST NOT throw on non-positive `maxBytes`.
- **Community** (`NativeTcpStream.read`): `> target.byteSize()` is now the only out-of-range throw; `maxBytes <= 0` (including negative, previously an `IllegalArgumentException`) is the no-op `return 0`, aligned to the contract.
- **TCK** (`AbstractTransportStreamTck.ReadBounds`): asserts `read(target, 0)` and `read(target, -1)` return `0` on a stream with pending data, and the pending payload is still readable afterwards (no consumption). Inherited by all Community bindings (single + multi-reactor variants).

## Verification
- `CommunityNativeTcpStreamTckTest` green — new `ReadBounds` (1/1) + full `ResetContract` (5/5) + rest of the suite.
- `pmd:check` + `checkstyle:check` clean on `exeris-kernel-spi` / `-tck` / `-community`.

## Notes
- Refs #182. Auto-close skipped — this targets `development/0.9.0`, not the default branch; the issue is closed manually on merge.
- Sibling backlog items #178 (JfrAllocationMonitor — already resolved by #179) and #180 (ResetContract drain-vs-abandon discriminator — design complete, larger change) land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)