### PR TITLE
fix(transport): abortively cancel the key in closeKeyStream to stop closed-engine TLS reactor spin

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityReactorDispatchFaultEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityReactorDispatchFaultEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * JFR event for an unrecoverable per-stream fault in the reactor select loop.
+ *
+ * <h2>JFR-First Contract</h2>
+ * <p>Emitted once per dying connection, from the {@code NativeTcpReactor} select-loop
+ * {@code catch (RuntimeException)} branch that triggers {@link NativeTcpCarrier#closeKeyStream}
+ * abortive teardown. This is a failure-detection point (per {@code docs/subsystems/transport.md}
+ * JFR-first guidance): a recurring fault here is the signature of a reactor spin, which is otherwise
+ * invisible to JFR exception sampling when the cause is a zero-alloc, stack-trace-less sentinel
+ * (e.g. unwrap-on-closed {@code TlsDecryptException}). The payload is the exception <em>class</em>
+ * name only — no message — so it carries no request data.
+ *
+ * <p>Single-phase {@code commit()} on the reactor's platform thread; zero overhead when JFR is not
+ * recording ({@link #isEnabled()} check). Not on the read/write ingress hot path.
+ *
+ * @since 0.9.0
+ */
+@Name("eu.exeris.kernel.transport.CommunityReactorDispatchFault")
+@Label("Community Reactor Dispatch Fault")
+@Description("Unrecoverable per-stream fault caught in the reactor select loop, triggering abortive teardown")
+@Category({"Exeris Kernel", "Transport"})
+@StackTrace(false)
+final class CommunityReactorDispatchFaultEvent extends Event {
+
+    @Label("Stream Id")
+    /* default */ long streamId;
+
+    @Label("Reactor Index")
+    /* default */ int reactorIndex;
+
+    @Label("Fault Class")
+    /* default */ String faultClass;
+
+    /* default */ static void emit(long streamId, int reactorIndex, String faultClass) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        CommunityReactorDispatchFaultEvent event = new CommunityReactorDispatchFaultEvent();
+        if (event.isEnabled()) {
+            event.streamId = streamId;
+            event.reactorIndex = reactorIndex;
+            event.faultClass = faultClass;
+            event.commit();
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -66,6 +66,9 @@ public final class NativeTcpCarrier implements TransportEngine {
     private static final String ENGINE_NAME = "CommunityNativeTcpCarrier";
     private static final int MIN_LISTENER_BACKLOG = 64;
     private static final int MAX_LISTENER_BACKLOG = 1_024;
+    // Advisory TCP reset code for an abortive teardown driven by a reactor dispatch fault
+    // (see closeKeyStream). The peer observes a RST; the value carries no application semantics.
+    private static final long DISPATCH_FAULT_RESET_CODE = 0L;
     // Fairness cap on TLS records drained per readable event (see readIngress / PERF-062 in
     // docs/subsystems/transport.md). Overridable for field tuning, mirroring
     // exeris.transport.queueBackpressureEnabled.
@@ -442,6 +445,23 @@ public final class NativeTcpCarrier implements TransportEngine {
     }
 
     /* default */ void closeKeyStream(SelectionKey key) {
+        // Reached only from the reactor select-loop catch(RuntimeException) (NativeTcpReactor), i.e.
+        // on the reactor thread, after a per-key dispatch (read-ingress or flush) faulted — most
+        // often an unwrap-on-closed TlsDecryptException once the stream's TLS engine is already
+        // closed. The connection is unrecoverable, so tear it down ABORTIVELY:
+        //  1. cancel the key synchronously — removes it from this reactor's selector so the
+        //     level-triggered dead channel cannot re-fire (read OR write) and busy-spin the reactor
+        //     while teardown completes. Direct cancel honours the single-consumer key protocol
+        //     (this runs on the reactor thread); a graceful interest-narrow does not suffice because
+        //     a closed-engine stream's queued egress is undrainable and would keep OP_WRITE armed.
+        //  2. reset() rather than close(): reset abandons the undrainable queue and sets
+        //     resetRequested — the designed escape hatch (issue #180) that lets finishCloseIfDrained
+        //     bypass its drain gate, finalize, and deregister the channel, including under
+        //     slot-owner deferral via the deferred-abort wake. A graceful close() would defer
+        //     forever here.
+        if (key.isValid()) {
+            key.cancel();
+        }
         if (!(key.channel() instanceof SocketChannel channel)) {
             return;
         }
@@ -450,7 +470,7 @@ public final class NativeTcpCarrier implements TransportEngine {
             return;
         }
         stream.markRemoteClosed();
-        stream.close();
+        stream.reset(DISPATCH_FAULT_RESET_CODE);
     }
 
     private void acceptPendingConnections() throws IOException {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
@@ -154,7 +154,13 @@ final class NativeTcpReactor {
                         dispatchSelectedKey(key);
                     } catch (CancelledKeyException _) {
                         // channel closed concurrently by VT handler path
-                    } catch (RuntimeException _) {
+                    } catch (RuntimeException ex) {
+                        // JFR-first: surface the unrecoverable per-stream fault before abortive
+                        // teardown. A recurring fault here is the signature of a reactor spin that
+                        // a zero-alloc, stack-trace-less sentinel cause hides from exception sampling.
+                        NativeTcpStream faulted = (NativeTcpStream) key.attachment();
+                        CommunityReactorDispatchFaultEvent.emit(
+                                faulted != null ? faulted.streamId() : -1L, index, ex.getClass().getName());
                         host.closeKeyStream(key);
                     }
                 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCloseKeyStreamReadInterestTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCloseKeyStreamReadInterestTest.java
@@ -69,6 +69,7 @@ class NativeTcpCloseKeyStreamReadInterestTest {
 
             try (SocketChannel clientChannel =
                          SocketChannel.open(new InetSocketAddress("127.0.0.1", port));
+                 // accepted only to complete the TCP handshake so the client can register; never read
                  SocketChannel serverChannel = listener.accept()) {
 
                 clientChannel.configureBlocking(false);

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCloseKeyStreamReadInterestTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/NativeTcpCloseKeyStreamReadInterestTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for the TLS reactor busy-spin: {@link NativeTcpCarrier#closeKeyStream} must
+ * cancel the selection key <em>synchronously</em> so a faulted connection's key can never be
+ * re-selected (for read or write).
+ *
+ * <h2>Why this exists</h2>
+ * <p>The reactor select loop reaches {@code closeKeyStream} only via its {@code catch
+ * (RuntimeException)} branch — most often an unwrap-on-closed {@code TlsDecryptException} thrown
+ * when a stream's TLS engine is already closed but its graceful close is still deferred for
+ * outbound drain ({@code NativeTcpStream#finishCloseIfDrained}). Because the deferred graceful close
+ * never reaches {@code channel.close()}, the key stays registered; the level-triggered channel
+ * re-fires every select, re-throwing and busy-spinning the reactor (~5.7M throws/s measured).
+ * Withdrawing only {@code OP_READ} merely relocates the spin onto {@code OP_WRITE} (a closed-engine
+ * stream's queued egress is undrainable, so {@link NativeTcpCarrier#flushStream} never narrows
+ * interest). The fix cancels the key outright and resets the stream abortively.
+ *
+ * <p>The assertion is non-vacuous: with the channel's stream unregistered, the pre-fix
+ * {@code closeKeyStream} returns without touching the key, so the key would stay valid — the
+ * cancellation assertion fails. The cancel happens before {@code resolveStream}, so it is
+ * independent of whether the stream's teardown completes or defers.
+ */
+class NativeTcpCloseKeyStreamReadInterestTest {
+
+    private static final MemoryAllocator ALLOCATOR =
+            new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+
+    @AfterAll
+    @SuppressWarnings("unused")
+    static void releaseAllocator() {
+        ALLOCATOR.close();
+    }
+
+    @Test
+    void closeKeyStreamCancelsKeySynchronously() throws Exception {
+        // Port is irrelevant — the carrier is never started/bound; closeKeyStream only manipulates
+        // the supplied SelectionKey. A valid SERVER-mode port just satisfies config validation.
+        NativeTcpCarrier carrier =
+                new NativeTcpCarrier(TransportConfig.serverDefaults(8443), ALLOCATOR, null, null);
+        try (ServerSocketChannel listener = ServerSocketChannel.open();
+             Selector selector = Selector.open()) {
+            listener.bind(new InetSocketAddress("127.0.0.1", 0));
+            int port = ((InetSocketAddress) listener.getLocalAddress()).getPort();
+
+            try (SocketChannel clientChannel =
+                         SocketChannel.open(new InetSocketAddress("127.0.0.1", port));
+                 SocketChannel serverChannel = listener.accept()) {
+
+                clientChannel.configureBlocking(false);
+                SelectionKey key = clientChannel.register(selector, SelectionKey.OP_READ);
+
+                assertTrue(key.isValid() && (key.interestOps() & SelectionKey.OP_READ) != 0,
+                        "precondition: channel must start registered and armed for OP_READ");
+
+                carrier.closeKeyStream(key);
+
+                assertFalse(key.isValid(),
+                        "closeKeyStream must cancel the key synchronously so the faulted connection "
+                                + "cannot be re-selected for read or write and busy-spin the reactor");
+            }
+        } finally {
+            carrier.close();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Under HTTP/2 over TLS the Community `NativeTcp` transport burned **2–2.4× the CPU per request** of the same workload without TLS (and of Quarkus over TLS), while throughput looked fine. The deficit was pure reactor overhead, not crypto.

## Root cause (JFR-confirmed)

The reactor select loop reaches `NativeTcpCarrier.closeKeyStream` only via its `catch (RuntimeException)` branch — a per-key dispatch (read-ingress or flush) faulted. The dominant trigger under TLS h2 is an **unwrap-on-closed `TlsDecryptException`** (the pre-allocated `DECRYPT_CLOSED_SENTINEL` in `OffHeapTlsEngine`) thrown once a stream's TLS engine is already closed but its graceful close is still deferred for outbound drain (`NativeTcpStream#finishCloseIfDrained` returns early while the outbound consumer slot is owned by another thread or data is pending).

Because the deferred graceful close never reaches `channel.close()`, the `SelectionKey` stays registered; the level-triggered channel re-fires every select, re-throwing and **busy-spinning the reactor** — measured **~688M throws / 120s (~5.7M/s, ~47% CPU)**. It was invisible to JFR exception sampling because the sentinel is zero-alloc with no stack trace (the earlier "~200 exceptions" reading was a sampling artifact).

Withdrawing only `OP_READ` is insufficient: a closed-engine stream's queued egress is **undrainable** (cannot wrap), so `flushStream` never narrows interest and the spin merely relocates onto `OP_WRITE` (measured: `flushStream` jumps to ~23% CPU, `cpu_time` unchanged).

## Fix

`closeKeyStream` is the reactor's error-teardown path, so tear the connection down **abortively**:

1. **`key.cancel()` synchronously** — removes the key from this reactor's selector so the dead channel cannot be re-selected for read **or** write. Direct cancel honours the single-consumer key protocol (it runs on the reactor thread).
2. **`reset()` instead of `close()`** — `reset` abandons the undrainable queue and sets `resetRequested`, the designed escape hatch (issue #180) that lets `finishCloseIfDrained` bypass its drain gate, finalize, and deregister the channel, including under slot-owner deferral via the deferred-abort wake. A graceful `close()` would defer forever here.

Abortive-on-error matches the existing `abortOnUnrecoverableWriteFailure` pattern. **Core `OffHeapTlsEngine` is unchanged** — the sentinel is the correct terminal signal; the defect was the transport treating it as retryable.

## Results (live benchmark, entity-read-by-id, TLS h2, loopback, 120s)

| Metric | Before | After |
|---|---|---|
| Throughput | ~4,100 rps | **6,770 rps** (+65%) |
| Target-JVM CPU time | ~680 s | **332 s** (−51%) |
| Efficiency | ~723 rps/core | **~2,444 rps/core** (~3.4×) |
| h2load errors | 0 | **0** |

That lifts TLS h2 efficiency to ~h2c plaintext (~2,790 rps/core) — the TLS CPU/req penalty is eliminated. JFR hot-methods after the fix are entirely legitimate application work (Postgres JDBC + Jackson + FFM `MethodHandle`); the whole transport spin chain (`flushStream`, `finishCloseIfDrained`, `runLoop`, `closeKeyStream`, `AbstractLoanedBuffer.close`, `CLQ.poll/offer`) is gone from the hot set — eliminated, not relocated.

## Tests

Adds `NativeTcpCloseKeyStreamReadInterestTest` (community impl-level): builds a carrier + selector + loopback channel armed for `OP_READ`, calls `closeKeyStream`, asserts the key is cancelled synchronously. Verified **fails before the fix** (key stays valid) and **passes after**. Existing transport suite green (41 tests incl. multi-reactor and the #180 deferred-abort TCK).

## Scope / boundary

Community-only. **No SPI / Abstract*Tck / ADR change** — selector mechanics are not an SPI contract (ADR-008: high-perf transport is Enterprise; SPI `TransportStream` is implementation-blind). Reviewed via `exeris-architect` (placement + abortive-teardown re-validation) and `exeris-tck` (test contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)