### PR TITLE
perf(transport): drop dead per-write cipher buffer in fd-owner TLS egress

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -205,7 +205,7 @@ final class NativeTcpStream implements TransportStream {
         this.pendingWriteTlsContext = tlsEngine == null
                 ? null
                 : new NativeTcpStreamPendingWrite.TlsContext(
-                        tlsEngine, tlsLock, allocator, tlsCiphertextPlaceholder);
+                        tlsEngine, tlsLock, tlsCiphertextPlaceholder);
         this.pendingWriteTryWriter = this::tryWrite;
     }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -193,16 +193,20 @@ final class NativeTcpStream implements TransportStream {
                     "NativeTcpStream only supports socket-owner TLS engines (CommunityTlsEngine); "
                     + "buffer-owner engines are not supported");
         }
-        this.pendingWriteTlsContext = tlsEngine == null
-                ? null
-                : new NativeTcpStreamPendingWrite.TlsContext(tlsEngine, tlsLock, allocator);
-        this.pendingWriteTryWriter = this::tryWrite;
         if (tlsEngine == null) {
             this.tlsCiphertextPlaceholder = null;
         } else {
             this.tlsCiphertextPlaceholder = allocator.allocateInfrastructure(1);
             this.tlsCiphertextPlaceholder.setSize(0);
         }
+        // The same per-stream empty placeholder serves both ingress unwrap and egress wrap: in
+        // fd-owner BIO mode neither dereferences the ciphertext segment (see tlsCiphertextPlaceholder
+        // and NativeTcpStreamPendingWrite.prepareCipher). Both run under tlsLock, so no interleave.
+        this.pendingWriteTlsContext = tlsEngine == null
+                ? null
+                : new NativeTcpStreamPendingWrite.TlsContext(
+                        tlsEngine, tlsLock, allocator, tlsCiphertextPlaceholder);
+        this.pendingWriteTryWriter = this::tryWrite;
     }
 
     @Override

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWrite.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWrite.java
@@ -11,7 +11,6 @@ package eu.exeris.kernel.community.transport;
 import eu.exeris.kernel.spi.crypto.TlsEngine;
 import eu.exeris.kernel.spi.crypto.TlsStatus;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
-import eu.exeris.kernel.spi.memory.MemoryAllocator;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -26,7 +25,7 @@ import java.lang.foreign.MemorySegment;
  * first drain attempt for TLS streams), and tracks offsets across partial
  * socket writes.
  *
- * <p>Construction takes a {@link TlsContext} (engine + lock + allocator) and a
+ * <p>Construction takes a {@link TlsContext} (engine + lock + ciphertext placeholder) and a
  * {@link TryWriter} dispatcher so the stream's socket-backend selection stays
  * encapsulated in {@link NativeTcpStreamPlainSocketIo}; this class never
  * touches the underlying file descriptor directly.
@@ -43,6 +42,10 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
     private LoanedBuffer cipherBuffer;
     private int cipherLength;
     private int cipherOffset;
+    // True once wrap() has run for this write. On the fd-owner path cipherBuffer stays null
+    // (wrap writes straight to the socket), so idempotency cannot key off cipherBuffer — a second
+    // prepareCipher() would otherwise re-invoke wrap() and re-send the same plaintext.
+    private boolean cipherPrepared;
 
     /**
      * TLS wrap dependency surface for a single stream. {@code tlsLock} must be
@@ -55,7 +58,7 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
      * touches its ciphertext argument, so the same placeholder used by ingress unwrap is
      * passed to {@code wrap} on egress instead of allocating a per-write cipher buffer.
      */
-    /* default */ record TlsContext(TlsEngine tlsEngine, Object tlsLock, MemoryAllocator allocator,
+    /* default */ record TlsContext(TlsEngine tlsEngine, Object tlsLock,
                                     LoanedBuffer ciphertextPlaceholder) {
     }
 
@@ -93,7 +96,7 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
     // a fresh allocation, so there is no resource for this method to close.
     @SuppressWarnings("PMD.CloseResource")
     /* default */ TlsStatus prepareCipher() {
-        if (cipherBuffer != null) {
+        if (cipherPrepared) {
             return TlsStatus.OK;
         }
         // fd-owner BIO (the only TLS engine NativeTcpStream accepts — buffer-owner engines are
@@ -116,6 +119,7 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
                     "fd-owner TLS wrap produced ciphertext in the shared placeholder (size="
                             + cipher.size() + "); buffer-owner engines are unsupported here");
         }
+        cipherPrepared = true;
         return TlsStatus.OK;
     }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWrite.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWrite.java
