### PR TITLE
chore(claude): sharpen skill invocability + add workflow skills

### DIFF
--- a/.claude/skills/exeris-adr-register/SKILL.md
+++ b/.claude/skills/exeris-adr-register/SKILL.md
@@ -21,7 +21,7 @@ Three shapes for three question kinds (templates in `~/exeris-systems/exeris-doc
 If upstream measurement or option comparison is missing, propose Research or RFC before going straight to ADR.
 
 ## Step 1 — Reserve the number BEFORE writing content (ADR only)
-- Open `~/exeris-systems/exeris-docs/adr-index.md` and find the next free slot (numbering is chronological by decision date with reserved gap-fillers).
+- Open `adr-index.md` in the separate `exeris-docs` repo (locally `~/exeris-systems/exeris-docs/adr-index.md`; requires that repo checked out alongside the kernel) and find the next free slot (numbering is chronological by decision date with reserved gap-fillers).
 - Reserve the row there FIRST. Only then write the ADR body. NEVER write content first.
 - Scope of the registry: `exeris-*` repos plus `Corelio/` stack-level decisions. `budgetHQ/` and `pbm/` have their own internal namespaces — they do NOT enter `adr-index.md`.
 - Out of scope: refactor-only ADRs (those live in PR descriptions / commit history), and Polish-language kernel-enterprise refactor notes — never promote them.
@@ -34,6 +34,7 @@ If upstream measurement or option comparison is missing, propose Research or RFC
 
 ## Step 3 — Register the row AFTER landing
 - Add/finalize the row in `adr-index.md` as a SEPARATE commit in the `exeris-docs` repo (separate from the content commit, separate repo).
+- This step requires `exeris-docs` access. If it is not available in the current session, do NOT skip it silently — open a follow-up issue/note to register (or reserve) the number so the global namespace stays collision-safe.
 
 ## Business decisions are separate
 Legal / IP / financial / procurement decisions go in the private decision registry in `~/exeris-systems/exeris-business/`, NOT the public tech registry. Public ADRs invoke a business policy descriptively (e.g. "the IP detachment commercial policy"), never by an internal id.

--- a/.claude/skills/exeris-adr-register/SKILL.md
+++ b/.claude/skills/exeris-adr-register/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: exeris-adr-register
+description: Authoring workflow for an Exeris ADR / RFC / Research doc — picks the right document shape, reserves the GLOBAL ADR number BEFORE writing content, and registers the row after landing. Use whenever asked to draft, write, or number an ADR/RFC/research note anywhere in the exeris-* ecosystem.
+---
+
+# Exeris ADR Register
+
+## Purpose
+Prevent ADR-number collisions and wrong-shape decision docs. ADR numbering is a single GLOBAL namespace across all `exeris-*` repos; claiming a number before reserving it caused the PR #129 / ADR-026 collision. This skill encodes the safe order of operations.
+
+## When to Use
+- Asked to draft/write/number an ADR, RFC, or Research note in any exeris-* repo.
+- A change's architectural intent or boundary meaning is changing and needs a decision record.
+
+## Step 0 — Pick the document shape FIRST
+Three shapes for three question kinds (templates in `~/exeris-systems/exeris-docs/templates/`); they are NOT interchangeable:
+- **Research** (`RESEARCH-TEMPLATE.md`) — falsifiable hypothesis, lab-notebook, JMH/JFR-driven. Branch-scoped (`research/<slug>`). **No central registry.**
+- **RFC** (`RFC-TEMPLATE.md`) — multi-option strategic question. File: `RFC-YYYY-MM-DD <Short Title>.md`. **No central registry.**
+- **ADR** (`ADR-TEMPLATE.md`) — decision ALREADY made. File: `ADR-NNN <Short Title>.md`. **Enters the registry.**
+
+If upstream measurement or option comparison is missing, propose Research or RFC before going straight to ADR.
+
+## Step 1 — Reserve the number BEFORE writing content (ADR only)
+- Open `~/exeris-systems/exeris-docs/adr-index.md` and find the next free slot (numbering is chronological by decision date with reserved gap-fillers).
+- Reserve the row there FIRST. Only then write the ADR body. NEVER write content first.
+- Scope of the registry: `exeris-*` repos plus `Corelio/` stack-level decisions. `budgetHQ/` and `pbm/` have their own internal namespaces — they do NOT enter `adr-index.md`.
+- Out of scope: refactor-only ADRs (those live in PR descriptions / commit history), and Polish-language kernel-enterprise refactor notes — never promote them.
+
+## Step 2 — Place the file next to the code it describes
+- ADR file lives in the owning repo's `docs/adr/`.
+- For cross-repo ADRs, the owning repo holds the authoritative copy; every other affected repo gets a `docs/adr/ADR-NNN.link.md` stub.
+- Visibility taxonomy (ADR-020): `public` or `enterprise-private` (the old `public-staged` is deprecated).
+- Open-core hygiene: a public kernel ADR never deep-links an enterprise-private repo. A private ADR gets a standalone open-core counterpart ADR (the ADR-039 ↔ ADR-018 pattern), not a dead link stub.
+
+## Step 3 — Register the row AFTER landing
+- Add/finalize the row in `adr-index.md` as a SEPARATE commit in the `exeris-docs` repo (separate from the content commit, separate repo).
+
+## Business decisions are separate
+Legal / IP / financial / procurement decisions go in the private decision registry in `~/exeris-systems/exeris-business/`, NOT the public tech registry. Public ADRs invoke a business policy descriptively (e.g. "the IP detachment commercial policy"), never by an internal id.
+
+## Terminology guard
+Exeris is pre-1.0 / TRL-3 with no external SPI consumers — do NOT use "breaking change" framing. Reserve that vocabulary for 1.0.0 GA / TRL-5+.
+
+## Output
+1. Chosen shape + why.
+2. For ADR: reserved number + confirmation the index row was added before content.
+3. File path(s) + any `.link.md` stubs + visibility tag.
+4. Separate-commit plan for the index row.
+
+## Non-Negotiable Rules
+- Reserve the ADR number in the global index BEFORE writing content.
+- Research/RFC never enter the central registry; ADRs always do.
+- No dead enterprise links in open-core docs.
+- No "breaking change" framing pre-1.0.

--- a/.claude/skills/exeris-architect-guardrails/SKILL.md
+++ b/.claude/skills/exeris-architect-guardrails/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-architect-guardrails
-description: Architectural PR review for Exeris Kernel. Use for every PR review to enforce docs/modules, docs/subsystems, ADR alignment, The Wall boundaries, SPI blindness, Core isolation, and dependency graph integrity.
+description: Architectural review for Exeris Kernel changes that touch module boundaries, SPI/Core/Community/Enterprise placement, dependency direction, provider wiring, or ADR-fixed structure. Use when a change adds or moves interfaces/providers, alters module layering, or risks a The-Wall breach (SPI implementation leak, Core driver leak). Not needed for pure intra-module edits with no boundary impact.
 ---
 
 # Exeris Architect Guardrails

--- a/.claude/skills/exeris-doc-impact-triage/SKILL.md
+++ b/.claude/skills/exeris-doc-impact-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-doc-impact-triage
-description: Router/Planner docs skill for Exeris Kernel. Classifies expected documentation/ADR impact and required review level.
+description: Quick check of whether an Exeris Kernel change needs documentation/ADR updates and at what level (none / minor / docs-review / ADR-review). Use during triage to decide if a full exeris-docs-adr-check review is warranted before merging.
 ---
 
 # Exeris Doc Impact Triage

--- a/.claude/skills/exeris-java26-panama-loom/SKILL.md
+++ b/.claude/skills/exeris-java26-panama-loom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-java26-panama-loom
-description: Java 26+ runtime PR review for Exeris Kernel. Use for every PR that touches concurrency, memory, native interop, and data carriers to enforce ScopedValue, StructuredTaskScope, Panama FFM, Valhalla readiness, immutable/early construction, and removal of legacy framework idioms.
+description: Java 26+ idiom review for Exeris Kernel. Use when a change touches concurrency, context propagation, native interop, memory APIs, or runtime data carriers — to enforce ScopedValue over ThreadLocal, StructuredTaskScope over ad-hoc async, Panama FFM (MemorySegment/Linker/SymbolLookup), Valhalla-ready immutable carriers, early construction, and removal of legacy framework idioms.
 ---
 
 # Exeris Java 26 Panama Loom

--- a/.claude/skills/exeris-jfr-perf-research/SKILL.md
+++ b/.claude/skills/exeris-jfr-perf-research/SKILL.md
@@ -14,7 +14,7 @@ Make perf conclusions reproducible and falsifiable. Past investigations burned t
 - Running JMH or HTTP load (wrk/wrk2/h2load/k6) to support a decision.
 
 ## Where work belongs
-- Perf claims, JMH harnesses, HTTP load → `exeris-benchmarks` (or `exeris-benchmarks-enterprise`). **Never** add merge gates there — benchmarks are not a guard-test repo.
+- Perf claims, JMH harnesses, HTTP load → `exeris-benchmarks` (or `exeris-benchmarks-enterprise`). **Never** add merge gates there — benchmarks are environment-sensitive (CPU, driver, NUMA, JIT warmup) and would produce flaky gates; benchmarks are not a guard-test repo.
 - The kernel change that the benchmark justifies → `exeris-kernel`, with a `research/<slug>` branch and a Research note.
 
 ## Method — non-negotiable discipline

--- a/.claude/skills/exeris-jfr-perf-research/SKILL.md
+++ b/.claude/skills/exeris-jfr-perf-research/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: exeris-jfr-perf-research
+description: Disciplined JMH/JFR performance-research loop for Exeris Kernel — guards against single-run flukes, driver confounds, and wrong conclusions from hot-method noise. Use when investigating a throughput/latency/allocation regression or claim, reading a JFR recording, or running a benchmark on a research/<slug> branch.
+---
+
+# Exeris JFR Perf Research
+
+## Purpose
+Make perf conclusions reproducible and falsifiable. Past investigations burned time on a single broken run and on driver confounds; this skill encodes the discipline that prevents both. Pairs with the Research doc shape (`RESEARCH-TEMPLATE.md`, branch-scoped, no central registry).
+
+## When to Use
+- Investigating a throughput/latency/allocation/CPU regression or a perf claim.
+- Reading or summarizing a JFR recording (`jfr summary`, hot methods, alloc, GC).
+- Running JMH or HTTP load (wrk/wrk2/h2load/k6) to support a decision.
+
+## Where work belongs
+- Perf claims, JMH harnesses, HTTP load → `exeris-benchmarks` (or `exeris-benchmarks-enterprise`). **Never** add merge gates there — benchmarks are not a guard-test repo.
+- The kernel change that the benchmark justifies → `exeris-kernel`, with a `research/<slug>` branch and a Research note.
+
+## Method — non-negotiable discipline
+
+1. **Repeat before concluding (2–3 runs minimum).**
+   - A single run is not evidence. A re-run of the *same* config has flipped a "1522 rps catastrophe" back to ~3742 rps. If runs disagree by >~10–15%, treat the run as unstable and find out why before drawing any conclusion.
+   - Report the spread (min/median/max), not a single number.
+
+2. **Control the driver — rule out confounds.**
+   - `wrk` vs `h2load` can differ materially on the same server (connect cost, HTTP/2 framing, keep-alive). Hold the driver fixed across compared runs, or run both and report both. Do not compare a `wrk` baseline to an `h2load` candidate.
+   - Hold fixed: CPU pinning / `ActiveProcessorCount`, connection count, warmup, TLS vs plaintext, HTTP/1 vs h2 vs h2c.
+
+3. **Read JFR for *where*, then verify the mechanism.**
+   - Hot methods tell you where CPU goes (e.g. runLoop %, CLQ poll/offer, CHM.get, LoanedBuffer alloc → GC rate), not *why*. Confirm the causal mechanism with a targeted change, not by correlation alone.
+   - Distinguish "more expensive" from "slower" — higher CPU per request is not automatically lower throughput. State the actual bottleneck.
+   - Watch for absence as signal (e.g. OpenSSL absent from hot methods ⇒ deficit is reactor plumbing, not crypto).
+
+4. **Calibrate against a known-good baseline.**
+   - Compare to a healthy reference (e.g. plaintext core, or a prior commit), not just an absolute target. A regression is a delta vs a trusted point.
+   - Beware constrained-config artifacts: a `pool=2` under `ActiveProcessorCount=1` can shed load via the v0.6.0 503 admission gate and *look* like a throughput collapse (it is 92% errors, not slowness). Check error rate, not just rps.
+
+5. **JFR-event safety on the runtime side.**
+   - If the change adds JFR instrumentation: never `begin() → blocking-op → commit()` an event on a virtual thread — a carrier-bound `EventWriter` straddling a VT mount/unmount has caused SIGSEGV (JfrStorage::flush) on JDK 26. Use single-phase `commit()`. (ConnectionAcquireEvent was the cautionary tale.)
+
+6. **Environment caveat.**
+   - JDK 26 has sporadic SIGSEGV in G1/PMD during Maven — a crashed run is not a perf result; just retry. Keep `hs_err_pid*.log` only to confirm it was a JVM crash, not your change.
+
+## Output
+1. Hypothesis (falsifiable) + config held fixed.
+2. Runs table: driver, N repeats, min/median/max, error rate.
+3. JFR finding: where (hot methods) → claimed mechanism → how it was verified.
+4. Baseline delta + verdict (regression confirmed / fluke / confound).
+5. Next action (kernel change, or more measurement).
+
+## Non-Negotiable Rules
+- No conclusion from a single run.
+- No cross-driver comparison.
+- No "slower" claim without separating CPU-per-req from throughput and checking error rate.
+- No two-phase JFR event on a virtual thread.

--- a/.claude/skills/exeris-multi-agent-handoff/SKILL.md
+++ b/.claude/skills/exeris-multi-agent-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-multi-agent-handoff
-description: Router/Planner coordination skill for Exeris Kernel. Builds ordered handoff chains and identifies blocking dependencies between specialist steps.
+description: Order the specialist chain and surface blocking dependencies for a multi-domain Exeris Kernel task. Use when work spans architecture + implementation + verification + docs and must run in strict dependency order (e.g. placement before implementation, implementation before TCK/perf, docs/ADR sync when meaning changes).
 ---
 
 # Exeris Multi-Agent Handoff

--- a/.claude/skills/exeris-performance-contract/SKILL.md
+++ b/.claude/skills/exeris-performance-contract/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-performance-contract
-description: Performance-lawyer PR review for Exeris Kernel. Use for every PR review to enforce No Waste Compute, zero-allocation hot paths, structured concurrency, off-heap discipline, and mandatory JFR lifecycle telemetry.
+description: Performance-lawyer review enforcing No Waste Compute for Exeris Kernel. Use when a change touches runtime hot paths (transport, flow, memory, persistence, bootstrap, dispatch) or can affect allocations, structured concurrency, off-heap copies, or banned APIs (ThreadLocal, ExecutorService, CompletableFuture, ByteBuffer, Unsafe). Skip for docs-only or pure test/tooling changes.
 ---
 
 # Exeris Performance Contract

--- a/.claude/skills/exeris-pr-preflight/SKILL.md
+++ b/.claude/skills/exeris-pr-preflight/SKILL.md
@@ -16,7 +16,7 @@ Catch the recurring, expensive footguns that a green `mvn verify` does **not** c
 ## Mandatory Checks (in order)
 
 1. **Branch hygiene — fresh branch per task**
-   - Confirm work is on a fresh feature branch cut off `origin/development/<active-ver>` (or the current research branch), NOT on an already-merged branch or directly on `main`.
+   - Confirm work is on a fresh feature branch cut off the current active development base (the `development/<active-ver>` branch on origin; check the repo `CLAUDE.md` / README for the current name as it advances per release), or the current `research/<slug>` branch — NOT an already-merged branch or directly on `main`.
    - If multiple Claude sessions may share this tree, prefer a git worktree off a clean base — a parallel branch-switch/commit can revert uncommitted edits.
 
 2. **Lint gate is NOT in `verify` — run it explicitly**
@@ -50,6 +50,6 @@ A go/no-go summary: each check → PASS / FAIL / N/A, with the exact failing com
 
 ## Non-Negotiable Rules
 - Never equate green `mvn verify` with lint-clean.
-- Never run lint with `exeris-kernel-build-config` in scope.
+- Never include `exeris-kernel-build-config` in the `-pl` module list when running lint.
 - Never open a PR that changes a contract without TCK implications.
 - Never claim an ADR number before reserving it in the global index.

--- a/.claude/skills/exeris-pr-preflight/SKILL.md
+++ b/.claude/skills/exeris-pr-preflight/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: exeris-pr-preflight
+description: Pre-PR gate for Exeris Kernel — run BEFORE opening or pushing any PR. Enforces the lint footgun (mvn verify SKIPS PMD), the architecture guard test, fresh-branch-per-task discipline, and the register-ADR-before-claiming rule. Use whenever about to commit/push a branch or open a PR in the kernel repo.
+---
+
+# Exeris PR Preflight
+
+## Purpose
+Catch the recurring, expensive footguns that a green `mvn verify` does **not** catch, before a PR is opened. This is a workflow skill (it runs checks), not a review-lens.
+
+## When to Use
+- About to push a branch or open a PR in `exeris-kernel`.
+- Finished a change and want a single deterministic pre-merge checklist.
+- Unsure whether lint/arch gates were actually exercised.
+
+## Mandatory Checks (in order)
+
+1. **Branch hygiene — fresh branch per task**
+   - Confirm work is on a fresh feature branch cut off `origin/development/<active-ver>` (or the current research branch), NOT on an already-merged branch or directly on `main`.
+   - If multiple Claude sessions may share this tree, prefer a git worktree off a clean base — a parallel branch-switch/commit can revert uncommitted edits.
+
+2. **Lint gate is NOT in `verify` — run it explicitly**
+   - `mvn verify` does **not** run `pmd:check` (it is `default-cli`). A green verify is NOT lint-clean.
+   - Run explicitly, scoped to the changed modules (spi/core/community/etc.), and **exclude `exeris-kernel-build-config`** (it ships the rulesets, is `pmd.skip`, and is not checkstyle-gated; APT processors there inherit that exemption):
+     ```
+     mvn -pl <changed-modules> pmd:check checkstyle:check
+     ```
+   - On JDK 26 sporadic SIGSEGV during PMD/G1: just retry, or for long chains add `-Dpmd.skip=true -Dcheckstyle.skip=true` and run lint separately on a short scope.
+
+3. **Architecture guard test (The Wall)**
+   - Run the ArchUnit guard so SPI/Core/Driver boundaries are enforced (it has historically been `@ArchIgnore`'d — do not assume CI covers it):
+     ```
+     mvn -q -pl exeris-kernel-tck -am -Dtest=ExerisArchitectureTest \
+       -Dsurefire.failIfNoSpecifiedTests=false \
+       -Dpmd.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true test
+     ```
+
+4. **Contract change → TCK present**
+   - If the diff touches SPI/observable behavior, confirm `Abstract*Tck` coverage + bindings exist (delegate to `exeris-tck-first` if unsure). No contract change merges without executable TCK implications.
+
+5. **Docs / ADR drift**
+   - If behavior/boundary meaning changed, confirm docs/ADR are synced (delegate to `exeris-docs-adr-check`).
+   - If an ADR is involved: numbers are a GLOBAL namespace — reserve the slot in `~/exeris-systems/exeris-docs/adr-index.md` BEFORE writing content (see `exeris-adr-register`). PR #129 (ADR-026 collision) is the cautionary tale.
+
+6. **Public-docs hygiene**
+   - Release notes/CHANGELOG describe only what is published: no unpublished-consumer-behavior-as-shipped, no local-only links, no cross-repo/private PR# leaks, no deep links into enterprise-private repos.
+
+## Output
+A go/no-go summary: each check → PASS / FAIL / N/A, with the exact failing command output and the minimal fix. Do not report "ready to PR" unless lint, arch guard, and (if applicable) TCK are all green or explicitly N/A with reason.
+
+## Non-Negotiable Rules
+- Never equate green `mvn verify` with lint-clean.
+- Never run lint with `exeris-kernel-build-config` in scope.
+- Never open a PR that changes a contract without TCK implications.
+- Never claim an ADR number before reserving it in the global index.

--- a/.claude/skills/exeris-pr-review-waste-hunter/SKILL.md
+++ b/.claude/skills/exeris-pr-review-waste-hunter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-pr-review-waste-hunter
-description: Meta PR review persona for Exeris Kernel. Use as the default review style to ruthlessly detect software inflation, enforce simplification, flag classes with >5 dependencies, reward lock-free/zero-copy/contract-pure patterns, and justify findings with architecture lore.
+description: Default entry-point for ANY Exeris Kernel PR/diff/branch review — start here. Triages software inflation, >5-dependency classes, and boundary/perf/contract risk, then dispatches to the focused lens skills (exeris-architect-guardrails, exeris-performance-contract, exeris-tck-first, exeris-jfr-telemetry-review, exeris-java26-panama-loom, exeris-subsystem-specialist) as the diff warrants. Trigger whenever asked to review, look at, audit, or assess a change.
 ---
 
 # Exeris PR Review Waste Hunter
@@ -16,6 +16,19 @@ This skill is designed as a default PR review stance.
 - Demand architectural and performance justification, not stylistic preference.
 - Explicitly praise clean lock-free, zero-copy, and contract-pure solutions.
 - Always explain "why" with references to Exeris lore/contracts.
+
+## Lens Dispatch (apply only what the diff touches)
+This skill is the entry point. After the inflation/boundary triage, invoke the focused lens skills that the diff actually warrants — do not run all of them blindly:
+- Boundary / module placement / SPI-Core-Driver / ADR-fixed structure → `exeris-architect-guardrails`
+- Hot-path alloc/copy/concurrency, banned APIs, No Waste Compute → `exeris-performance-contract`
+- Concurrency / ScopedValue / FFM / carriers / Java 26 idioms → `exeris-java26-panama-loom`
+- SPI/contract/error-code/observable behavior change → `exeris-tck-first`
+- Bootstrap/telemetry/lifecycle/exception-mapping observability → `exeris-jfr-telemetry-review`
+- Change concentrated in one subsystem → `exeris-subsystem-specialist` (state the mode)
+- Provider discovery / bootstrap DAG / ServiceLoader → `exeris-service-loader-and-bootstrap`
+- Doc/ADR drift suspected → `exeris-docs-adr-check`
+
+If unsure how to route a multi-domain change, use the triage skills first: `exeris-task-classifier` → `exeris-risk-prioritizer` → `exeris-routing-planner`.
 
 ## Canon to Load First
 - docs/whitepaper.md

--- a/.claude/skills/exeris-risk-prioritizer/SKILL.md
+++ b/.claude/skills/exeris-risk-prioritizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-risk-prioritizer
-description: Router/Planner risk skill for Exeris Kernel. Identifies primary risk, justification, and secondary risks to drive routing priority.
+description: Pick the single primary risk for an Exeris Kernel change when several compete (The-Wall/placement > observable contract drift > hot-path allocation/copy/concurrency > missing verification > docs/ADR drift). Use during triage when a change carries multiple risks and you must decide what to address first.
 ---
 
 # Exeris Risk Prioritizer

--- a/.claude/skills/exeris-routing-planner/SKILL.md
+++ b/.claude/skills/exeris-routing-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-routing-planner
-description: Router/Planner skill for Exeris Kernel. Produces primary agent, required secondary handoffs, execution order, and minimal next action.
+description: Build the specialist handoff route for an Exeris Kernel task — primary agent, ordered secondary handoffs, a 4-6 step execution plan, and the minimal next action. Use after triage to sequence architect/implementer/tck/performance/docs-adr work for a multi-step or cross-domain change.
 ---
 
 # Exeris Routing Planner

--- a/.claude/skills/exeris-subsystem-scope-detector/SKILL.md
+++ b/.claude/skills/exeris-subsystem-scope-detector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-subsystem-scope-detector
-description: Optional Router/Planner scope skill for Exeris Kernel. Detects impacted subsystem(s), required contract docs, and single-vs-cross subsystem scope.
+description: Identify which Exeris Kernel subsystem(s) a change touches, which contract docs to load, and whether the blast radius is single- or cross-subsystem. Use during triage when the impacted subsystem is unclear or a change may span several subsystems.
 ---
 
 # Exeris Subsystem Scope Detector

--- a/.claude/skills/exeris-subsystem-specialist/SKILL.md
+++ b/.claude/skills/exeris-subsystem-specialist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-subsystem-specialist
-description: Subsystem-focused PR review for Exeris Kernel using one skill with modes — bootstrap, memory, crypto, transport, persistence, events, flow, http, security, config. Use when you want a targeted subsystem review without creating many separate agents.
+description: Targeted single-subsystem review for Exeris Kernel via one mode-driven skill (modes: bootstrap, memory, crypto, transport, persistence, events, flow, http, security, config). Use when a change is concentrated in one subsystem and you want its contract doc loaded as the primary source of truth plus mode-specific deep checks — without spawning multiple agents. State the mode (e.g. "review this as Transport").
 ---
 
 # Exeris Subsystem Specialist

--- a/.claude/skills/exeris-task-classifier/SKILL.md
+++ b/.claude/skills/exeris-task-classifier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-task-classifier
-description: Router/Planner triage skill for Exeris Kernel. Classifies task type, scope, severity, and recommends primary agent based on primary risk.
+description: First-pass triage for a new Exeris Kernel task, PR, or request — classifies task type, scope, severity, primary risk, and which specialist agent should own it. Use at the START of work when the right owner/agent is not obvious or the scope crosses domains, before diving into implementation or review.
 ---
 
 # Exeris Task Classifier

--- a/.claude/skills/exeris-tck-first/SKILL.md
+++ b/.claude/skills/exeris-tck-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-tck-first
-description: TCK-first PR review for Exeris Kernel. Use when changes touch SPI contracts, observable behavior, or provider bindings to enforce that every contract change has executable Abstract*Tck coverage and implementation bindings in Core/Community/Enterprise.
+description: TCK-first review for Exeris Kernel. Use when a change touches SPI interfaces, value/error contracts, lifecycle/state behavior, or provider bindings — to enforce that every contract change has executable Abstract*Tck coverage plus binding tests in Core/Community/Enterprise, with semantic (not happy-path-only) assertions. Trigger on new contract surface, changed error codes, or altered observable behavior.
 ---
 
 # Exeris TCK First

--- a/.claude/skills/exeris-validation-gate-planner/SKILL.md
+++ b/.claude/skills/exeris-validation-gate-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-validation-gate-planner
-description: Router/Planner validation skill for Exeris Kernel. Defines required validation layers, merge gates, and optional checks based on risk and scope.
+description: Decide which validation/merge gates an Exeris Kernel change must pass (TCK, performance/memory, architecture, docs/ADR, local build) based on its risk and scope. Use when planning what must be green before merge, or to confirm no required gate is being skipped.
 ---
 
 # Exeris Validation Gate Planner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,4 +82,11 @@ When the SonarQube MCP server is available:
 ## Agents, Commands, and Skills
 - Functional subagents live in `.claude/agents/` (Architect, Implementer, TCK/Test, Performance/Memory, Docs/ADR, Router).
 - Reusable slash commands live in `.claude/commands/` (Community/Open-Core review and implementation prompts).
-- Skill packs live in `.claude/skills/` (PR-review, routing/planner, subsystem-specific lenses).
+- Skill packs live in `.claude/skills/` (PR-review lenses, routing/planner, subsystem lenses, plus the `exeris-pr-preflight` / `exeris-adr-register` / `exeris-jfr-perf-research` workflow skills).
+
+### When to use which
+These three surfaces overlap on purpose; pick by *how* you need the work done, not *what* it is:
+- **Skill** (`Skill` tool, inline) — runs the checklist in the current conversation, keeping full context. Default for review lenses, triage, and the workflow skills above. Start a PR review with `exeris-pr-review-waste-hunter`, which dispatches to the focused lenses.
+- **Agent** (`Agent` tool, delegated) — spins up a separate context window. Use for broad fan-out, read-heavy exploration, or parallel independent work where you only want the conclusion back (e.g. `exeris-architect`, `exeris-performance`).
+- **Command** (`/name`, explicit) — user-invoked Community/Open-Core prompt; reach for it when the user types the slash command.
+- Skills and agents intentionally mirror the same personas (e.g. `exeris-architect-guardrails` skill ↔ `exeris-architect` agent): same lens, different execution mode.


### PR DESCRIPTION
## Why
Project skills are auto-selected purely by their `description` field — that is the only lever for invocation reliability. An audit of the 16 `.claude/skills/` packs found three weaknesses hurting auto-invocation, plus gaps in coverage of recurring workflow footguns.

## What changed

**Invocation fixes (description-only, low risk):**
- **Broke the "every PR review" collision.** Three skills (`architect-guardrails`, `performance-contract`, `pr-review-waste-hunter`) all claimed to be the default → ambiguous selection. `exeris-pr-review-waste-hunter` is now the single review entry-point with a new **Lens Dispatch** section that routes to the focused lenses; the other two are rescoped to their own triggers (boundary/placement vs hot-path/alloc).
- **Made the 7 Router/Planner micro-skills triggerable.** Rewrote their descriptions to lead with a user-intent trigger instead of role text ("Router/Planner X skill…"), which the model could never spontaneously select.
- Sharpened `tck-first`, `java26-panama-loom`, `subsystem-specialist` triggers (incl. mode hint).

**New workflow skills (cover recurring footguns):**
- `exeris-pr-preflight` — `mvn verify` skips PMD; run `pmd:check checkstyle:check` (excluding `build-config`), run the ArchUnit guard, fresh-branch discipline, register-ADR-before-claiming.
- `exeris-adr-register` — pick Research/RFC/ADR shape; reserve the GLOBAL `adr-index.md` number **before** writing content (the ADR-026 / PR #129 collision).
- `exeris-jfr-perf-research` — 2–3 reps before concluding, no cross-driver comparison, separate CPU-per-req from throughput, JFR×virtual-thread commit safety.

**Docs:** added a skill-vs-agent-vs-command "when to use which" convention to `CLAUDE.md`.

## Scope / safety
- Touches only `.claude/skills/` and `CLAUDE.md`. No kernel code, no contract surface, no TCK impact.
- 13 changes are pure `description` rewrites; 3 new skill files; 1 dispatch section; 1 CLAUDE.md section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)