### PR TITLE
perf(http2): coalesce a response's frames into one socket write (egress)

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
@@ -428,17 +428,20 @@ final class CommunityHttp2SessionProcessor {
                         position = serializeDataFrames(
                                 outbound.segment(), position, streamId, bodyBuffer.segment(), bodyBytes);
                     }
-                    outbound.setSize(position);
                     stream.write(outbound.segment(), (int) position);
                 }
             }
         }
     }
 
-    /** Number of frames a payload of {@code payloadLength} bytes spans (one frame even when empty). */
+    /**
+     * Number of HTTP/2 frames a payload of {@code payloadLength} bytes spans — zero when empty, to
+     * match the serialize loops (which emit no frame for a zero-length payload). Used only to size
+     * the coalescing buffer; the actual written length is the position returned by serialization.
+     */
     private static int frameCount(int payloadLength) {
         if (payloadLength <= 0) {
-            return 1;
+            return 0;
         }
         return (payloadLength + HTTP2_MAX_FRAME_PAYLOAD_BYTES - 1) / HTTP2_MAX_FRAME_PAYLOAD_BYTES;
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttp2SessionProcessor.java
@@ -407,29 +407,40 @@ final class CommunityHttp2SessionProcessor {
                                     Http2SessionContext session,
                                     int streamId,
                                     HttpResponse response) {
-        // PERF-061: per-response reusable outbound carrier sized to MAX frame header + payload.
-        // One borrow replaces (1 HEADERS/CONTINUATION + N DATA) per-frame allocations from the
-        // pre-PERF-061 path. Frame writers receive a slice of this carrier and serialize the
-        // wire image in-place; no per-frame slab borrow + free cycle on the response hot path.
-        try (LoanedBuffer headerBlock = allocator.allocateNetwork(HTTP2_MAX_HEADER_BLOCK_BYTES);
-             LoanedBuffer outboundFrame = allocator.allocateNetwork(
-                     Http2FrameParser.FRAME_HEADER_SIZE + HTTP2_MAX_FRAME_PAYLOAD_BYTES)) {
-            long headerBytes = session.encodeResponseHeaders(headerBlock.segment(), response);
+        // PERF (egress coalesce): serialize the whole framed response (HEADERS[+CONTINUATION] + all
+        // DATA) into ONE buffer and issue a single stream.write(), so the TLS path does one
+        // wrap()/SSL_write and the reactor one outbound enqueue per response instead of one per frame.
+        // Wire framing is unchanged — still multiple H2 frames, each <= SETTINGS_MAX_FRAME_SIZE; only
+        // the socket write is coalesced.
+        try (LoanedBuffer headerBlock = allocator.allocateNetwork(HTTP2_MAX_HEADER_BLOCK_BYTES)) {
+            int headerBytes = (int) session.encodeResponseHeaders(headerBlock.segment(), response);
             LoanedBuffer bodyBuffer = response.body();
-            int bodyBytes = bodyBuffer == null ? 0 : (int) bodyBuffer.size();
-            boolean headerEndsStream = bodyBytes == 0;
-            writeHttp2HeaderBlockFrames(stream, streamId, headerBlock.segment(), (int) headerBytes,
-                    headerEndsStream, outboundFrame);
-
-            if (bodyBuffer != null) {
-                try (bodyBuffer) {
+            try (bodyBuffer) {
+                int bodyBytes = bodyBuffer == null ? 0 : (int) bodyBuffer.size();
+                boolean headerEndsStream = bodyBytes == 0;
+                int dataFrames = bodyBytes == 0 ? 0 : frameCount(bodyBytes);
+                long framedSize = (long) headerBytes + bodyBytes
+                        + (long) Http2FrameParser.FRAME_HEADER_SIZE * (frameCount(headerBytes) + dataFrames);
+                try (LoanedBuffer outbound = allocator.allocateNetwork((int) framedSize)) {
+                    long position = serializeHeaderBlockFrames(
+                            outbound.segment(), 0L, streamId, headerBlock.segment(), headerBytes, headerEndsStream);
                     if (bodyBytes > 0) {
-                        writeHttp2DataFrames(stream, streamId, bodyBuffer.segment(), bodyBytes,
-                                outboundFrame);
+                        position = serializeDataFrames(
+                                outbound.segment(), position, streamId, bodyBuffer.segment(), bodyBytes);
                     }
+                    outbound.setSize(position);
+                    stream.write(outbound.segment(), (int) position);
                 }
             }
         }
+    }
+
+    /** Number of frames a payload of {@code payloadLength} bytes spans (one frame even when empty). */
+    private static int frameCount(int payloadLength) {
+        if (payloadLength <= 0) {
+            return 1;
+        }
+        return (payloadLength + HTTP2_MAX_FRAME_PAYLOAD_BYTES - 1) / HTTP2_MAX_FRAME_PAYLOAD_BYTES;
     }
 
     private void writeHttp2NoBodyResponse(TransportStream stream,
@@ -439,14 +450,15 @@ final class CommunityHttp2SessionProcessor {
         writeHttp2Response(stream, session, streamId, HttpResponse.noBody(status, HttpVersion.HTTP_2));
     }
 
-    private void writeHttp2HeaderBlockFrames(TransportStream stream,
-                                             int streamId,
-                                             MemorySegment headerBlock,
-                                             int headerLength,
-                                             boolean endStream,
-                                             LoanedBuffer outboundFrame) {
+    private static long serializeHeaderBlockFrames(MemorySegment target,
+                                                   long position,
+                                                   int streamId,
+                                                   MemorySegment headerBlock,
+                                                   int headerLength,
+                                                   boolean endStream) {
         int written = 0;
         boolean firstFrame = true;
+        long pos = position;
         while (written < headerLength) {
             int chunk = Math.min(HTTP2_MAX_FRAME_PAYLOAD_BYTES, headerLength - written);
             boolean last = (written + chunk) == headerLength;
@@ -455,51 +467,49 @@ final class CommunityHttp2SessionProcessor {
             if (firstFrame && endStream) {
                 flags |= HTTP2_FLAG_END_STREAM;
             }
-            writeHttp2Frame(stream, type, flags, streamId, headerBlock, written, chunk, outboundFrame);
+            pos = serializeFrame(target, pos, type, flags, streamId, headerBlock, written, chunk);
             written += chunk;
             firstFrame = false;
         }
+        return pos;
     }
 
-    private void writeHttp2DataFrames(TransportStream stream,
-                                      int streamId,
-                                      MemorySegment body,
-                                      int bodyLength,
-                                      LoanedBuffer outboundFrame) {
+    private static long serializeDataFrames(MemorySegment target,
+                                            long position,
+                                            int streamId,
+                                            MemorySegment body,
+                                            int bodyLength) {
         int written = 0;
+        long pos = position;
         while (written < bodyLength) {
             int chunk = Math.min(HTTP2_MAX_FRAME_PAYLOAD_BYTES, bodyLength - written);
             boolean endStream = (written + chunk) == bodyLength;
             int flags = endStream ? HTTP2_FLAG_END_STREAM : 0;
-            writeHttp2Frame(stream, Http2FrameType.DATA.code(), flags, streamId, body, written, chunk,
-                    outboundFrame);
+            pos = serializeFrame(target, pos, Http2FrameType.DATA.code(), flags, streamId, body, written, chunk);
             written += chunk;
         }
+        return pos;
     }
 
-    private void writeHttp2Frame(TransportStream stream,
-                                 int frameType,
-                                 int flags,
-                                 int streamId,
-                                 MemorySegment payloadSource,
-                                 int payloadOffset,
-                                 int payloadLength,
-                                 LoanedBuffer outboundFrame) {
-        // PERF-061: serialize the frame wire image into the per-response reusable carrier.
-        // No allocator borrow on the per-frame path; the carrier is sized to one full frame
-        // (header + max payload) and is reused across every frame in the response.
-        Http2FrameEncoder.writeHeader(outboundFrame.segment(), 0, payloadLength, frameType, flags, streamId);
+    /**
+     * Serializes one frame (9-byte header + payload slice) into {@code target} at {@code position}
+     * and returns the position just past it. No socket write — the whole response is written once by
+     * the caller (egress coalescing).
+     */
+    private static long serializeFrame(MemorySegment target,
+                                       long position,
+                                       int frameType,
+                                       int flags,
+                                       int streamId,
+                                       MemorySegment payloadSource,
+                                       int payloadOffset,
+                                       int payloadLength) {
+        Http2FrameEncoder.writeHeader(target, position, payloadLength, frameType, flags, streamId);
+        long payloadPos = position + Http2FrameParser.FRAME_HEADER_SIZE;
         if (payloadLength > 0) {
-            MemorySegment.copy(
-                    payloadSource,
-                    payloadOffset,
-                    outboundFrame.segment(),
-                    Http2FrameParser.FRAME_HEADER_SIZE,
-                    payloadLength);
+            MemorySegment.copy(payloadSource, payloadOffset, target, payloadPos, payloadLength);
         }
-        long written = Http2FrameParser.FRAME_HEADER_SIZE + (long) payloadLength;
-        outboundFrame.setSize(written);
-        stream.write(outboundFrame.segment(), (int) written);
+        return payloadPos + payloadLength;
     }
 
     private int readHttp2Bytes(TransportStream stream,

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
@@ -583,6 +583,78 @@ class CommunityHttpRequestProcessorTest {
         assertThat(dataPayload).isEqualTo(body);
     }
 
+    @Test
+    @DisplayName("HTTP/2 multi-frame DATA body splits into <=16KiB frames coalesced into one write")
+    void h2MultiDataFrameBodyCoalescedAndWireCorrect() {
+        byte[] preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] hpack = encodeHpackHeaders(List.of(
+                new HttpHeader(":method", "GET"),
+                new HttpHeader(":path", "/big"),
+                new HttpHeader(":scheme", "http"),
+                new HttpHeader(":authority", "localhost")));
+
+        ByteArrayOutputStream inbound = new ByteArrayOutputStream();
+        inbound.writeBytes(preface);
+        inbound.writeBytes(emptySettingsFrame());
+        inbound.writeBytes(headersFrame(1, hpack, true, true));
+
+        // 40000 B > 2 * 16384 → exactly 3 DATA frames (16384 + 16384 + 7232), exercising the
+        // serializeDataFrames loop boundary. Position-dependent bytes so any offset slip corrupts
+        // the reassembled body.
+        int maxFramePayload = 16 * 1024;
+        int bodyLen = 40_000;
+        byte[] body = new byte[bodyLen];
+        for (int i = 0; i < bodyLen; i++) {
+            body[i] = (byte) ((i * 31 + 7) & 0xFF);
+        }
+
+        CommunityHttpRequestProcessor processor = new CommunityHttpRequestProcessor(
+                ALLOCATOR, HttpResponseBodyEncoderRegistry.empty(), HttpConfig.defaultServer());
+        CapturingTransportStream stream = new CapturingTransportStream(inbound.toByteArray());
+
+        processor.process(stream, exchange -> {
+            LoanedBuffer responseBody = ALLOCATOR.allocateNetwork(body.length);
+            responseBody.segment().asSlice(0, body.length).asByteBuffer().put(body);
+            responseBody.setSize(body.length);
+            exchange.respond(new HttpResponse(HttpStatus.OK, HttpVersion.HTTP_2, List.of(), responseBody));
+        });
+
+        // All stream-1 HEADERS + DATA frames must arrive in exactly ONE socket write (coalesced),
+        // even when the body spans multiple DATA frames.
+        int responseWrites = 0;
+        int dataFramesInResponseWrite = 0;
+        for (byte[] segment : stream.writeSegments) {
+            List<FrameSnapshot> frames = decodeFrames(segment);
+            boolean hasStream1Response = frames.stream().anyMatch(f -> f.header().streamId() == 1
+                    && (f.header().frameType() == Http2FrameType.HEADERS
+                        || f.header().frameType() == Http2FrameType.DATA));
+            if (hasStream1Response) {
+                responseWrites++;
+                dataFramesInResponseWrite = (int) frames.stream().filter(
+                        f -> f.header().streamId() == 1 && f.header().frameType() == Http2FrameType.DATA).count();
+            }
+        }
+        assertThat(responseWrites).as("multi-frame response delivered in one socket write").isEqualTo(1);
+        assertThat(dataFramesInResponseWrite).as("body split into ceil(40000/16384) DATA frames").isEqualTo(3);
+
+        // Each DATA frame respects the max frame payload; concatenation equals the body (offsets);
+        // only the final DATA frame carries END_STREAM.
+        List<FrameSnapshot> dataFrames = decodeFrames(stream.responseBytes()).stream()
+                .filter(f -> f.header().frameType() == Http2FrameType.DATA && f.header().streamId() == 1)
+                .toList();
+        assertThat(dataFrames).hasSize(3);
+        ByteArrayOutputStream reassembled = new ByteArrayOutputStream();
+        for (int i = 0; i < dataFrames.size(); i++) {
+            FrameSnapshot frame = dataFrames.get(i);
+            assertThat(frame.payload().length).as("DATA frame within max frame payload")
+                    .isLessThanOrEqualTo(maxFramePayload);
+            assertThat(frame.header().isEndStream()).as("END_STREAM only on the final DATA frame")
+                    .isEqualTo(i == dataFrames.size() - 1);
+            reassembled.writeBytes(frame.payload());
+        }
+        assertThat(reassembled.toByteArray()).as("reassembled DATA payload equals original body").isEqualTo(body);
+    }
+
     private static byte[] emptySettingsFrame() {
             return new byte[]{0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00};
     }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessorTest.java
@@ -524,6 +524,65 @@ class CommunityHttpRequestProcessorTest {
                 | ((goAwayPayload[6] & 0xFF) << 8) | (goAwayPayload[7] & 0xFF);
     }
 
+    @Test
+    @DisplayName("HTTP/2 response HEADERS+DATA is coalesced into a single socket write")
+    void h2ResponseHeadersAndDataCoalescedIntoOneWrite() {
+        byte[] preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] hpack = encodeHpackHeaders(List.of(
+                new HttpHeader(":method", "GET"),
+                new HttpHeader(":path", "/body"),
+                new HttpHeader(":scheme", "http"),
+                new HttpHeader(":authority", "localhost")));
+
+        ByteArrayOutputStream inbound = new ByteArrayOutputStream();
+        inbound.writeBytes(preface);
+        inbound.writeBytes(emptySettingsFrame());
+        inbound.writeBytes(headersFrame(1, hpack, true, true));
+
+        byte[] body = "coalesced-response-body".getBytes(StandardCharsets.US_ASCII);
+
+        CommunityHttpRequestProcessor processor = new CommunityHttpRequestProcessor(
+                ALLOCATOR, HttpResponseBodyEncoderRegistry.empty(), HttpConfig.defaultServer());
+        CapturingTransportStream stream = new CapturingTransportStream(inbound.toByteArray());
+
+        processor.process(stream, exchange -> {
+            LoanedBuffer responseBody = ALLOCATOR.allocateNetwork(body.length);
+            responseBody.segment().asSlice(0, body.length).asByteBuffer().put(body);
+            responseBody.setSize(body.length);
+            // processor (writeHttp2Response) owns + closes the body buffer.
+            exchange.respond(new HttpResponse(HttpStatus.OK, HttpVersion.HTTP_2, List.of(), responseBody));
+        });
+
+        // Egress coalescing: the response stream-1 HEADERS and DATA frames must arrive in ONE
+        // socket write (not HEADERS in one write and DATA in another). Control frames (SETTINGS /
+        // SETTINGS-ACK) are stream 0 and excluded.
+        int responseWrites = 0;
+        boolean headersAndDataTogether = false;
+        for (byte[] segment : stream.writeSegments) {
+            List<FrameSnapshot> frames = decodeFrames(segment);
+            boolean hasHeaders = frames.stream().anyMatch(
+                    f -> f.header().frameType() == Http2FrameType.HEADERS && f.header().streamId() == 1);
+            boolean hasData = frames.stream().anyMatch(
+                    f -> f.header().frameType() == Http2FrameType.DATA && f.header().streamId() == 1);
+            if (hasHeaders || hasData) {
+                responseWrites++;
+            }
+            if (hasHeaders && hasData) {
+                headersAndDataTogether = true;
+            }
+        }
+        assertThat(headersAndDataTogether).as("HEADERS+DATA coalesced into one write").isTrue();
+        assertThat(responseWrites).as("response delivered in exactly one socket write").isEqualTo(1);
+
+        // Wire-correct: the single DATA frame on stream 1 carries the exact body bytes.
+        byte[] dataPayload = decodeFrames(stream.responseBytes()).stream()
+                .filter(f -> f.header().frameType() == Http2FrameType.DATA && f.header().streamId() == 1)
+                .map(FrameSnapshot::payload)
+                .findFirst()
+                .orElseThrow();
+        assertThat(dataPayload).isEqualTo(body);
+    }
+
     private static byte[] emptySettingsFrame() {
             return new byte[]{0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00};
     }
@@ -822,6 +881,7 @@ class CommunityHttpRequestProcessorTest {
         private final byte[] inbound;
         private int readOffset;
         private final ByteArrayOutputStream writes = new ByteArrayOutputStream();
+        private final List<byte[]> writeSegments = new ArrayList<>();
         private boolean closed;
 
         private CapturingTransportStream(String requestText) {
@@ -854,6 +914,7 @@ class CommunityHttpRequestProcessorTest {
             byte[] bytes = new byte[length];
             MemorySegment.copy(source, 0, MemorySegment.ofArray(bytes), 0, length);
             writes.writeBytes(bytes);
+            writeSegments.add(bytes);
         }
 
         @Override


### PR DESCRIPTION
## Summary

The egress counterpart to #197's ingress loop-drain, targeting the **dominant remaining TLS churn**. Per the #198 analysis, the per-record buffer cycle (CLQ poll/offer ~15.6% + `close()` + `allocateBuffer`) is **egress-bound**: `writeHttp2Response` issued a separate `stream.write()` for the HEADERS frame and for **each** DATA frame, so every response cost ≥2 outbound enqueues — and on TLS, ≥2 `PendingWrite` + `wrap()` + `SSL_write` cycles.

### Fix
Serialize the whole framed response (HEADERS[+CONTINUATION] + all DATA) into **one** buffer (sized to the framed length via `frameCount()`) and issue a **single** `stream.write()`. The wire framing is **unchanged** — still multiple H2 frames, each ≤ `SETTINGS_MAX_FRAME_SIZE`; only the socket write is coalesced, so the TLS path does one `wrap()`/`SSL_write` and the reactor one outbound enqueue per response.

The per-frame writers (`writeHttp2HeaderBlockFrames` / `writeHttp2DataFrames` / `writeHttp2Frame`) become offset-based serialize helpers (`serializeHeaderBlockFrames` / `serializeDataFrames` / `serializeFrame`) that write into the shared buffer and return the advanced position.

### Why this one (vs the closed #198)
#198 (reused ingress slab) was net-negative — ingress was already handled by #197, and it added a memcpy + RSS. Egress is where the response-side per-frame churn actually lives, and the Quarkus cross-check pinned the gap to fragmented-I/O buffer churn. This attacks that directly.

## Tests
- New `h2ResponseHeadersAndDataCoalescedIntoOneWrite`: a body response's HEADERS and DATA frames arrive in **exactly one** socket write (`CapturingTransportStream` now records per-write segments), and the DATA payload is wire-correct.
- Full HTTP/2 codec suite green (framing unchanged — the response-decoding tests confirm wire correctness).
- 0 PMD / 0 Checkstyle.

## Validation on the target-bound rig
Re-bench h2load H2+TLS: expect the egress `stream.write` count to drop to ~1/response and the CLQ poll/offer + `close`/`allocateBuffer` egress share to fall (and, if the box is target-CPU-bound, rps/core to rise). Take 2–3 reps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)