### PR TITLE
fix(crypto): terminate TLS handshake on fatal SSL_get_error to stop reactor busy-spin

### DIFF
--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/openssl/CoreOpenSslLoader.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/openssl/CoreOpenSslLoader.java
@@ -50,11 +50,19 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.TooManyMethods"})
 public final class CoreOpenSslLoader {
 
-    /** {@code SSL_FILETYPE_PEM = 1} from {@code openssl/ssl.h}. */
+    /**
+     * {@code SSL_FILETYPE_PEM = 1} from {@code openssl/ssl.h}.
+     * Distinct OpenSSL domain from {@link #SSL_ERROR_SSL} despite the shared value {@code 1}:
+     * this is a file-type argument, not an {@code SSL_get_error} code.
+     */
     public static final int SSL_FILETYPE_PEM   = 1;
     /** {@code SSL_VERIFY_NONE = 0} — no peer certificate verification. */
     public static final int SSL_VERIFY_NONE    = 0;
-    /** {@code SSL_ERROR_SSL = 1} — fatal protocol error (e.g. non-TLS bytes on a TLS port). */
+    /**
+     * {@code SSL_ERROR_SSL = 1} — fatal protocol error (e.g. non-TLS bytes on a TLS port).
+     * An {@code SSL_get_error} return code; unrelated to {@link #SSL_FILETYPE_PEM} (same value {@code 1},
+     * different OpenSSL domain).
+     */
     public static final int SSL_ERROR_SSL        = 1;
     /** {@code SSL_ERROR_WANT_READ = 2}. */
     public static final int SSL_ERROR_WANT_READ  = 2;

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/openssl/CoreOpenSslLoader.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/openssl/CoreOpenSslLoader.java
@@ -54,10 +54,14 @@ public final class CoreOpenSslLoader {
     public static final int SSL_FILETYPE_PEM   = 1;
     /** {@code SSL_VERIFY_NONE = 0} — no peer certificate verification. */
     public static final int SSL_VERIFY_NONE    = 0;
+    /** {@code SSL_ERROR_SSL = 1} — fatal protocol error (e.g. non-TLS bytes on a TLS port). */
+    public static final int SSL_ERROR_SSL        = 1;
     /** {@code SSL_ERROR_WANT_READ = 2}. */
     public static final int SSL_ERROR_WANT_READ  = 2;
     /** {@code SSL_ERROR_WANT_WRITE = 3}. */
     public static final int SSL_ERROR_WANT_WRITE = 3;
+    /** {@code SSL_ERROR_SYSCALL = 5} — I/O error or unexpected peer EOF mid-operation. */
+    public static final int SSL_ERROR_SYSCALL    = 5;
     /** {@code SSL_ERROR_ZERO_RETURN = 6} — clean peer close. */
     public static final int SSL_ERROR_ZERO_RETURN = 6;
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngine.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngine.java
@@ -345,6 +345,11 @@ public final class OffHeapTlsEngine implements TlsEngine {
                     && sslErr != CoreOpenSslLoader.SSL_ERROR_WANT_WRITE) {
                 TlsHandshakeFailureEvent.emit(ptr, serverMode,
                         KernelErrorCodes.EX_NET_2002, "SSL handshake step failed", sslErr);
+                // Self-guard: a fatal code ({@link #mapSslError} → CLOSED) leaves a broken
+                // session. Forcing ERROR makes a re-entrant beginHandshake() fail fast on the
+                // wrong-state guard rather than re-driving SSL_accept, so engine teardown no
+                // longer depends solely on the transport calling close() on the CLOSED status.
+                stateMachine.forceError();
             }
             return mapSslError(sslErr);
 
@@ -423,7 +428,14 @@ public final class OffHeapTlsEngine implements TlsEngine {
                 return TlsStatus.CLOSED;
             }
 
-            return mapSslError(sslErr);
+            TlsStatus status = mapSslError(sslErr);
+            if (status == TlsStatus.CLOSED) {
+                // Fatal read error (not a clean ZERO_RETURN) on an active session: force ERROR
+                // so a subsequent read/renegotiation fails fast on a broken session, mirroring
+                // the beginHandshake() self-guard. WANT_READ/WANT_WRITE stay non-terminal.
+                stateMachine.forceError();
+            }
+            return status;
 
         } finally {
             cipherCtx.release();

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngine.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngine.java
@@ -649,15 +649,25 @@ public final class OffHeapTlsEngine implements TlsEngine {
      * Maps an {@code SSL_get_error} result code to a {@link TlsStatus}.
      *
      * <p>Only the two "retry" codes ({@code SSL_ERROR_WANT_READ},
-     * {@code SSL_ERROR_WANT_WRITE}) are mapped to non-error statuses.
-     * All other codes are treated as requiring a handshake retry or are considered
-     * transient during the handshake phase and return {@link TlsStatus#NEED_HANDSHAKE}.
+     * {@code SSL_ERROR_WANT_WRITE}) are non-terminal — they request more I/O.
+     * On a non-blocking fd-owner BIO, "would block" always surfaces as one of those
+     * two codes, so <em>any other</em> code (notably {@code SSL_ERROR_SSL} — a fatal
+     * protocol error such as non-TLS bytes on the TLS port — and {@code SSL_ERROR_SYSCALL}
+     * — an I/O error or unexpected peer EOF) is a terminal condition that maps to
+     * {@link TlsStatus#CLOSED}.
+     *
+     * <p>Mapping these terminal codes to {@link TlsStatus#NEED_HANDSHAKE} (the prior
+     * behaviour) caused an unbounded reactor busy-spin: a half-open or garbage probe
+     * connection stuck in {@code HANDSHAKE_IN_PROGRESS} was re-stepped on every
+     * level-triggered read, never torn down, emitting millions of phantom handshake
+     * "failure" events. Returning {@code CLOSED} lets the transport layer
+     * ({@code ensureTlsReady}/{@code unwrap}) tear the fd down after a single real failure.
      */
-    private TlsStatus mapSslError(int sslErrorCode) {
+    /* default */ static TlsStatus mapSslError(int sslErrorCode) {
         return switch (sslErrorCode) {
             case CoreOpenSslLoader.SSL_ERROR_WANT_READ  -> TlsStatus.NEED_UNWRAP;
             case CoreOpenSslLoader.SSL_ERROR_WANT_WRITE -> TlsStatus.NEED_WRAP;
-            default -> TlsStatus.NEED_HANDSHAKE;
+            default -> TlsStatus.CLOSED;
         };
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/CoreOffHeapTlsEngineTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/CoreOffHeapTlsEngineTckTest.java
@@ -137,6 +137,18 @@ class CoreOffHeapTlsEngineTckTest extends AbstractCryptoEngineTck {
         return false;
     }
 
+    /**
+     * {@code OffHeapTlsEngine} is a fd-owner BIO: {@code beginHandshake()} cannot
+     * step before a real socket fd is bound, so it MUST fail fast with a lifecycle
+     * error rather than driving {@code SSL_accept} on an unbound {@code SSL*}.
+     * Mirrors {@code CommunityKernelCryptoProviderTckTest}; the TCK asserts the
+     * fail-fast-before-bind branch instead of a (now correctly terminal) status.
+     */
+    @Override
+    protected boolean requiresExternalBindBeforeHandshake() {
+        return true;
+    }
+
     // =========================================================================
     // Named provider — satisfies ServiceLoader public no-arg constructor contract
     // =========================================================================
@@ -170,9 +182,11 @@ class CoreOffHeapTlsEngineTckTest extends AbstractCryptoEngineTck {
                 throw new CryptoBootstrapException(providerName(),
                         "QUIC requires Enterprise Memory-BIO tier — fd-owner Core does not support QUIC");
             }
-            OffHeapTlsEngine engine = new OffHeapTlsEngine(handles, serverCtxPtr, true, allocator);
-            engine.notifyBound();
-            return engine;
+            // No notifyBound() / fd bind here: the fd-owner engine stays UNINITIALIZED so
+            // beginHandshake() fails fast (see requiresExternalBindBeforeHandshake()). Real
+            // handshake I/O is covered by OffHeapTlsEngineLoopbackIT. notifyBound() without a
+            // real fd previously masked the phantom-handshake busy-spin bug.
+            return new OffHeapTlsEngine(handles, serverCtxPtr, true, allocator);
         }
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
@@ -16,6 +16,7 @@ import eu.exeris.kernel.core.crypto.openssl.CoreSslHandles;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.crypto.TlsPhase;
 import eu.exeris.kernel.spi.crypto.TlsStatus;
+import eu.exeris.kernel.spi.exceptions.crypto.TlsHandshakeException;
 import eu.exeris.kernel.spi.memory.AllocationHint;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
@@ -41,6 +44,7 @@ import java.util.concurrent.StructuredTaskScope;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -448,6 +452,73 @@ class OffHeapTlsEngineLoopbackIT {
                                     .as("All decrypted bytes must equal 0xAB — mismatch offset (−1 = none)")
                                     .isEqualTo(-1L);
                         }
+                    });
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Test: fatal handshake error (non-TLS bytes) → terminal CLOSED + ERROR self-guard
+    // =========================================================================
+
+    /**
+     * End-to-end coverage for the phantom-handshake fix: a plain-TCP client sends
+     * non-TLS bytes (an HTTP probe) to the TLS port. {@code SSL_accept} reports
+     * {@code SSL_ERROR_SSL}, which {@link OffHeapTlsEngine#beginHandshake} must map to a
+     * terminal {@link TlsStatus#CLOSED} (not the prior retryable {@code NEED_HANDSHAKE}
+     * that busy-spun the reactor) and self-guard by forcing the engine to
+     * {@link TlsPhase#ERROR}. A re-entrant {@code beginHandshake()} must then fail fast
+     * rather than re-drive {@code SSL_accept} on the broken session.
+     */
+    @Test
+    @DisplayName("Fatal handshake (non-TLS bytes): beginHandshake → CLOSED, engine → ERROR, re-entry fails fast")
+    void garbageProbeYieldsClosedAndErrorState(@TempDir Path tempDir) throws Exception {
+        CertPair cert = generateSelfSignedCert(tempDir);
+        assumeTrue(cert != null, "openssl CLI not available — skipping loopback IT");
+
+        try (SslCtxHandle serverCtx       = buildServerCtx(cert.certPath(), cert.keyPath());
+             ServerSocketChannel serverSock = ServerSocketChannel.open();
+             SocketChannel clientSock       = SocketChannel.open()) {
+
+            serverSock.configureBlocking(true);
+            serverSock.bind(new InetSocketAddress("127.0.0.1", 0));
+            int port = ((InetSocketAddress) serverSock.getLocalAddress()).getPort();
+
+            clientSock.configureBlocking(true);
+            clientSock.connect(new InetSocketAddress("127.0.0.1", port));
+
+            try (SocketChannel acceptedSock = serverSock.accept()) {
+                int serverFd = extractFd(acceptedSock);
+                assumeTrue(serverFd > 0, "Could not extract server FD — skipping loopback IT");
+
+                // Non-TLS bytes on the TLS port: OpenSSL detects an HTTP request and returns
+                // SSL_ERROR_SSL on the first SSL_accept read.
+                ByteBuffer garbage = StandardCharsets.US_ASCII.encode("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+                while (garbage.hasRemaining()) {
+                    clientSock.write(garbage);
+                }
+
+                try (OffHeapTlsEngine serverEngine = new OffHeapTlsEngine(handles, serverCtx.ptr(), true, ALLOC);
+                     LoanedBuffer serverOut        = ALLOC.allocate(AllocationHint.MEDIUM)) {
+
+                    ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOC).run(() -> {
+                        communityBind(serverEngine, serverFd);
+
+                        TlsStatus status = serverEngine.beginHandshake(serverOut);
+
+                        assertThat(status)
+                                .as("Non-TLS bytes during handshake must map to terminal CLOSED")
+                                .isEqualTo(TlsStatus.CLOSED);
+                        assertThat(serverEngine.phase())
+                                .as("Self-guard: a fatal handshake error must force the engine to ERROR")
+                                .isEqualTo(TlsPhase.ERROR);
+                        assertThat(serverEngine.isHandshakeComplete())
+                                .as("A failed handshake must not report complete")
+                                .isFalse();
+                        assertThatThrownBy(() -> serverEngine.beginHandshake(serverOut))
+                                .as("Re-entry after a fatal error must fail fast, not re-drive SSL_accept")
+                                .isInstanceOf(TlsHandshakeException.class);
                     });
                 }
             }

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineSslErrorMappingTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineSslErrorMappingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.crypto.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.exeris.kernel.core.crypto.openssl.CoreOpenSslLoader;
+import eu.exeris.kernel.spi.crypto.TlsStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit coverage for {@link OffHeapTlsEngine#mapSslError(int)} — the
+ * {@code SSL_get_error} → {@link TlsStatus} contract. No OpenSSL/FFM required.
+ *
+ * <p>Regression lock for the phantom-handshake busy-spin: terminal codes
+ * ({@code SSL_ERROR_SSL}, {@code SSL_ERROR_SYSCALL}, and any unknown code) MUST map
+ * to {@link TlsStatus#CLOSED} so the transport layer tears the fd down, rather than
+ * {@link TlsStatus#NEED_HANDSHAKE} (the prior behaviour that re-stepped the handshake
+ * on every level-triggered read of a half-open/garbage probe connection).
+ */
+@DisplayName("L0: OffHeapTlsEngine.mapSslError — SSL_get_error → TlsStatus contract")
+class OffHeapTlsEngineSslErrorMappingTest {
+
+    @Test
+    @DisplayName("WANT_READ → NEED_UNWRAP (non-terminal: more ciphertext needed)")
+    void wantReadMapsToNeedUnwrap() {
+        assertThat(OffHeapTlsEngine.mapSslError(CoreOpenSslLoader.SSL_ERROR_WANT_READ))
+                .isEqualTo(TlsStatus.NEED_UNWRAP);
+    }
+
+    @Test
+    @DisplayName("WANT_WRITE → NEED_WRAP (non-terminal: outbound flight must flush)")
+    void wantWriteMapsToNeedWrap() {
+        assertThat(OffHeapTlsEngine.mapSslError(CoreOpenSslLoader.SSL_ERROR_WANT_WRITE))
+                .isEqualTo(TlsStatus.NEED_WRAP);
+    }
+
+    @Test
+    @DisplayName("SSL_ERROR_SSL → CLOSED (fatal protocol error is terminal, not retryable)")
+    void sslErrorIsTerminal() {
+        assertThat(OffHeapTlsEngine.mapSslError(CoreOpenSslLoader.SSL_ERROR_SSL))
+                .isEqualTo(TlsStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("SSL_ERROR_SYSCALL → CLOSED (I/O error / unexpected peer EOF is terminal)")
+    void syscallErrorIsTerminal() {
+        assertThat(OffHeapTlsEngine.mapSslError(CoreOpenSslLoader.SSL_ERROR_SYSCALL))
+                .isEqualTo(TlsStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("SSL_ERROR_ZERO_RETURN → CLOSED (clean peer close is terminal)")
+    void zeroReturnIsTerminal() {
+        assertThat(OffHeapTlsEngine.mapSslError(CoreOpenSslLoader.SSL_ERROR_ZERO_RETURN))
+                .isEqualTo(TlsStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("unknown SSL_get_error code → CLOSED (fail-safe terminal, never spin)")
+    void unknownCodeIsTerminal() {
+        assertThat(OffHeapTlsEngine.mapSslError(4242))
+                .isEqualTo(TlsStatus.CLOSED);
+    }
+}


### PR DESCRIPTION
## Problem

`OffHeapTlsEngine.mapSslError` mapped every non-WANT `SSL_get_error` code — including the **fatal** `SSL_ERROR_SSL` (protocol error, e.g. non-TLS bytes on the TLS port) and `SSL_ERROR_SYSCALL` (I/O error / unexpected peer EOF) — to `NEED_HANDSHAKE` (retry).

On a non-blocking fd-owner BIO, a "would block" condition always surfaces as `WANT_READ`/`WANT_WRITE`, so any other code is terminal. A half-open or garbage probe connection stuck in `HANDSHAKE_IN_PROGRESS` was therefore re-stepped on **every level-triggered read**, never torn down — busy-spinning a reactor thread until the 10s handshake timeout and emitting **~1.4M phantom `HandshakeFailure` JFR events** per run.

Root-caused from a JFR capture: `1,435,151` `HandshakeFailure` events from only **2 distinct `sslPtr`** (2 connections), `ConcurrentLinkedQueue` poll/offer at **27% of CPU**.

## Fix

- `mapSslError`: `default -> CLOSED` (fatal/unknown codes are terminal). `ensureTlsReady()`/`unwrap()` already tear the fd down on `CLOSED`, so a bad connection now closes after **one** real failure instead of spinning.
- Add `SSL_ERROR_SSL` / `SSL_ERROR_SYSCALL` constants to `CoreOpenSslLoader`.
- Make `mapSslError` package-private `static` + add a pure mapping unit test (no OpenSSL needed).
- Align the **Core** crypto TCK with the existing **Community** TCK: the fd-owner engine must fail-fast before external bind. The previous artificial `notifyBound()`-without-fd setup masked the bug through the "beginHandshake never immediately returns CLOSED" invariant.

## Validation (wrk + TLS loopback, same driver/config, before → after)

| metric | before | after |
|---|---|---|
| throughput | 3493 rps | **4755 rps (+36%)** |
| cpu / req | 1.29 ms | **0.43 ms** (Quarkus parity) |
| RSS avg | 1327 MB | **594 MB** |
| p99 latency | 73.6 ms | **54.7 ms** |
| JFR `HandshakeFailure` | 1,435,151 | **3** |

In the post-fix JFR the `ConcurrentLinkedQueue` poll/offer pair drops out of the top hot methods entirely; the hot path is now real work (Jackson serialization + Postgres JDBC).

## Tests

- New `OffHeapTlsEngineSslErrorMappingTest` — 6/6.
- `CoreOffHeapTlsEngineTckTest` — 15 run / 0 fail (3 IO-gated skips).
- `CommunityKernelCryptoProviderTckTest` — 15 run / 0 fail (unchanged).
- PMD + Checkstyle (core) clean.

## Out of scope (separate follow-ups)

- Concurrent-handshake serialization on the single acceptor thread (connection-establishment latency, not steady-state throughput).
- Residual app-layer throughput gap vs Quarkus (Jackson/JDBC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)