### PR TITLE
perf(transport): reuse per-stream TLS ciphertext placeholder on fd-owner ingress

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -109,6 +109,13 @@ final class NativeTcpStream implements TransportStream {
     private final NativeTcpStreamPendingWrite.TlsContext pendingWriteTlsContext;
     private final NativeTcpStreamPendingWrite.TryWriter pendingWriteTryWriter;
 
+    // PERF: fd-owner BIO unwrap pulls ciphertext directly from the kernel socket and never
+    // inspects its {@code ciphertext} parameter (OffHeapTlsEngine#unwrap contract). A single
+    // per-stream empty placeholder is reused for every ingress record instead of allocating one
+    // per read, removing the dominant per-request LoanedBuffer/ReleaseAction churn on the TLS hot
+    // path. Owned by this stream; released in finishCloseIfDrained(). null for non-TLS streams.
+    private final LoanedBuffer tlsCiphertextPlaceholder;
+
     private final AtomicBoolean closeRequested = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean remoteClosed = new AtomicBoolean(false);
@@ -190,6 +197,12 @@ final class NativeTcpStream implements TransportStream {
                 ? null
                 : new NativeTcpStreamPendingWrite.TlsContext(tlsEngine, tlsLock, allocator);
         this.pendingWriteTryWriter = this::tryWrite;
+        if (tlsEngine == null) {
+            this.tlsCiphertextPlaceholder = null;
+        } else {
+            this.tlsCiphertextPlaceholder = allocator.allocateInfrastructure(1);
+            this.tlsCiphertextPlaceholder.setSize(0);
+        }
     }
 
     @Override
@@ -635,17 +648,18 @@ final class NativeTcpStream implements TransportStream {
             return null;
         }
 
-        LoanedBuffer ciphertextPlaceholder = allocator.allocateInfrastructure(1);
+        // PERF: reuse the per-stream empty placeholder — fd-owner unwrap never reads it (see field
+        // doc). Only the plaintext slab is allocated per record; the prior per-read placeholder
+        // allocate+close pair is gone.
         LoanedBuffer plaintext = allocator.allocateCarrierSlab(0);
         // PERF-062: ownership-transfer flag replaces the prior retain()/auto-close ceremony.
         // The successful return path keeps the buffer alive at refcount 1 without an extra
         // retain+close pair; the unsuccessful path closes the slab in finally.
         boolean transferred = false;
         try {
-            ciphertextPlaceholder.setSize(0);
             TlsStatus status;
             synchronized (tlsLock) {
-                status = tlsEngine.unwrap(ciphertextPlaceholder, plaintext);
+                status = tlsEngine.unwrap(tlsCiphertextPlaceholder, plaintext);
             }
             if (status == TlsStatus.OK && plaintext.size() > 0) {
                 transferred = true;
@@ -656,7 +670,6 @@ final class NativeTcpStream implements TransportStream {
             }
             return null;
         } finally {
-            ciphertextPlaceholder.close();
             if (!transferred) {
                 plaintext.close();
             }
@@ -1090,20 +1103,7 @@ final class NativeTcpStream implements TransportStream {
             return;
         }
 
-        if (tlsEngine != null) {
-            try {
-                try (LoanedBuffer outbound = allocator.allocateNetwork(1024)) {
-                    tlsEngine.initiateShutdown(outbound);
-                }
-            } catch (RuntimeException _) {
-                // best effort
-            }
-            try {
-                tlsEngine.close();
-            } catch (RuntimeException _) {
-                // best effort
-            }
-        }
+        releaseTlsResources();
 
         try {
             cleanupInboundIfOwnedByCurrentThreadOrIdle();
@@ -1121,6 +1121,40 @@ final class NativeTcpStream implements TransportStream {
 
         connection.markClosedByCarrier();
         closeCallback.run();
+    }
+
+    /**
+     * Terminal, best-effort release of TLS-owned resources: graceful shutdown record, the engine
+     * itself, and the per-stream ciphertext placeholder (see {@link #tlsCiphertextPlaceholder}).
+     * Invoked exactly once from {@link #finishCloseIfDrained()} under its {@code closed} CAS guard.
+     */
+    private void releaseTlsResources() {
+        if (tlsEngine == null) {
+            return;
+        }
+        try {
+            try (LoanedBuffer outbound = allocator.allocateNetwork(1024)) {
+                tlsEngine.initiateShutdown(outbound);
+            }
+        } catch (RuntimeException _) {
+            // best effort
+        }
+        try {
+            tlsEngine.close();
+        } catch (RuntimeException _) {
+            // best effort
+        }
+        if (tlsCiphertextPlaceholder != null) {
+            try {
+                // Safe outside tlsLock: fd-owner unwrap never dereferences the ciphertext segment
+                // (OffHeapTlsEngine#unwrap reads the socket BIO directly). Do NOT move this under
+                // tlsLock — that lock is held on the ingress hot path, and finishCloseIfDrained()
+                // must never block on it.
+                tlsCiphertextPlaceholder.close();
+            } catch (RuntimeException _) {
+                // best effort
+            }
+        }
     }
 
     /**

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/crypto/tls/OffHeapTlsEngineLoopbackIT.java
@@ -459,6 +459,94 @@ class OffHeapTlsEngineLoopbackIT {
     }
 
     // =========================================================================
+    // Test: fd-owner unwrap ignores the ciphertext argument (locks the lever-B invariant)
+    // =========================================================================
+
+    /**
+     * Locks the contract that {@link OffHeapTlsEngine#unwrap} relies on in fd-owner BIO mode:
+     * the {@code ciphertext} argument is never read — {@code SSL_read} pulls ciphertext directly
+     * from the kernel socket via the fd BIO (see unwrap Javadoc). The Community ingress hot path
+     * (NativeTcpStream) exploits this by passing a single reusable empty placeholder instead of
+     * allocating a ciphertext buffer per record; this test guards that optimization.
+     *
+     * <p>The placeholder here is deliberately filled with garbage (0xFF) and given a non-zero size.
+     * If a future change ever made {@code unwrap} consume {@code ciphertext}, it would try to
+     * decrypt that garbage and the assertion on the recovered 0xAB payload would fail.
+     */
+    @Test
+    @DisplayName("fd-owner unwrap ignores ciphertext arg — garbage placeholder still decrypts socket data (lever B)")
+    void unwrapIgnoresCiphertextArgument(@TempDir Path tempDir) throws Exception {
+        CertPair cert = generateSelfSignedCert(tempDir);
+        assumeTrue(cert != null, "openssl CLI not available — skipping loopback IT");
+
+        final int payloadSize = 512;
+
+        try (SslCtxHandle serverCtx = buildServerCtx(cert.certPath(), cert.keyPath());
+             SslCtxHandle clientCtx = buildClientCtx();
+             ServerSocketChannel serverSock = ServerSocketChannel.open();
+             SocketChannel clientSock       = SocketChannel.open()) {
+
+            serverSock.configureBlocking(true);
+            serverSock.bind(new InetSocketAddress("127.0.0.1", 0));
+            int port = ((InetSocketAddress) serverSock.getLocalAddress()).getPort();
+
+            clientSock.configureBlocking(true);
+            clientSock.connect(new InetSocketAddress("127.0.0.1", port));
+
+            try (SocketChannel acceptedSock = serverSock.accept()) {
+                int serverFd = extractFd(acceptedSock);
+                int clientFd = extractFd(clientSock);
+
+                assumeTrue(serverFd > 0 && clientFd > 0,
+                        "Could not extract socket FDs — skipping loopback IT");
+
+                try (OffHeapTlsEngine serverEngine = new OffHeapTlsEngine(handles, serverCtx.ptr(), true, ALLOC);
+                     OffHeapTlsEngine clientEngine = new OffHeapTlsEngine(handles, clientCtx.ptr(), false, ALLOC);
+                     LoanedBuffer serverOut       = ALLOC.allocate(AllocationHint.MEDIUM);
+                     LoanedBuffer clientOut       = ALLOC.allocate(AllocationHint.MEDIUM);
+                     LoanedBuffer plaintext        = ALLOC.allocate(AllocationHint.MEDIUM);
+                     LoanedBuffer staleCiphertext = ALLOC.allocate(AllocationHint.MEDIUM);
+                     LoanedBuffer decrypted        = ALLOC.allocate(AllocationHint.MEDIUM)) {
+
+                    ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOC).run(() -> {
+                        communityBind(serverEngine, serverFd);
+                        communityBind(clientEngine, clientFd);
+                        driveHandshake(serverEngine, serverOut, clientEngine, clientOut);
+
+                        plaintext.segment().asSlice(0, payloadSize).fill((byte) 0xAB);
+                        plaintext.setSize(payloadSize);
+
+                        // fd-owner: serverOut stays size=0 — wrap() pushes ciphertext to the socket BIO.
+                        assertThat(serverEngine.wrap(plaintext, serverOut))
+                                .as("Server wrap() must succeed")
+                                .isEqualTo(TlsStatus.OK);
+
+                        // Garbage ciphertext argument with a non-zero size: a correct fd-owner
+                        // unwrap must ignore it entirely and decrypt the real socket bytes.
+                        staleCiphertext.segment().asSlice(0, 256).fill((byte) 0xFF);
+                        staleCiphertext.setSize(256);
+
+                        assertThat(clientEngine.unwrap(staleCiphertext, decrypted))
+                                .as("Client unwrap() must succeed despite garbage ciphertext arg")
+                                .isEqualTo(TlsStatus.OK);
+                        assertThat(decrypted.size())
+                                .as("Decrypted byte count must equal original payload — ciphertext arg ignored")
+                                .isEqualTo(payloadSize);
+
+                        try (LoanedBuffer patternBuf = ALLOC.allocate(AllocationHint.MEDIUM)) {
+                            patternBuf.segment().asSlice(0, decrypted.size()).fill((byte) 0xAB);
+                            assertThat(decrypted.segment().asSlice(0, decrypted.size())
+                                    .mismatch(patternBuf.segment().asSlice(0, decrypted.size())))
+                                    .as("Recovered plaintext must be the 0xAB payload, not the 0xFF garbage")
+                                    .isEqualTo(-1L);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    // =========================================================================
     // Test: fatal handshake error (non-TLS bytes) → terminal CLOSED + ERROR self-guard
     // =========================================================================
 


### PR DESCRIPTION
## What

fd-owner BIO `unwrap` pulls ciphertext directly from the kernel socket and **never reads its `ciphertext` argument** (`OffHeapTlsEngine#unwrap` contract, lines 396-397; impl uses `plaintext` only). Yet `NativeTcpStream.readTlsIngressFromFd` allocated a throwaway `allocateInfrastructure(1)` placeholder and `close()`d it **on every TLS record**.

This change allocates **one** empty placeholder per TLS stream and reuses it for every ingress record, releasing it deterministically in `finishCloseIfDrained()` (extracted to `releaseTlsResources()`). Only the plaintext slab is allocated per record now.

## Why — diagnosis (JFR, TLS h2load run `20260616T061640Z`)

The TLS-vs-plaintext deficit on this build is **allocation + ingress machinery (~45%)**, not crypto (FFM ~8.5%):
- `readTlsIngressFromFd` = **#1 allocation site**
- `CommunityLoanedBuffer` = **#1 allocated class**, `CommunityReleaseAction` #2

The per-read placeholder allocate+close pair was pure waste — the argument is provably ignored by fd-owner unwrap.

> Note: macro throughput/cpu_time cannot adjudicate this lever — run-to-run cpu/req variance is ±15% (0.90–1.23 ms/req across identical configs) and JFR allocation sampling is throttled (~52k cap). The justification is **No Waste Compute** + the deterministic contract, not a throughput delta.

## Test

New loopback IT (real OpenSSL handshake) **locks the invariant** this relies on: `unwrap` given a garbage, non-zero-size ciphertext buffer must still decrypt the real socket data — fails fast if a future change ever consumes the ciphertext argument.

- `OffHeapTlsEngineLoopbackIT`: 5/5 (was 4) ✅
- `NativeTcpStream*` + `NativeTcpCarrier*`: 20/20 ✅
- `pmd:check` + `checkstyle:check` (core + community): clean ✅

## Relation to #189 (drain-batch / lever A)

Supersedes #189. That branch's drain loop was confirmed a **net regression in closed-loop**: its terminating `WANT_READ` probe allocates two buffers + does an `SSL_read` *before* discovering the socket is drained, doubling per-request allocations and FFM downcalls. This PR is cut from `development/0.9.0` (fix #2), so lever A is simply not included. **#189 should be closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)