@@ -35,8 +35,6 @@ import java.lang.foreign.MemorySegment;
 @SuppressWarnings("PMD.NullAssignment")
 final class NativeTcpStreamPendingWrite implements AutoCloseable {
 
-    private static final int TLS_WRAP_OVERHEAD_BYTES = 1024;
-
     private final TlsContext tlsContext;
     private final TryWriter tryWriter;
     private LoanedBuffer plainBuffer;
@@ -50,8 +48,15 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
      * TLS wrap dependency surface for a single stream. {@code tlsLock} must be
      * the same monitor used by the stream for {@code unwrap} so wrap/unwrap
      * cannot interleave on the same {@link TlsEngine}.
+     *
+     * <p>{@code ciphertextPlaceholder} is the stream's reused empty ({@code size()==0})
+     * buffer. In fd-owner BIO mode — the only mode {@code NativeTcpStream} accepts —
+     * {@link TlsEngine#wrap} writes ciphertext straight to the kernel socket and never
+     * touches its ciphertext argument, so the same placeholder used by ingress unwrap is
+     * passed to {@code wrap} on egress instead of allocating a per-write cipher buffer.
      */
-    /* default */ record TlsContext(TlsEngine tlsEngine, Object tlsLock, MemoryAllocator allocator) {
+    /* default */ record TlsContext(TlsEngine tlsEngine, Object tlsLock, MemoryAllocator allocator,
+                                    LoanedBuffer ciphertextPlaceholder) {
     }
 
     /**
@@ -83,25 +88,35 @@ final class NativeTcpStreamPendingWrite implements AutoCloseable {
         return plainOffset >= plainLength;
     }
 
+    // CloseResource: ciphertextPlaceholder is borrowed (owned by NativeTcpStream, released in
+    // finishCloseIfDrained); it must NOT be closed here. The local is the shared placeholder, never
+    // a fresh allocation, so there is no resource for this method to close.
+    @SuppressWarnings("PMD.CloseResource")
     /* default */ TlsStatus prepareCipher() {
         if (cipherBuffer != null) {
             return TlsStatus.OK;
         }
-        try (LoanedBuffer cipher = tlsContext.allocator().allocateNetwork(plainLength + TLS_WRAP_OVERHEAD_BYTES)) {
-            TlsStatus status;
-            synchronized (tlsContext.tlsLock()) {
-                status = tlsContext.tlsEngine().wrap(plainBuffer, cipher);
-            }
-            if (status != TlsStatus.OK) {
-                return status;
-            }
-            if (cipher.size() > 0) {
-                cipher.retain();
-                cipherBuffer = cipher;
-                cipherLength = (int) cipher.size();
-            }
-            return TlsStatus.OK;
+        // fd-owner BIO (the only TLS engine NativeTcpStream accepts — buffer-owner engines are
+        // rejected at stream construction): wrap() pushes the ciphertext straight to the kernel
+        // socket and never touches its ciphertext argument, leaving size()==0. Reuse the per-stream
+        // empty placeholder instead of allocating plainLength+overhead per write (mirrors the ingress
+        // unwrap placeholder) — removes the dominant per-write egress LoanedBuffer/ReleaseAction churn.
+        LoanedBuffer cipher = tlsContext.ciphertextPlaceholder();
+        TlsStatus status;
+        synchronized (tlsContext.tlsLock()) {
+            status = tlsContext.tlsEngine().wrap(plainBuffer, cipher);
         }
+        if (status != TlsStatus.OK) {
+            return status;
+        }
+        if (cipher.size() > 0) {
+            // Unreachable in fd-owner BIO: a buffer-owner engine would write ciphertext into the
+            // shared placeholder, which must never be retained or sent. Fail loud, never corrupt.
+            throw new IllegalStateException(
+                    "fd-owner TLS wrap produced ciphertext in the shared placeholder (size="
+                            + cipher.size() + "); buffer-owner engines are unsupported here");
+        }
+        return TlsStatus.OK;
     }
 
     /* default */ boolean writeCipher() throws IOException {

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWriteTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWriteTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.crypto.TlsEngine;
+import eu.exeris.kernel.spi.crypto.TlsStatus;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Locks the fd-owner TLS egress contract for {@link NativeTcpStreamPendingWrite#prepareCipher()}:
+ * the per-write cipher buffer is the reused per-stream empty placeholder, so wrapping a queued
+ * write allocates <b>nothing</b> (the dominant per-request egress churn this fix removed). A
+ * buffer-owner engine — unsupported by {@code NativeTcpStream} — that writes into the shared
+ * placeholder must fail loud rather than corrupt the wire.
+ */
+@DisplayName("NativeTcpStreamPendingWrite — fd-owner TLS egress reuses placeholder (zero per-write alloc)")
+final class NativeTcpStreamPendingWriteTest {
+
+    private MemoryAllocator allocator;
+    private LoanedBuffer placeholder;
+
+    @BeforeEach
+    void setUp() {
+        allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        placeholder = allocator.allocateInfrastructure(1);
+        placeholder.setSize(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        placeholder.close();
+        allocator.close();
+    }
+
+    @Test
+    @DisplayName("prepareCipher reuses the placeholder and allocates nothing (fd-owner BIO)")
+    void prepareCipherAllocatesNothingInFdOwnerMode() {
+        FdOwnerTlsEngine engine = new FdOwnerTlsEngine();
+        NativeTcpStreamPendingWrite pending = newPendingWrite(engine, "hello-world-payload");
+
+        long before = allocator.stats().allocationCount();
+        assertThat(pending.prepareCipher()).isEqualTo(TlsStatus.OK);
+        long after = allocator.stats().allocationCount();
+
+        assertThat(after - before).as("prepareCipher must not allocate on the fd-owner egress path").isZero();
+        assertThat(engine.wrapCalls).isEqualTo(1);
+        assertThat(placeholder.size()).as("placeholder stays empty and reusable").isZero();
+        // Idempotent (already-prepared returns OK) and writeCipher no-ops: the ciphertext is already
+        // on the socket via wrap()'s SSL_write, so there is nothing left to drain.
+        assertThat(pending.prepareCipher()).isEqualTo(TlsStatus.OK);
+        pending.close();
+    }
+
+    @Test
+    @DisplayName("a buffer-owner engine writing into the shared placeholder fails loud, never corrupts")
+    void bufferOwnerWrapFailsLoud() {
+        NativeTcpStreamPendingWrite pending = newPendingWrite(new BufferOwnerTlsEngine(), "x");
+        assertThatThrownBy(pending::prepareCipher)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("buffer-owner engines are unsupported");
+        pending.close();
+    }
+
+    private NativeTcpStreamPendingWrite newPendingWrite(TlsEngine engine, String payload) {
+        byte[] bytes = payload.getBytes(StandardCharsets.US_ASCII);
+        LoanedBuffer plain = allocator.allocateNetwork(bytes.length);
+        MemorySegment.copy(MemorySegment.ofArray(bytes), 0, plain.segment(), 0, bytes.length);
+        NativeTcpStreamPendingWrite.TlsContext ctx =
+                new NativeTcpStreamPendingWrite.TlsContext(engine, new Object(), allocator, placeholder);
+        return new NativeTcpStreamPendingWrite(plain, bytes.length, ctx, (src, off, len) -> len);
+    }
+
+    /** Simulates fd-owner BIO: wrap() pushes ciphertext to the socket and leaves the buffer untouched. */
+    private static final class FdOwnerTlsEngine implements TlsEngine {
+        private int wrapCalls;
+
+        @Override
+        public TlsStatus wrap(LoanedBuffer plaintext, LoanedBuffer ciphertext) {
+            wrapCalls++;
+            return TlsStatus.OK;
+        }
+
+        @Override public TlsStatus beginHandshake(LoanedBuffer outbound) {
+            return TlsStatus.OK;
+        }
+
+        @Override public TlsStatus unwrap(LoanedBuffer ciphertext, LoanedBuffer plaintext) {
+            return TlsStatus.OK;
+        }
+
+        @Override public boolean isHandshakeComplete() {
+            return true;
+        }
+
+        @Override public String negotiatedProtocol() {
+            return "h2";
+        }
+
+        @Override public void initiateShutdown(LoanedBuffer outbound) {
+            // no-op
+        }
+
+        @Override public void close() {
+            // no-op
+        }
+    }
+
+    /** Simulates an (unsupported) buffer-owner engine writing ciphertext into the buffer. */
+    private static final class BufferOwnerTlsEngine implements TlsEngine {
+        @Override
+        public TlsStatus wrap(LoanedBuffer plaintext, LoanedBuffer ciphertext) {
+            ciphertext.setSize(1);
+            return TlsStatus.OK;
+        }
+
+        @Override public TlsStatus beginHandshake(LoanedBuffer outbound) {
+            return TlsStatus.OK;
+        }
+
+        @Override public TlsStatus unwrap(LoanedBuffer ciphertext, LoanedBuffer plaintext) {
+            return TlsStatus.OK;
+        }
+
+        @Override public boolean isHandshakeComplete() {
+            return true;
+        }
+
+        @Override public String negotiatedProtocol() {
+            return "h2";
+        }
+
+        @Override public void initiateShutdown(LoanedBuffer outbound) {
+            // no-op
+        }
+
+        @Override public void close() {
+            // no-op
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWriteTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpStreamPendingWriteTest.java
@@ -64,9 +64,11 @@ final class NativeTcpStreamPendingWriteTest {
         assertThat(after - before).as("prepareCipher must not allocate on the fd-owner egress path").isZero();
         assertThat(engine.wrapCalls).isEqualTo(1);
         assertThat(placeholder.size()).as("placeholder stays empty and reusable").isZero();
-        // Idempotent (already-prepared returns OK) and writeCipher no-ops: the ciphertext is already
-        // on the socket via wrap()'s SSL_write, so there is nothing left to drain.
+        // Idempotent: a second prepareCipher() returns OK WITHOUT re-invoking wrap() (guarded by the
+        // cipherPrepared flag). Re-wrapping would re-run SSL_write on the same plaintext — silent wire
+        // corruption — so true idempotency must hold independently of the production drain loop.
         assertThat(pending.prepareCipher()).isEqualTo(TlsStatus.OK);
+        assertThat(engine.wrapCalls).as("second prepareCipher must not re-invoke wrap").isEqualTo(1);
         pending.close();
     }
 
@@ -85,7 +87,7 @@ final class NativeTcpStreamPendingWriteTest {
         LoanedBuffer plain = allocator.allocateNetwork(bytes.length);
         MemorySegment.copy(MemorySegment.ofArray(bytes), 0, plain.segment(), 0, bytes.length);
         NativeTcpStreamPendingWrite.TlsContext ctx =
-                new NativeTcpStreamPendingWrite.TlsContext(engine, new Object(), allocator, placeholder);
+                new NativeTcpStreamPendingWrite.TlsContext(engine, new Object(), placeholder);
         return new NativeTcpStreamPendingWrite(plain, bytes.length, ctx, (src, off, len) -> len);
     }
 


### PR DESCRIPTION
## Summary

First fix in the v0.9 TLS-path perf investigation. Targets the **common root cause** behind the TLS throughput loss that hits **both** H1+TLS (~−26%) and H2+TLS (~−42%) — not crypto, but allocation/reactor churn (per JFR: ~44% alloc pressure on buffers, ~5 Young GC/s, `runLoop`/CLQ-pool-freelist dominating CPU; OpenSSL absent from hot methods).

### The waste
On every outbound drain, `NativeTcpStreamPendingWrite.prepareCipher()` allocated a `plainLength + 1024` ciphertext buffer and passed it to `TlsEngine.wrap()`. But in **fd-owner BIO** mode — the only mode `NativeTcpStream` accepts (buffer-owner engines are rejected at construction, `NativeTcpStream.java:191`) — `wrap()` pushes ciphertext straight to the kernel socket via `SSL_write` and never touches that buffer (`size()` stays 0, `OffHeapTlsEngine.wrap`). The buffer was allocated, ignored, and immediately closed. **Pure dead weight, paid per write on both protocols** (H2 ≥2×/response via multi-frame → larger regression).

### Fix (Community-internal, zero SPI)
Reuse the per-stream empty `tlsCiphertextPlaceholder` — already used for ingress unwrap (#190) — for egress `wrap()` too, threaded through the `PendingWrite.TlsContext`. No allocation on the wrap path.

**Why not a `TlsEngine` capability flag (Option B):** that would put a BIO-mode signal on the SPI contract and erode the Community↔Enterprise easy-swap. The mode is already known locally (`NativeTcpStream` only accepts `CommunityTlsEngine`), so the fix stays codec-internal with no SPI surface. A buffer-owner engine that ever wrote into the shared placeholder now **fails loud** (`IllegalStateException`) rather than corrupting the wire — unreachable today, but a guarded invariant.

### Behavior unchanged
`wrap()` already left ciphertext `size()==0`; `writeCipher()` already no-ops on `cipherLength==0`. This removes an **allocation**, not a syscall — wire behavior / `SocketWrite` counts are unchanged.

## Tests
- `NativeTcpStreamPendingWriteTest` (new): asserts `prepareCipher` allocates **nothing** on the fd-owner path (`allocationCount` delta == 0), is idempotent, and fails loud on a buffer-owner engine.
- Full transport / TLS / HTTP suites green; **0 PMD / 0 Checkstyle**.

## Validation (bench host — not yet run)
Per the JFR analysis, expect on re-run (2–3 repetitions):
- H1+TLS **and** H2+TLS: JFR allocation-by-site + Young-GC count drop.
- Plaintext: flat (never enters the TLS branch — neutrality proof).
- `SocketWrite` count/byte distribution: unchanged.

This is the first of several ranked transport-perf fixes; H2-specific frame coalescing and ingress-slab right-sizing follow once this baseline recovery is measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)