### PR TITLE
perf(transport): dispatch reactor events off SelectionKey attachment, not per-event CHM lookup

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -601,12 +601,7 @@ public final class NativeTcpCarrier implements TransportEngine {
         return channelRuntimeRegistry.resolveStream(channel);
     }
 
-    /* default */ void readIngress(SocketChannel channel) {
-        NativeTcpStream stream = resolveStream(channel);
-        if (stream == null) {
-            return;
-        }
-
+    /* default */ void readIngress(NativeTcpStream stream) {
         if (stream.usesFdOwnerTls()) {
             LoanedBuffer offered = stream.readTlsIngressFromFd();
             if (offered != null) {
@@ -645,13 +640,7 @@ public final class NativeTcpCarrier implements TransportEngine {
         return stream.decryptIngress(slab, read);
     }
 
-    /* default */ void flushStream(SocketChannel channel, SelectionKey key) {
-        NativeTcpStream stream = resolveStream(channel);
-        if (stream == null) {
-            key.interestOps(SelectionKey.OP_READ);
-            return;
-        }
-
+    /* default */ void flushStream(NativeTcpStream stream, SelectionKey key) {
         stream.signalWriteReady();
         boolean drained = stream.flushPendingWrites();
         if (drained && !stream.hasPendingData()) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
@@ -154,11 +154,15 @@ final class NativeTcpReactor {
                         if (!key.isValid()) {
                             continue;
                         }
+                        NativeTcpStream attached = (NativeTcpStream) key.attachment();
+                        if (attached == null) {
+                            continue;
+                        }
                         if (key.isReadable()) {
-                            host.readIngress((SocketChannel) key.channel());
+                            host.readIngress(attached);
                         }
                         if (key.isWritable()) {
-                            host.flushStream((SocketChannel) key.channel(), key);
+                            host.flushStream(attached, key);
                         }
                     } catch (CancelledKeyException _) {
                         // channel closed concurrently by VT handler path
@@ -210,7 +214,11 @@ final class NativeTcpReactor {
                 int interestOps = enableWriteOnRegister
                         ? SelectionKey.OP_READ | SelectionKey.OP_WRITE
                         : SelectionKey.OP_READ;
-                channel.register(selector, interestOps);
+                // Attach the resolved stream so the per-event dispatch reads it off the key
+                // (key.attachment()) instead of a ConcurrentHashMap lookup per readable/writable
+                // event. The runtime maps stay authoritative for off-reactor callers
+                // (requestWriteInterest / onStreamClosed) and for registration itself.
+                channel.register(selector, interestOps, stream);
                 if (stream != null) {
                     stream.markRegistrationReady();
                 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
@@ -47,6 +47,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
     "PMD.AvoidCatchingGenericException", // selector loop must catch RuntimeException from key dispatch.
     "PMD.CloseResource",                 // Selector lifetime is owned by NativeTcpCarrier.closeSelectorAndChannels.
     "PMD.CyclomaticComplexity",          // reactor lifecycle (start/drain/loop/cancel) is intrinsically cohesive.
+    "PMD.GodClass",                      // WMC tipped +1 by extracting dispatchSelectedKey (lower per-method
+                                         // cognitive complexity); the reactor orchestrator stays cohesive.
     "PMD.TooManyMethods"                 // selector + MPSC queue + interest set lifecycle co-located by design.
 })
 final class NativeTcpReactor {
@@ -126,10 +128,8 @@ final class NativeTcpReactor {
         }
     }
 
-    @SuppressWarnings({
-        "PMD.CognitiveComplexity",   // selector loop drains MPSC, polls keys, dispatches READ/WRITE — flat structure.
-        "PMD.CyclomaticComplexity"   // single hot loop with key.isValid/isReadable/isWritable branches.
-    })
+    @SuppressWarnings("PMD.CognitiveComplexity") // selector loop drains MPSC + polls keys; per-key
+    // dispatch extracted to dispatchSelectedKey (PERF-073) so cyclomatic complexity no longer trips.
     private void runLoop() {
         while (host.isRunning()) {
             try {
@@ -151,19 +151,7 @@ final class NativeTcpReactor {
                     iterator.remove();
 
                     try {
-                        if (!key.isValid()) {
-                            continue;
-                        }
-                        NativeTcpStream attached = (NativeTcpStream) key.attachment();
-                        if (attached == null) {
-                            continue;
-                        }
-                        if (key.isReadable()) {
-                            host.readIngress(attached);
-                        }
-                        if (key.isWritable()) {
-                            host.flushStream(attached, key);
-                        }
+                        dispatchSelectedKey(key);
                     } catch (CancelledKeyException _) {
                         // channel closed concurrently by VT handler path
                     } catch (RuntimeException _) {
@@ -176,6 +164,30 @@ final class NativeTcpReactor {
                 }
                 return;
             }
+        }
+    }
+
+    // PERF-073: dispatch a single selected key by reading the stream off key.attachment()
+    // (set at registerChannel) instead of a per-event runtimeByChannel lookup. Extracted from
+    // runLoop so the select loop stays low-complexity.
+    private void dispatchSelectedKey(SelectionKey key) {
+        if (!key.isValid()) {
+            return;
+        }
+        NativeTcpStream attached = (NativeTcpStream) key.attachment();
+        if (attached == null) {
+            // Degenerate (stream null at register): clear write interest so the key does not
+            // re-fire writable every select cycle (matches the pre-attachment flushStream path).
+            if (key.isWritable()) {
+                key.interestOps(SelectionKey.OP_READ);
+            }
+            return;
+        }
+        if (key.isReadable()) {
+            host.readIngress(attached);
+        }
+        if (key.isWritable()) {
+            host.flushStream(attached, key);
         }
     }
 
@@ -214,10 +226,8 @@ final class NativeTcpReactor {
                 int interestOps = enableWriteOnRegister
                         ? SelectionKey.OP_READ | SelectionKey.OP_WRITE
                         : SelectionKey.OP_READ;
-                // Attach the resolved stream so the per-event dispatch reads it off the key
-                // (key.attachment()) instead of a ConcurrentHashMap lookup per readable/writable
-                // event. The runtime maps stay authoritative for off-reactor callers
-                // (requestWriteInterest / onStreamClosed) and for registration itself.
+                // PERF-073: attach the stream so runLoop reads key.attachment() instead of a
+                // per-event runtimeByChannel lookup; the maps stay authoritative for off-reactor callers.
                 channel.register(selector, interestOps, stream);
                 if (stream != null) {
                     stream.markRegistrationReady();


### PR DESCRIPTION
## Summary

Second transport-perf fix (after #194). Targets the per-event ConcurrentHashMap lookup the reactor did to find the stream for each readable/writable event.

JFR (h2load, loopback, entity-read, **post-#194**) hot methods:
- `ChannelRuntimeRegistry.resolveRuntime` — **6.4%**
- `ConcurrentHashMap.get` — **6.2%**

Both come from `runtimeByChannel.get(channel)` inside `readIngress`/`flushStream`, called **per reactor event** — it scales with event count, not connection count.

### Fix
- Attach the resolved `NativeTcpStream` to the `SelectionKey` at registration (`channel.register(selector, ops, stream)` — the stream is already resolved there).
- The per-event dispatch reads `key.attachment()` instead of looking up the channel in the map.
- `readIngress` / `flushStream` (whose **only** caller is the reactor dispatch) now take the stream directly.

### Scope / safety
- The runtime maps stay authoritative for the off-reactor / once-per-connection callers (`registerChannel`, `requestWriteInterest`, `onStreamClosed`, `closeKeyStream`, diagnostics). Only the hot per-event reactor-thread lookups move to the attachment.
- Protocol-agnostic — helps both H1 and H2.
- A cancelled key fails `isValid()` before the attachment read; a null attachment (degenerate: stream null at register) is skipped defensively.
- Community-internal, no SPI surface.

## Validation
This is an **rps/core efficiency** change — validate by JFR CPU-profile share (`resolveRuntime` + `ConcurrentHashMap.get` should drop), **not** loopback throughput (CPU-saturated + run-to-run noisy, as #194 established; take 2–3 reps).

- Transport / reactor / HTTP suites green (201 tests).
- Real reactor read dispatch covered by `NativeTcpCarrierIngressIntegrationTest` (live sockets).
- 0 PMD / 0 Checkstyle.

Part of the ranked transport-perf series; next candidates: H2 frame coalescing (buffer-count) and the higher-risk LoanedBuffer wrapper/release-action pooling (the `close()` 15.5% + `allocateOwned` 7.9% cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)