### PR TITLE
perf(memory): drop redundant per-buffer pooledReturnDone AtomicBoolean

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/memory/CommunityLoanedBuffer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/memory/CommunityLoanedBuffer.java
@@ -12,7 +12,6 @@ import eu.exeris.kernel.core.memory.AbstractLoanedBuffer;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Community: Off-heap {@link eu.exeris.kernel.spi.memory.LoanedBuffer} backed by shared
@@ -43,7 +42,6 @@ final class CommunityLoanedBuffer extends AbstractLoanedBuffer {
     private final CommunityArenaShardPool pool;
     private final long originalCapacityBytes;
     private final int originShard;
-    private final AtomicBoolean pooledReturnDone = new AtomicBoolean(false);
 
     // =========================================================================
     // Constructor — DeclarationOrder: fields → constructor → static factories
@@ -114,7 +112,10 @@ final class CommunityLoanedBuffer extends AbstractLoanedBuffer {
 
     @Override
     protected void onRelease() {
-        if (pool != null && pooledReturnDone.compareAndSet(false, true)) {
+        // AbstractLoanedBuffer.close() invokes onRelease() exactly once — the refcount CAS only
+        // reaches the isInitialCount branch for the single thread that performs the final
+        // decrement — so no extra idempotency guard is needed for the segment return.
+        if (pool != null) {
             pool.returnSegment(originalCapacityBytes, originShard, segment);
         }
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/memory/CommunityLoanedBuffer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/memory/CommunityLoanedBuffer.java
@@ -112,9 +112,7 @@ final class CommunityLoanedBuffer extends AbstractLoanedBuffer {
 
     @Override
     protected void onRelease() {
-        // AbstractLoanedBuffer.close() invokes onRelease() exactly once — the refcount CAS only
-        // reaches the isInitialCount branch for the single thread that performs the final
-        // decrement — so no extra idempotency guard is needed for the segment return.
+        // Single dispatch guaranteed by refcount CAS — see AbstractLoanedBuffer.onRelease().
         if (pool != null) {
             pool.returnSegment(originalCapacityBytes, originShard, segment);
         }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/memory/AbstractLoanedBuffer.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/memory/AbstractLoanedBuffer.java
@@ -85,6 +85,12 @@ public abstract class AbstractLoanedBuffer implements LoanedBuffer { //NOPMD Too
 
     protected abstract MemorySegment backingSegment();
 
+    /**
+     * Called exactly once when the final reference is released. {@link #close()} dispatches it
+     * only on the single thread whose refcount CAS reaches the {@code isInitialCount} branch, so
+     * implementations MUST NOT add their own idempotency guard — single dispatch is already
+     * guaranteed by the refcount CAS.
+     */
     protected abstract void onRelease();
 
     // =========================================================================


### PR DESCRIPTION
## Summary

First, lowest-risk step into the LoanedBuffer allocation cluster. JFR allocation-by-**class** (h2load, loopback, entity-read, post-#194/#195) shows the per-buffer machinery is ~25% of all allocation samples:

| Allocated class | samples | % | addressable by |
|---|---|---|---|
| `CommunityLoanedBuffer` (wrapper) | 6381 | 12.1% | wrapper pooling (high-risk, later) |
| `CommunityReleaseAction` | 3513 | 6.7% | wrapper pooling (high-risk, later) |
| `CommunityArenaShardPool$Allocation` | 2101 | 4.0% | pool-API tweak (medium, later) |
| **`AtomicBoolean` (`pooledReturnDone`)** | **1392** | **2.6%** | **this PR** |

### This change
`CommunityLoanedBuffer.onRelease()` returned its segment to the pool guarded by a per-buffer `AtomicBoolean pooledReturnDone`. That guard is **redundant**: `AbstractLoanedBuffer.close()` calls `onRelease()` only inside the `isInitialCount` branch, which the refcount `VarHandle` CAS lets exactly one thread (the final decrementer) reach — so `onRelease()` already fires **exactly once** per lifecycle (verified: it has no other caller; `resetForReuse()` does not call it).

Removing the `AtomicBoolean`:
- cuts ~2.6% of allocation volume (one fewer heap object per pooled buffer),
- removes a CAS from the `onRelease` path, which sits under `close()` — the current **#1 hot method (~19.5% CPU)** in the TLS profile,
- **unblocks future wrapper reuse** — a sticky `pooledReturnDone` would wrongly suppress the segment return on a reused wrapper's second lifecycle.

## Validation
- Memory / leak-detection / allocation / transport suites green (245+ tests); 0 PMD / 0 Checkstyle.
- Cross-run metric to watch on re-benchmark: `ObjectAllocationSample` (stable ~52k ±1% across all prior runs — the reliable signal) should drop by the `AtomicBoolean` share.

## Staged plan for the rest of the cluster
1. **(this PR)** redundant `AtomicBoolean` — 2.6%, low-risk.
2. `CommunityArenaShardPool$Allocation` record — 4%, medium (2-value pool return; needs an API tweak to avoid the per-call tuple).
3. Wrapper + `CommunityReleaseAction` pooling — ~18.8%, **high-risk** (mutable wrapper + `resetForReuse` + use-after-return hazard → JCStress + leak-TCK, possible ADR). Decide after measuring 1–2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)