### PR TITLE
perf(transport): drain all buffered TLS records per readable event (ingress loop-drain)

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -66,11 +66,11 @@ public final class NativeTcpCarrier implements TransportEngine {
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
     private static final int MIN_LISTENER_BACKLOG = 64;
     private static final int MAX_LISTENER_BACKLOG = 1_024;
-    // Fairness cap on TLS records drained per readable event (ingress loop-drain). One readable
-    // event pumps up to this many records (one SSL_read each) instead of one record per reactor
-    // iteration, so a single busy connection cannot monopolise the reactor thread; the
-    // level-triggered selector re-reports any remainder on the next select().
-    private static final int MAX_TLS_RECORDS_PER_READ = 32;
+    // Fairness cap on TLS records drained per readable event (see readIngress / PERF-062 in
+    // docs/subsystems/transport.md). Overridable for field tuning, mirroring
+    // exeris.transport.queueBackpressureEnabled.
+    private static final int MAX_TLS_RECORDS_PER_READ =
+            Integer.parseInt(System.getProperty("exeris.transport.maxTlsRecordsPerRead", "32"));
 
     private final TransportConfig config;
     private final MemoryAllocator allocator;
@@ -608,12 +608,9 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     /* default */ void readIngress(NativeTcpStream stream) {
         if (stream.usesFdOwnerTls()) {
-            // Drain all TLS records buffered for this connection in one readable event (loop SSL_read
-            // until no record / backpressure) instead of one record per reactor iteration — collapses
-            // the per-record readIngress + slab-alloc + dispatch overhead that makes TLS h2 burn ~2.5x
-            // the cores of plaintext. readTlsIngressFromFd() returns null on WANT_READ, inbound-queue
-            // backpressure, or close, ending the loop; MAX_TLS_RECORDS_PER_READ bounds the per-event
-            // share so other connections on this reactor thread are not starved.
+            // PERF-062: drain all buffered TLS records in one readable event (loop until null =
+            // WANT_READ / backpressure / close), bounded by MAX_TLS_RECORDS_PER_READ for fairness.
+            // See docs/subsystems/transport.md. The level-triggered selector re-reports any remainder.
             for (int drained = 0; drained < MAX_TLS_RECORDS_PER_READ; drained++) {
                 LoanedBuffer offered = stream.readTlsIngressFromFd();
                 if (offered == null) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -66,6 +66,11 @@ public final class NativeTcpCarrier implements TransportEngine {
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
     private static final int MIN_LISTENER_BACKLOG = 64;
     private static final int MAX_LISTENER_BACKLOG = 1_024;
+    // Fairness cap on TLS records drained per readable event (ingress loop-drain). One readable
+    // event pumps up to this many records (one SSL_read each) instead of one record per reactor
+    // iteration, so a single busy connection cannot monopolise the reactor thread; the
+    // level-triggered selector re-reports any remainder on the next select().
+    private static final int MAX_TLS_RECORDS_PER_READ = 32;
 
     private final TransportConfig config;
     private final MemoryAllocator allocator;
@@ -603,8 +608,17 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     /* default */ void readIngress(NativeTcpStream stream) {
         if (stream.usesFdOwnerTls()) {
-            LoanedBuffer offered = stream.readTlsIngressFromFd();
-            if (offered != null) {
+            // Drain all TLS records buffered for this connection in one readable event (loop SSL_read
+            // until no record / backpressure) instead of one record per reactor iteration — collapses
+            // the per-record readIngress + slab-alloc + dispatch overhead that makes TLS h2 burn ~2.5x
+            // the cores of plaintext. readTlsIngressFromFd() returns null on WANT_READ, inbound-queue
+            // backpressure, or close, ending the loop; MAX_TLS_RECORDS_PER_READ bounds the per-event
+            // share so other connections on this reactor thread are not starved.
+            for (int drained = 0; drained < MAX_TLS_RECORDS_PER_READ; drained++) {
+                LoanedBuffer offered = stream.readTlsIngressFromFd();
+                if (offered == null) {
+                    return;
+                }
                 stream.offerIngress(offered);
             }
             return;

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpClientServerE2eIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpClientServerE2eIntegrationTest.java
@@ -231,6 +231,102 @@ class NativeTcpClientServerE2eIntegrationTest {
         }
     }
 
+    @Test
+    @DisplayName("TLS ingress drains a burst of multiple records (loop-drain path, PERF-062)")
+    void clientServerTlsRecordBurstDrains() throws Exception {
+        int port = nextFreePort();
+        int messages = 16;
+        byte[] unit = "tls-burst-record!".getBytes(StandardCharsets.UTF_8);
+        int total = unit.length * messages;
+        CountDownLatch handled = new CountDownLatch(1);
+        byte[][] received = new byte[1][];
+
+        assumeTrue(isSocketFdAccessible(),
+            "SocketChannel FileDescriptor field access is unavailable without --add-opens java.base/sun.nio.ch=ALL-UNNAMED and --add-opens java.base/java.io=ALL-UNNAMED");
+
+        Path certPath = Path.of("..", "native-libs", "certs", "server.crt").normalize();
+        Path keyPath = Path.of("..", "native-libs", "certs", "server.key").normalize();
+        assumeTrue(Files.isRegularFile(certPath) && Files.isRegularFile(keyPath),
+                "TLS test cert/key not found — skipping test");
+
+        KernelCryptoProvider cryptoProvider;
+        try {
+            cryptoProvider = new CommunityKernelCryptoProvider();
+        } catch (RuntimeException ex) {
+            assumeTrue(false, "OpenSSL runtime unavailable — skipping TLS E2E test");
+            return;
+        }
+
+        NativeTcpTransportProvider provider = new NativeTcpTransportProvider();
+        TransportEngine[] serverHolder = new TransportEngine[1];
+        TransportEngine[] clientHolder = new TransportEngine[1];
+
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
+                .where(KernelProviders.CRYPTO_PROVIDER, cryptoProvider)
+                .run(() -> {
+                    serverHolder[0] = provider.createEngine(new TransportConfig(
+                            TransportMode.SERVER, "127.0.0.1", port, 1,
+                            certPath.toString(), keyPath.toString(), 1024, 30_000));
+                    clientHolder[0] = provider.createEngine(new TransportConfig(
+                            TransportMode.CLIENT, "127.0.0.1", 0, 1, null, null, 1024, 30_000));
+                });
+
+        TransportEngine server = serverHolder[0];
+        TransportEngine client = clientHolder[0];
+
+        // Server accumulates every byte of the burst. The reactor's readIngress loop-drains all
+        // TLS records buffered per readable event; the handler reads them out of the inbound queue.
+        server.setStreamHandler(stream -> {
+            try (LoanedBuffer inbound = ALLOCATOR.allocateNetwork(total)) {
+                int got = 0;
+                int idleSpins = 0;
+                while (got < total && idleSpins < 100_000) {
+                    int r = stream.read(inbound.segment().asSlice(got, total - got), total - got);
+                    if (r > 0) {
+                        got += r;
+                        idleSpins = 0;
+                    } else if (r < 0) {
+                        break;
+                    } else {
+                        idleSpins++;
+                    }
+                }
+                byte[] acc = new byte[got];
+                inbound.segment().asSlice(0, got).asByteBuffer().get(acc);
+                received[0] = acc;
+            } finally {
+                handled.countDown();
+            }
+        });
+
+        try {
+            server.start();
+            client.start();
+
+            TransportConnection connection = client.connect("127.0.0.1", port);
+            try (TransportStream stream = connection.openStream();
+                 LoanedBuffer outbound = ALLOCATOR.allocateNetwork(unit.length)) {
+                // Burst: 16 back-to-back writes → 16 TLS records → the server reactor drains them
+                // across one (or few) readable events, exercising multiple loop-drain iterations.
+                for (int i = 0; i < messages; i++) {
+                    outbound.segment().asSlice(0, unit.length).asByteBuffer().put(unit);
+                    outbound.setSize(unit.length);
+                    stream.write(outbound.segment(), unit.length);
+                }
+                assertThat(handled.await(10, TimeUnit.SECONDS)).isTrue();
+            }
+
+            assertThat(received[0]).hasSize(total);
+            for (int i = 0; i < messages; i++) {
+                byte[] slice = Arrays.copyOfRange(received[0], i * unit.length, (i + 1) * unit.length);
+                assertThat(Arrays.equals(slice, unit)).as("record %d intact", i).isTrue();
+            }
+        } finally {
+            client.close();
+            server.close();
+        }
+    }
+
     private static int nextFreePort() {
         try (ServerSocketChannel server = ServerSocketChannel.open()) {
             server.bind(new InetSocketAddress("127.0.0.1", 0));


### PR DESCRIPTION
## Summary

Attacks the **root cause** of the TLS throughput gap, confirmed by a target-bound JFR A/B (h2 entity-read, target pinned / driver disjoint):

| | cores | rps | rps/core | CPU samples |
|---|---|---|---|---|
| plaintext h2 | 2.06 | 6477 | 3144 | 9225 |
| **TLS h2** | **5.22** | 4656 | 892 | **22370 (2.4×)** |

The TLS path burns **2.4× the CPU for fewer requests** — and it is **not** crypto (OpenSSL absent from the profile), **not** affinity (plaintext is neutral with pinning), **not** lock contention (`JavaMonitorEnter` 254; carriers idle-park on `ForkJoinPool.awaitWork`). It is **I/O event multiplication**: `NativeTcpStream.readTlsIngressFromFd()` did **one `SSL_read` (one TLS record) per reactor readable event**, so a connection with N buffered records cost N reactor iterations — each paying the full `readIngress` + slab-alloc + dispatch fixed cost. `readIngress` was the **#1 TLS hot method (12.6%)** yet absent from the plaintext top (plaintext `readPlainIngress` already drains a full slab per event). wrk never shows the gap: H1 1-req/conn = one large record, minimal events; h2load h2 multiplexes many small frames.

### Fix
`NativeTcpCarrier.readIngress()` now **loops** `readTlsIngressFromFd()` within one readable event, draining all buffered TLS records instead of one. Loop ends on `null` (WANT_READ / inbound-queue backpressure / close — all already returned as null), bounded by `MAX_TLS_RECORDS_PER_READ` (32) so one busy connection cannot starve others; the level-triggered selector re-reports any remainder next `select()`. Collapses N reactor cycles → 1.

### Scope / safety
- Community-internal, no SPI. TLS branch only (plaintext already drains a slab/event).
- Backpressure preserved (the existing `INBOUND_QUEUE_CAPACITY` guard inside `readTlsIngressFromFd` returns null when full → loop stops).
- Fairness cap + level-triggered selector → no starvation, no missed data.

## Validation
- Transport / reactor / HTTP suites green (190); real reactor TLS read path covered by `NativeTcpCarrierIngressIntegrationTest` (5 green); 0 PMD / 0 Checkstyle.
- On the target-bound rig: expect the `readIngress` CPU-profile share to drop and target rps/core to rise (2–3 reps; per-method share is the reliable signal, not single-run throughput).

Next ranked lever: egress H2 frame coalescing (#1) — batch HEADERS+DATA into fewer/larger `SSL_write` → fewer records, the egress counterpart of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)