### PR TITLE
test(tck): ResetContract abandon-vs-drain discriminator + opt-in expectsTrueReset (v0.9 #180)

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -448,6 +448,35 @@ final class NativeTcpStream implements TransportStream {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Test-only seams (package-private; used by CommunityTransportTestHarness
+    // to make the AbstractTransportStreamTck reset()-abandon discriminator
+    // deterministic — see issue #180). NOT part of the production API.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Test-only: pins the outbound single-consumer slot to {@code owner} so a concurrent
+     * {@link #queueWrite} cannot synchronously flush the queued write (it stays genuinely
+     * pending). Returns {@code true} once {@code owner} holds the slot.
+     */
+    /* default */ boolean tryPinOutboundConsumerForTest(Thread owner) {
+        return NativeTcpStreamConsumerGate.tryAcquireSingleConsumer(runtime.outboundConsumer(), owner);
+    }
+
+    /**
+     * Test-only: completes a deferred abortive close while {@code owner} still holds the outbound
+     * consumer slot, then releases it. Running {@link #finishCloseIfDrained()} on the slot owner
+     * discards the queued write (it is never written to the socket) before the carrier reactor can
+     * acquire the slot and flush it — the determinism the {@code reset()}-abandon discriminator needs.
+     */
+    /* default */ void completeAbortAndUnpinOutboundConsumerForTest(Thread owner) {
+        try {
+            finishCloseIfDrained();
+        } finally {
+            NativeTcpStreamConsumerGate.releaseSingleConsumer(runtime.outboundConsumer(), owner);
+        }
+    }
+
     /* default */ void offerIngress(LoanedBuffer ingressBuffer) {
         if (closed.get()) {
             try (ingressBuffer) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -470,6 +470,10 @@ final class NativeTcpStream implements TransportStream {
      * acquire the slot and flush it — the determinism the {@code reset()}-abandon discriminator needs.
      */
     /* default */ void completeAbortAndUnpinOutboundConsumerForTest(Thread owner) {
+        assert resetRequested.get()
+                : "completeAbortAndUnpinOutboundConsumerForTest requires a prior reset() — "
+                + "completing a close while holding the consumer slot without an abort request "
+                + "would tear down a still-live stream";
         try {
             finishCloseIfDrained();
         } finally {

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamMultiReactor2TckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamMultiReactor2TckTest.java
@@ -11,6 +11,7 @@ package eu.exeris.kernel.community.transport;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportStream;
 import eu.exeris.kernel.tck.contract.transport.AbstractTransportStreamTck;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,16 @@ class CommunityNativeTcpStreamMultiReactor2TckTest extends AbstractTransportStre
     protected StreamPair createStreamPair() {
         pair = CommunityTransportTestHarness.openLoopbackPair(allocator, false, 2);
         return new StreamPair(pair.clientStream(), pair.serverStream());
+    }
+
+    @Override
+    protected boolean expectsTrueReset() {
+        return true;   // NativeTcpStream.reset() == SO_LINGER-0 abortive close (RST)
+    }
+
+    @Override
+    protected AutoCloseable holdOutboundEgress(TransportStream writer) {
+        return CommunityTransportTestHarness.holdOutboundConsumer(writer);
     }
 
     @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamMultiReactor4TckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamMultiReactor4TckTest.java
@@ -11,6 +11,7 @@ package eu.exeris.kernel.community.transport;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportStream;
 import eu.exeris.kernel.tck.contract.transport.AbstractTransportStreamTck;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,16 @@ class CommunityNativeTcpStreamMultiReactor4TckTest extends AbstractTransportStre
     protected StreamPair createStreamPair() {
         pair = CommunityTransportTestHarness.openLoopbackPair(allocator, false, 4);
         return new StreamPair(pair.clientStream(), pair.serverStream());
+    }
+
+    @Override
+    protected boolean expectsTrueReset() {
+        return true;   // NativeTcpStream.reset() == SO_LINGER-0 abortive close (RST)
+    }
+
+    @Override
+    protected AutoCloseable holdOutboundEgress(TransportStream writer) {
+        return CommunityTransportTestHarness.holdOutboundConsumer(writer);
     }
 
     @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpStreamTckTest.java
@@ -11,6 +11,7 @@ package eu.exeris.kernel.community.transport;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportStream;
 import eu.exeris.kernel.tck.contract.transport.AbstractTransportStreamTck;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,16 @@ class CommunityNativeTcpStreamTckTest extends AbstractTransportStreamTck {
     protected StreamPair createStreamPair() {
         pair = CommunityTransportTestHarness.openLoopbackPair(allocator, false);
         return new StreamPair(pair.clientStream(), pair.serverStream());
+    }
+
+    @Override
+    protected boolean expectsTrueReset() {
+        return true;   // NativeTcpStream.reset() == SO_LINGER-0 abortive close (RST)
+    }
+
+    @Override
+    protected AutoCloseable holdOutboundEgress(TransportStream writer) {
+        return CommunityTransportTestHarness.holdOutboundConsumer(writer);
     }
 
     @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityTransportTestHarness.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityTransportTestHarness.java
@@ -116,6 +116,56 @@ final class CommunityTransportTestHarness {
         );
     }
 
+    /**
+     * Test-only egress hold for the {@code reset()}-abandon discriminator (issue #180). Pins the
+     * {@code writer}'s outbound consumer slot from a dedicated virtual thread so a subsequent
+     * {@link TransportStream#queueWrite} leaves its payload genuinely pending (no synchronous
+     * flush). The returned handle, on {@code close()}, completes the already-requested abortive
+     * {@code reset()} on the slot-owning thread — discarding the pending write before any carrier
+     * reactor can flush it — and then releases the slot.
+     */
+    static AutoCloseable holdOutboundConsumer(TransportStream writer) {
+        NativeTcpStream stream = (NativeTcpStream) writer;
+        CountDownLatch acquired = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = Thread.ofVirtual().name("tck-egress-hold").start(() -> {
+            Thread self = Thread.currentThread();
+            while (!stream.tryPinOutboundConsumerForTest(self)) {
+                Thread.onSpinWait();
+            }
+            acquired.countDown();
+            awaitUninterruptibly(release);
+            stream.completeAbortAndUnpinOutboundConsumerForTest(self);
+        });
+        awaitUninterruptibly(acquired);
+        return () -> {
+            release.countDown();
+            try {
+                holder.join(TimeUnit.SECONDS.toMillis(2));
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        };
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch) {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    latch.await();
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     static int nextFreePort() {
         try (ServerSocketChannel server = ServerSocketChannel.open()) {
             server.bind(new InetSocketAddress("127.0.0.1", 0));

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityTransportTestHarness.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityTransportTestHarness.java
@@ -131,7 +131,7 @@ final class CommunityTransportTestHarness {
         Thread holder = Thread.ofVirtual().name("tck-egress-hold").start(() -> {
             Thread self = Thread.currentThread();
             while (!stream.tryPinOutboundConsumerForTest(self)) {
-                Thread.onSpinWait();
+                Thread.yield();
             }
             acquired.countDown();
             awaitUninterruptibly(release);
@@ -144,6 +144,11 @@ final class CommunityTransportTestHarness {
                 holder.join(TimeUnit.SECONDS.toMillis(2));
             } catch (InterruptedException interrupted) {
                 Thread.currentThread().interrupt();
+            }
+            // Surface a hung abort as a test failure rather than silently entering the
+            // peer-read loop before the queued write was discarded.
+            if (holder.isAlive()) {
+                throw new AssertionError("tck-egress-hold VT did not complete the abort within 2s");
             }
         };
     }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -174,6 +174,14 @@ public interface TransportStream extends AutoCloseable {
      * transport stream, its native stream-reset frame). The code is a caller-supplied {@code long}
      * carrying no transport-specific meaning at this contract level.
      *
+     * <p>Abandonment is observable at the <em>peer</em>: outbound data still queued via
+     * {@link #queueWrite} at {@code reset} time MUST NOT be delivered to the remote endpoint
+     * (in contrast to {@link #close()}, which drains it). A transport that cannot guarantee
+     * non-delivery does not provide true abortive reset and should retain the default graceful
+     * behavior. The {@code AbstractTransportStreamTck} discriminator that enforces this is opt-in
+     * (a binding declares true-reset support); the default {@link #close()}-based implementation is
+     * exempt rather than silently treated as conformant.
+     *
      * <p>This method exists so callers can abort a single stream <em>polymorphically</em>, without
      * reaching through to a concrete transport type. It is <strong>idempotent</strong> and composes
      * with {@link #close()}: after {@code reset}, a subsequent {@code close()} (or {@code reset})

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
@@ -106,6 +106,57 @@ public abstract class AbstractTransportStreamTck {
     }
 
     /**
+     * Body of {@link ResetContract#resetAbandonsQueuedWriteAtPeer}, extracted (without the
+     * {@link #expectsTrueReset()} assumption) so the TCK's own meta-test can drive it against a
+     * fake binding and prove the discriminator is non-vacuous — a binding that drains queued data
+     * on {@code reset()} MUST make this throw {@link AssertionError}. Package-private, test-only.
+     */
+    final void runResetAbandonsAtPeerDiscriminator() throws Exception {
+        TransportStream writer = streams.writer();
+        TransportStream reader = streams.reader();
+
+        try (AutoCloseable hold = holdOutboundEgress(writer)) {
+            LoanedBuffer buf = allocator.allocate(AllocationHint.MICRO);
+            buf.segment().set(ValueLayout.JAVA_BYTE, 0, (byte) 0x7E);
+            writer.queueWrite(buf, 1);   // ownership transferred; egress held → stays pending
+
+            assertThat(writer.hasPendingData())
+                    .as("precondition: with egress held the queued write must be genuinely "
+                            + "pending — if false, holdOutboundEgress() did not defeat the "
+                            + "synchronous flush")
+                    .isTrue();
+
+            writer.reset(0L);            // abort: abandon the pending byte, engage stream reset
+        }   // hold.close() completes the abort on the slot owner before any reactor can flush
+
+        // The peer MUST NOT observe the abandoned 0x7E — only EOF (-1) or a reset error.
+        try (LoanedBuffer recvBuf = allocator.allocate(AllocationHint.MICRO)) {
+            MemorySegment recvSeg = recvBuf.segment();
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+            while (System.nanoTime() < deadline) {
+                int bytesRead;
+                try {
+                    bytesRead = reader.read(recvSeg, 1);
+                } catch (RuntimeException resetObserved) {
+                    return;   // RST surfaced as TransportException/IllegalStateException — abandoned. PASS.
+                }
+                if (bytesRead == -1) {
+                    return;   // EOF before any payload byte — abandoned. PASS.
+                }
+                if (bytesRead >= 1) {
+                    byte got = recvSeg.get(ValueLayout.JAVA_BYTE, 0);
+                    fail("reset() must abandon the queued write, but the peer received payload "
+                            + "byte 0x" + Integer.toHexString(got & 0xFF) + " — this binding "
+                            + "drains on reset() and must not declare expectsTrueReset()=true");
+                }
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+            }
+            fail("peer neither received the abandoned byte nor observed EOF/RST within 3s "
+                    + "(reset() did not engage, or the timing window is too tight)");
+        }
+    }
+
+    /**
      * Stream pair for loopback testing.
      */
     public record StreamPair(TransportStream writer, TransportStream reader) {
@@ -286,49 +337,7 @@ public abstract class AbstractTransportStreamTck {
             Assumptions.assumeTrue(expectsTrueReset(),
                     "binding does not claim true abortive reset (reset() degrades to graceful close); "
                             + "abandon-vs-drain peer discriminator skipped — see issue #180");
-
-            TransportStream writer = streams.writer();
-            TransportStream reader = streams.reader();
-
-            try (AutoCloseable hold = holdOutboundEgress(writer)) {
-                LoanedBuffer buf = allocator.allocate(AllocationHint.MICRO);
-                buf.segment().set(ValueLayout.JAVA_BYTE, 0, (byte) 0x7E);
-                writer.queueWrite(buf, 1);   // ownership transferred; egress held → stays pending
-
-                assertThat(writer.hasPendingData())
-                        .as("precondition: with egress held the queued write must be genuinely "
-                                + "pending — if false, holdOutboundEgress() did not defeat the "
-                                + "synchronous flush")
-                        .isTrue();
-
-                writer.reset(0L);            // abort: abandon the pending byte, engage stream reset
-            }   // hold.close() completes the abort on the slot owner before any reactor can flush
-
-            // The peer MUST NOT observe the abandoned 0x7E — only EOF (-1) or a reset error.
-            try (LoanedBuffer recvBuf = allocator.allocate(AllocationHint.MICRO)) {
-                MemorySegment recvSeg = recvBuf.segment();
-                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
-                while (System.nanoTime() < deadline) {
-                    int bytesRead;
-                    try {
-                        bytesRead = reader.read(recvSeg, 1);
-                    } catch (RuntimeException resetObserved) {
-                        return;   // RST surfaced as TransportException/IllegalStateException — abandoned. PASS.
-                    }
-                    if (bytesRead == -1) {
-                        return;   // EOF before any payload byte — abandoned. PASS.
-                    }
-                    if (bytesRead >= 1) {
-                        byte got = recvSeg.get(ValueLayout.JAVA_BYTE, 0);
-                        fail("reset() must abandon the queued write, but the peer received payload "
-                                + "byte 0x" + Integer.toHexString(got & 0xFF) + " — this binding "
-                                + "drains on reset() and must not declare expectsTrueReset()=true");
-                    }
-                    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
-                }
-                fail("peer neither received the abandoned byte nor observed EOF/RST within 3s "
-                        + "(reset() did not engage, or the timing window is too tight)");
-            }
+            runResetAbandonsAtPeerDiscriminator();
         }
 
         @Test

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportStreamTck.java
@@ -13,6 +13,7 @@ import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.transport.TransportStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +30,7 @@ import java.util.concurrent.locks.LockSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * TCK: Abstract base for {@link TransportStream} I/O semantics verification.
@@ -61,6 +63,47 @@ public abstract class AbstractTransportStreamTck {
      * Provides a {@link MemoryAllocator} for buffer creation in tests.
      */
     protected abstract MemoryAllocator createAllocator();
+
+    /**
+     * Declares whether this binding implements TRUE abortive {@link TransportStream#reset(long)}
+     * semantics (reset as an <em>abort</em>) rather than the SPI-default best-effort graceful
+     * {@link TransportStream#close()}.
+     *
+     * <p>When {@code false} (the default), the abandon-vs-drain peer discriminator
+     * ({@code resetAbandonsQueuedWriteAtPeer}) is SKIPPED via a JUnit assumption: a binding that
+     * degrades reset to graceful close is <em>visibly exempt</em> (reported skipped) instead of
+     * silently passing abort semantics it does not provide. This is the contract gate of issue
+     * #180 — no binding may silently claim abort fidelity.
+     *
+     * <p>When {@code true}, the binding asserts that data genuinely queued but unflushed at
+     * {@code reset()} time is NOT delivered to the peer. Override to {@code true} only for a
+     * transport with a distinct abort primitive (SO_LINGER-0 abortive TCP close, QUIC RESET_STREAM),
+     * and pair it with {@link #holdOutboundEgress(TransportStream)}.
+     *
+     * @return {@code true} if this binding provides true abortive reset; {@code false} by default
+     */
+    protected boolean expectsTrueReset() {
+        return false;
+    }
+
+    /**
+     * Arranges for a subsequent {@link TransportStream#queueWrite} on {@code writer} to leave the
+     * payload GENUINELY PENDING (unflushed) rather than flushing it synchronously on the calling
+     * thread, then deterministically completes an already-requested {@link TransportStream#reset}
+     * as an abandon when the returned handle is closed.
+     *
+     * <p>Bindings whose {@code queueWrite} opportunistically flushes on the caller thread MUST
+     * override this so the abandon-vs-drain discriminator is deterministic on a constrained CI box;
+     * a volume-based socket-buffer fill is flaky and platform-dependent. The default returns a no-op
+     * handle and is only consulted from the {@link #expectsTrueReset()}-gated test, so default
+     * bindings never depend on it.
+     *
+     * @param writer the stream that will receive a queued write to be abandoned by {@code reset}
+     * @return a handle whose {@code close()} releases the hold; never {@code null}
+     */
+    protected AutoCloseable holdOutboundEgress(TransportStream writer) {
+        return () -> { };
+    }
 
     /**
      * Stream pair for loopback testing.
@@ -215,7 +258,7 @@ public abstract class AbstractTransportStreamTck {
     class ResetContract {
 
         @Test
-        @DisplayName("reset() abandons queued writes — hasPendingData() clears")
+        @DisplayName("reset() clears the pending-data flag (teardown liveness)")
         @Timeout(value = 5, unit = TimeUnit.SECONDS)
         void resetAbandonsPendingData() {
             TransportStream writer = streams.writer();
@@ -234,6 +277,58 @@ public abstract class AbstractTransportStreamTck {
                     .as("reset() MUST abandon queued writes (no drain wait) — hasPendingData() "
                             + "must clear, otherwise close()/teardown hangs")
                     .isFalse();
+        }
+
+        @Test
+        @DisplayName("reset() abandons a genuinely-pending queued write — peer does not receive it")
+        @Timeout(value = 5, unit = TimeUnit.SECONDS)
+        void resetAbandonsQueuedWriteAtPeer() throws Exception {
+            Assumptions.assumeTrue(expectsTrueReset(),
+                    "binding does not claim true abortive reset (reset() degrades to graceful close); "
+                            + "abandon-vs-drain peer discriminator skipped — see issue #180");
+
+            TransportStream writer = streams.writer();
+            TransportStream reader = streams.reader();
+
+            try (AutoCloseable hold = holdOutboundEgress(writer)) {
+                LoanedBuffer buf = allocator.allocate(AllocationHint.MICRO);
+                buf.segment().set(ValueLayout.JAVA_BYTE, 0, (byte) 0x7E);
+                writer.queueWrite(buf, 1);   // ownership transferred; egress held → stays pending
+
+                assertThat(writer.hasPendingData())
+                        .as("precondition: with egress held the queued write must be genuinely "
+                                + "pending — if false, holdOutboundEgress() did not defeat the "
+                                + "synchronous flush")
+                        .isTrue();
+
+                writer.reset(0L);            // abort: abandon the pending byte, engage stream reset
+            }   // hold.close() completes the abort on the slot owner before any reactor can flush
+
+            // The peer MUST NOT observe the abandoned 0x7E — only EOF (-1) or a reset error.
+            try (LoanedBuffer recvBuf = allocator.allocate(AllocationHint.MICRO)) {
+                MemorySegment recvSeg = recvBuf.segment();
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+                while (System.nanoTime() < deadline) {
+                    int bytesRead;
+                    try {
+                        bytesRead = reader.read(recvSeg, 1);
+                    } catch (RuntimeException resetObserved) {
+                        return;   // RST surfaced as TransportException/IllegalStateException — abandoned. PASS.
+                    }
+                    if (bytesRead == -1) {
+                        return;   // EOF before any payload byte — abandoned. PASS.
+                    }
+                    if (bytesRead >= 1) {
+                        byte got = recvSeg.get(ValueLayout.JAVA_BYTE, 0);
+                        fail("reset() must abandon the queued write, but the peer received payload "
+                                + "byte 0x" + Integer.toHexString(got & 0xFF) + " — this binding "
+                                + "drains on reset() and must not declare expectsTrueReset()=true");
+                    }
+                    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+                }
+                fail("peer neither received the abandoned byte nor observed EOF/RST within 3s "
+                        + "(reset() did not engage, or the timing window is too tight)");
+            }
         }
 
         @Test

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/ResetDiscriminatorSelfTest.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/ResetDiscriminatorSelfTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.transport;
+
+import eu.exeris.kernel.spi.memory.AllocationHint;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryStats;
+import eu.exeris.kernel.spi.transport.TransportConnection;
+import eu.exeris.kernel.spi.transport.TransportStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Meta-test proving the {@link AbstractTransportStreamTck} reset()-abandon discriminator
+ * (issue #180) is <em>not vacuously green</em>: a binding that declares
+ * {@link AbstractTransportStreamTck#expectsTrueReset() expectsTrueReset() = true} but actually
+ * DRAINS queued data on {@code reset()} (i.e. degrades abort to graceful close) MUST fail the
+ * discriminator, while a genuinely-abandoning binding MUST pass it.
+ *
+ * <p>It drives {@link AbstractTransportStreamTck#runResetAbandonsAtPeerDiscriminator()} directly
+ * against in-memory fakes — no sockets, no JUnit-in-JUnit. The fake binding is a {@code static}
+ * nested class so it is not itself discovered as a runnable TCK suite.
+ */
+class ResetDiscriminatorSelfTest {
+
+    @Test
+    @DisplayName("discriminator FAILS a draining binding that claims expectsTrueReset() (non-vacuous guard)")
+    void drainingBindingFailsDiscriminator() throws Exception {
+        SelfTestBinding draining = new SelfTestBinding(false); // drains queued data on reset()
+        draining.setUp();
+        try {
+            assertThatThrownBy(draining::runResetAbandonsAtPeerDiscriminator)
+                    .as("a binding that delivers queued data to the peer on reset() but declares "
+                            + "expectsTrueReset()=true MUST fail the discriminator")
+                    .isInstanceOf(AssertionError.class);
+        } finally {
+            draining.tearDown();
+        }
+    }
+
+    @Test
+    @DisplayName("discriminator PASSES a genuinely-abandoning binding")
+    void abandoningBindingPassesDiscriminator() throws Exception {
+        SelfTestBinding abandoning = new SelfTestBinding(true); // abandons queued data on reset()
+        abandoning.setUp();
+        try {
+            assertThatCode(abandoning::runResetAbandonsAtPeerDiscriminator)
+                    .doesNotThrowAnyException();
+        } finally {
+            abandoning.tearDown();
+        }
+    }
+
+    /**
+     * Fake binding: a single {@link DrainOrAbandonStream} instance serves as both writer and reader,
+     * so writer-side {@code queueWrite}/{@code reset} and reader-side {@code read} share state.
+     */
+    private static final class SelfTestBinding extends AbstractTransportStreamTck {
+
+        private final boolean abandonOnReset;
+
+        private SelfTestBinding(boolean abandonOnReset) {
+            this.abandonOnReset = abandonOnReset;
+        }
+
+        @Override
+        protected boolean expectsTrueReset() {
+            return true;
+        }
+
+        @Override
+        protected StreamPair createStreamPair() {
+            DrainOrAbandonStream stream = new DrainOrAbandonStream(abandonOnReset);
+            return new StreamPair(stream, stream);
+        }
+
+        @Override
+        protected MemoryAllocator createAllocator() {
+            return new FakeAllocator();
+        }
+    }
+
+    /**
+     * In-memory stream holding a single queued byte. {@code reset()} either abandons it (true abort)
+     * or delivers it to the read side (graceful-close degradation — the bug the discriminator catches).
+     */
+    private static final class DrainOrAbandonStream implements TransportStream {
+
+        private final boolean abandonOnReset;
+        private boolean pending;
+        private byte pendingByte;
+        private boolean delivered;
+        private byte deliveredByte;
+
+        private DrainOrAbandonStream(boolean abandonOnReset) {
+            this.abandonOnReset = abandonOnReset;
+        }
+
+        @Override
+        public int read(MemorySegment target, int maxBytes) {
+            if (maxBytes <= 0) {
+                return 0;
+            }
+            if (delivered) {
+                target.set(ValueLayout.JAVA_BYTE, 0, deliveredByte);
+                delivered = false;
+                return 1;
+            }
+            return -1;
+        }
+
+        @Override
+        public void write(MemorySegment source, int length) {
+            // not exercised by the discriminator
+        }
+
+        @Override
+        public void queueWrite(LoanedBuffer buffer, int length) {
+            pendingByte = buffer.segment().get(ValueLayout.JAVA_BYTE, 0);
+            pending = true;
+            buffer.close(); // ownership transfer
+        }
+
+        @Override
+        public void reset(long errorCode) {
+            if (pending) {
+                if (!abandonOnReset) {
+                    deliveredByte = pendingByte; // drain: deliver to the peer (the degradation)
+                    delivered = true;
+                }
+                pending = false;
+            }
+        }
+
+        @Override
+        public long streamId() {
+            return 1L;
+        }
+
+        @Override
+        public boolean isBidirectional() {
+            return true;
+        }
+
+        @Override
+        public boolean isClientInitiated() {
+            return true;
+        }
+
+        @Override
+        public TransportConnection connection() {
+            return null; // not exercised by the discriminator
+        }
+
+        @Override
+        public boolean hasPendingData() {
+            return pending;
+        }
+
+        @Override
+        public void close() {
+            // idempotent no-op
+        }
+    }
+
+    /**
+     * Minimal {@link MemoryAllocator} backing each buffer with a confined {@link Arena}. Only
+     * {@link #allocate(AllocationHint)} is exercised; the rest are unused by the discriminator.
+     */
+    private static final class FakeAllocator implements MemoryAllocator {
+
+        private static final int CAPACITY = 512;
+
+        @Override
+        public LoanedBuffer allocate(AllocationHint hint) {
+            return new FakeLoanedBuffer(CAPACITY);
+        }
+
+        @Override
+        public LoanedBuffer allocateNetwork(int estimatedBytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoanedBuffer allocateCarrierSlab(int carrierIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoanedBuffer allocateInfrastructure(long sizeBytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MemoryStats stats() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            // nothing pooled
+        }
+    }
+
+    private static final class FakeLoanedBuffer implements LoanedBuffer {
+
+        private final Arena arena;
+        private final MemorySegment segment;
+
+        private FakeLoanedBuffer(int capacity) {
+            this.arena = Arena.ofConfined();
+            this.segment = arena.allocate(capacity);
+        }
+
+        @Override
+        public MemorySegment segment() {
+            return segment;
+        }
+
+        @Override
+        public long size() {
+            return segment.byteSize();
+        }
+
+        @Override
+        public long capacity() {
+            return segment.byteSize();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public LoanedBuffer slice(long offset, long length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoanedBuffer view() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoanedBuffer peek(long offset, long length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void retain() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int refCount() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setSize(long newSize) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAlive() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addCloseAction(Runnable action) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## What

`AbstractTransportStreamTck.ResetContract` green-lit **any** binding whose `reset(long)` silently degrades to a graceful `close()`: `resetAbandonsPendingData` polls `hasPendingData()==false` (which a drain also satisfies), and the remaining reset cases are met by a plain `close()`. A transport that abort→drain-degrades passed the entire suite; true abort was pinned only by per-carrier unit tests (#180). Since enterprise PR #39 removed the `instanceof AbortableStream` runtime guard *on the basis that the TCK pins abort*, this was a real fidelity gap.

## How

**Opt-in capability gate + deterministic peer-observation discriminator.**

- **`AbstractTransportStreamTck`** — new `protected expectsTrueReset()` (default `false`) and `holdOutboundEgress(writer)` (default no-op). New `resetAbandonsQueuedWriteAtPeer` is gated by `assumeTrue(expectsTrueReset())`: a graceful-close binding is **visibly exempt (skipped)** instead of silently green — the core #180 fix. When a binding claims true reset, the test queues a genuinely-pending write, calls `reset`, and asserts the **peer** never receives the payload (only EOF/`-1` or a reset error). The former `resetAbandonsPendingData` is renamed to a teardown-liveness check.

- **Determinism vs. the synchronous flush** — `NativeTcpStream.queueWrite` flushes on the caller thread when the outbound queue was empty, so a queued write would not stay pending. The harness egress-hold **pins the outbound single-consumer slot** from a helper VT (CAS); `queueWrite`'s `tryFlushPendingWritesNow()` then fails to acquire it and the write stays in the MPSC queue (`hasPendingData()==true`, hard-asserted as a precondition). On hold close the helper **completes the already-requested abort on the slot-owning thread** (`finishCloseIfDrained` discards the queued write) **before** releasing — so the carrier reactor cannot flush the abandoned byte afterwards (`drainPendingWrites` then sees `closed==true` and only discards). No socket-buffer volume bet, no `SO_SNDBUF` — robust on a constrained CI box.

- **`NativeTcpStream`** — two package-private, test-only seams (`tryPinOutboundConsumerForTest` / `completeAbortAndUnpinOutboundConsumerForTest`); `CommunityTransportTestHarness.holdOutboundConsumer` drives them. All three Community bindings (single + MultiReactor 2/4) override `expectsTrueReset()=true` and wire the hold.

- **SPI** — `TransportStream.reset(long)` javadoc tightened with the peer-non-delivery contract the TCK now enforces (additive; no `@since` churn).

## Verification
- `ResetContract` **6/6** green across all 3 Community bindings; **10×** repeat run with **zero** flakiness.
- Full community transport package: **1123 tests, 0 failures** (13 pre-existing conditional skips).
- `pmd:check` + `checkstyle:check` clean on `exeris-kernel-spi` / `-tck` / `-community`.

## Notes & follow-ups
- Refs #180. Targets `development/0.9.0`, so `Closes` won't auto-fire — closed manually on merge.
- **Enterprise QUIC TCK binding** must override both seams in lockstep (otherwise QUIC reset fidelity stays pinned only by its per-carrier unit test — the exact gap #180 calls out). Cross-tier follow-up.
- Optional: a negative TCK self-test (a draining fake declaring `expectsTrueReset()=true`, expected to **fail** the discriminator) would guard against vacuous-green regression.
- Independent of #182 (PR #184): that touches `read` javadoc + a `ReadBounds` case; this touches `reset` javadoc + `ResetContract`. They merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)