### PR TITLE
perf(transport): drain a bounded batch of TLS records per reactor wakeup (trop #3 / lever A)

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -66,6 +66,15 @@ public final class NativeTcpCarrier implements TransportEngine {
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
     private static final int MIN_LISTENER_BACKLOG = 64;
     private static final int MAX_LISTENER_BACKLOG = 1_024;
+    /**
+     * Max TLS records drained per readable event before yielding the reactor to other keys.
+     * The fd-owner TLS path decrypts one record per {@code readTlsIngressFromFd()} call; with a
+     * level-triggered selector this otherwise costs a full reactor cycle (stream lookup, dispatch,
+     * VT wakeup) per record. Draining a bounded batch per wakeup amortises that overhead under
+     * fine-grained-read drivers (e.g. h2load) while the cap preserves fairness across connections
+     * (mirrors Netty's {@code maxMessagesPerRead}). Remaining data re-fires on the next selector pass.
+     */
+    private static final int MAX_TLS_RECORDS_PER_READ = 16;
 
     private final TransportConfig config;
     private final MemoryAllocator allocator;
@@ -608,8 +617,16 @@ public final class NativeTcpCarrier implements TransportEngine {
         }
 
         if (stream.usesFdOwnerTls()) {
-            LoanedBuffer offered = stream.readTlsIngressFromFd();
-            if (offered != null) {
+            // Drain up to MAX_TLS_RECORDS_PER_READ decrypted records in this wakeup. A null return
+            // ends the batch and covers every stop condition (WANT_READ == socket drained, inbound
+            // backpressure, or stream closed — all pre-checked inside readTlsIngressFromFd before
+            // any allocation), so the loop can neither spin nor overrun the inbound queue. Any data
+            // left after the cap re-fires on the next selector pass (level-triggered).
+            for (int drained = 0; drained < MAX_TLS_RECORDS_PER_READ; drained++) {
+                LoanedBuffer offered = stream.readTlsIngressFromFd();
+                if (offered == null) {
+                    break;
+                }
                 stream.offerIngress(offered);
             }
             return;


### PR DESCRIPTION
## Problem (isolated from benchmark data)

The fd-owner TLS ingress path decrypts **one record per `readTlsIngressFromFd()` call**, and the level-triggered selector dispatches `readIngress()` once per readable event. So a fine-grained-read driver pays a full reactor cycle — `resolveStream` (`ConcurrentHashMap.get`, ~5% of CPU), dispatch, VT wakeup — **per TLS record**.

Clean h2load matrix (no JFR):

| target | TLS | cpu/req |
|---|---|---|
| Exeris | off | **0.339 ms** |
| Exeris | on | **0.792 ms** (2.3x) |
| Quarkus | off | 0.459 ms |
| Quarkus | on | 0.474 ms |

The cost is **TLS-ingress-specific and read-granularity-sensitive**: Exeris TLS is 0.792 ms/req under h2load but **0.358 ms/req under wrk** (which batches reads), and plaintext is 0.339 ms/req under both. `readPlainIngress` drains the socket buffer in a single read; the TLS path did not.

## Fix (lever A)

Drain up to `MAX_TLS_RECORDS_PER_READ` (16) decrypted records per wakeup, amortising the per-cycle overhead across the batch:

```java
for (int drained = 0; drained < MAX_TLS_RECORDS_PER_READ; drained++) {
    LoanedBuffer offered = stream.readTlsIngressFromFd();
    if (offered == null) break;   // WANT_READ (drained) | backpressure | closed
    stream.offerIngress(offered);
}
```

- A `null` return ends the batch and covers **every** stop condition — `readTlsIngressFromFd` pre-checks inbound backpressure and stream-closed *before* any allocation and returns `null` on `WANT_READ`. The loop therefore cannot spin or overrun the inbound queue.
- The cap preserves **fairness** across connections (mirrors Netty's `maxMessagesPerRead`); data left after the cap re-fires on the next selector pass (level-triggered).
- Plaintext path unchanged (already drains in one read).

## Scope / safety

Community-internal, no SPI/Core, no ADR. Ownership (PERF-062 per-buffer transfer), `tlsLock`, and backpressure semantics are unchanged — only the number of records consumed per wakeup changes.

## Tests

- Transport suite **73 / 0 fail**, including **all zero-allocation TCKs** (`CommunityTransportZeroAllocTckTest` + multi-reactor) — the batch does not regress per-request allocation discipline.
- E2E client/server + ingress integration tests green via Failsafe (real TLS readIngress path through the drain loop).
- PMD + Checkstyle clean.

## Acceptance signal (benchmark, separate)

Re-run h2load TLS — expect Exeris cpu/req to drop from ~0.79 ms toward the ~0.34 ms plaintext floor, closing the gap with Quarkus (~0.47 ms). Levers B (drop the unused per-record `ciphertextPlaceholder` allocation) and C (coalesce the per-record VT wakeup) remain as follow-ups if A alone doesn't fully close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)