### PR TITLE
feat(bootstrap): v0.9 Sprint 7 — operational-continuity (DEGRADED health + restart/degraded ITs + CI gate)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -243,6 +243,70 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  recovery-continuity-gate:
+    # v0.9 Sprint 7: operational-continuity suite — @Tag("continuity") tests in
+    # exeris-kernel-community + exeris-kernel-community-kafka. The default `Build & TCK
+    # Verification` job excludes the continuity group (see <excludedGroups> in both poms)
+    # because these are Testcontainers-backed (Postgres/Kafka) restart-recovery and
+    # degraded-mode integration tests, too heavy for the default unit pass. This gate
+    # overrides -DincludedGroups=continuity and clears -DexcludedGroups= so Surefire picks
+    # them up — mirrors persistence-rls-gate / kafka-integration-gate exactly.
+    #
+    # Chains after kafka-integration-gate (sequencing isolates each gate's scheduler
+    # pressure): build-and-verify → persistence-rls-gate → kafka-integration-gate →
+    # recovery-continuity-gate → transport-stress-gate.
+    name: Recovery Continuity Gate
+    runs-on: ubuntu-latest
+    needs: kafka-integration-gate
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache JDK tarball
+        id: jdk-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/jdk.tar.gz
+          key: ${{ env.JDK_CACHE_KEY }}
+
+      - name: Fetch JDK
+        if: steps.jdk-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          wget -q -O ${{ runner.temp }}/jdk.tar.gz ${{ env.JDK_URL }}
+          echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
+
+      - name: Inject JDK into Runner
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'jdkfile'
+          jdkFile: ${{ runner.temp }}/jdk.tar.gz
+          java-version: ${{ env.JDK_VER }}
+          architecture: x64
+          cache: maven
+
+      - name: Run recovery/continuity gate
+        run: |
+          mvn -pl exeris-kernel-community,exeris-kernel-community-kafka -am install -DskipTests -B -e
+          mvn -pl exeris-kernel-community,exeris-kernel-community-kafka \
+            -DincludedGroups=continuity \
+            -DexcludedGroups= \
+            test -B -e
+
+      - name: Upload continuity JFR recordings
+        if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-continuity-${{ github.run_number }}
+          path: |
+            exeris-kernel-community/target/*.jfr
+            exeris-kernel-community-kafka/target/*.jfr
+          if-no-files-found: warn
+          retention-days: 14
+
   transport-stress-gate:
     # TCK-064 (v0.8 Sprint 0): dedicated job for @Tag("stress") transport tests.
     # The default `Build & TCK Verification` job excludes the stress group because the
@@ -259,7 +323,7 @@ jobs:
     # gate's scheduler pressure — no two stress-prone jobs run simultaneously.
     name: Transport Stress Gate
     runs-on: ubuntu-latest
-    needs: kafka-integration-gate
+    needs: recovery-continuity-gate
     permissions:
       contents: read
 

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -356,8 +356,8 @@ at all times.
 
 `KernelHealthMonitor` (Core) implements `eu.exeris.kernel.spi.bootstrap.HealthProbe` and exposes two snapshots:
 
-- **Readiness** — UP only when the kernel has transitioned to `STARTED` and every required subsystem is `RUNNING`. Returns `STARTING` while the Boot DAG is in progress, while a required subsystem is still initializing, and during `SHUTTING_DOWN`. Returns `FAILED` after `FAILED` state.
-- **Liveness** — UP after the kernel has transitioned to `INITIALIZED`. Returns `STARTING` before that point. Returns `DOWN` only after `FAILED` state.
+- **Readiness** — UP only when the kernel has transitioned to `STARTED` and every required subsystem is `RUNNING`. Returns `STARTING` while the Boot DAG is in progress, while a required subsystem is still initializing, and during `SHUTTING_DOWN`. Returns `DEGRADED` (not ready) when a **required** subsystem has gone `DEGRADED` — live but impaired after boot, e.g. its broker died — so the load balancer drains the instance; a still-initializing required subsystem outranks `DEGRADED` for the status label. A **degraded optional** subsystem never sheds readiness. Returns `FAILED` after `FAILED` state.
+- **Liveness** — UP after the kernel has transitioned to `INITIALIZED`. Returns `STARTING` before that point. Returns `DOWN` only after `FAILED` state. A `DEGRADED` subsystem never affects liveness — the process stays alive so it can recover (`DEGRADED → RUNNING` is reversible).
 
 ### `HealthEndpointHandler` (Community)
 
@@ -374,7 +374,7 @@ httpServerEngine.start();
 | **Readiness** | `/healthz/readiness`     | `200 OK`           | `503 Service Unavailable`                              |
 | **Liveness**  | `/healthz/liveness`      | `200 OK`           | `503 Service Unavailable`                              |
 
-Custom paths are available via `new HealthEndpointHandler(probe, readinessPath, livenessPath)`. The textual probe status (`READY`, `STARTING`, `UP`, `DOWN`, `FAILED`) is mirrored into the response header `X-Exeris-Health` for human diagnostics — Kubernetes probes evaluate the status code only, so responses are bodyless.
+Custom paths are available via `new HealthEndpointHandler(probe, readinessPath, livenessPath)`. The textual probe status (`READY`, `STARTING`, `DEGRADED`, `UP`, `DOWN`, `FAILED`) is mirrored into the response header `X-Exeris-Health` for human diagnostics — Kubernetes probes evaluate the status code only, so responses are bodyless. A required-subsystem `DEGRADED` surfaces as readiness `503` + `X-Exeris-Health: DEGRADED` while liveness stays `200`.
 
 The handler returns:
 - `404 Not Found` for paths that match neither probe, without invoking the probe;

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -88,7 +88,7 @@ flowchart TD
 ## Diagram 1b — Subsystem State Machine
 
 Each subsystem registered in the Boot DAG transitions through this state machine independently.
-Core's `SubsystemOrchestrator` drives transitions; transitions are irreversible — there is no `RESTART`.
+Core's `SubsystemOrchestrator` drives the boot transitions, which are irreversible — there is no `RESTART`. The one reversible axis is the post-boot health state `RUNNING ↔ DEGRADED`, driven not by the orchestrator but by the Community `CommunitySubsystemHealthWatcher` (see "Kubernetes Health Probes" below): a live-but-impaired dependency degrades readiness and recovers when it returns, without ever leaving the `RUNNING`-family or killing the process.
 
 ```mermaid
 stateDiagram-v2
@@ -104,6 +104,10 @@ stateDiagram-v2
     RUNNING --> STOPPED        : stop() called\nAll resources released
     RUNNING --> FAILED         : Unrecoverable runtime error
 
+    RUNNING --> DEGRADED       : Health watcher: dependency lost\n(post-boot, reversible)
+    DEGRADED --> RUNNING       : Health watcher: dependency recovered
+    DEGRADED --> STOPPED       : stop() called
+
     STOPPED --> [*]            : Virtual Threads drained
 
     FAILED --> [*]             : Emergency JFR snapshot\nJVM exit(1) · Glass-Box buffer flushed
@@ -117,6 +121,13 @@ stateDiagram-v2
     note right of FAILED
         K8s liveness probe → HTTP 503.
         Pod replaced by ReplicaSet controller.
+    end note
+
+    note right of DEGRADED
+        Live but impaired (required dep lost post-boot).
+        K8s readiness probe → HTTP 503 (drain).
+        K8s liveness probe → HTTP 200 (not killed).
+        Watcher-driven, post-boot only, reversible.
     end note
 
     %% Note: kernel-level SHUTTING_DOWN is from KernelState, not per-subsystem state.

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -382,6 +382,23 @@ The handler returns:
 
 The contract is pinned by `eu.exeris.kernel.tck.contract.health.AbstractHealthEndpointTck` plus the Community binding `CommunityHealthEndpointTckTest`. End-to-end behavior with the real `KernelHealthMonitor` is pinned by `HealthEndpointHandlerKernelMonitorIntegrationTest`.
 
+### `CommunitySubsystemHealthWatcher` (Community, host-wired)
+
+`KernelHealthMonitor` only marks a subsystem `RUNNING` at boot; it does not re-poll afterwards. To drop readiness when a dependency dies *after* boot (and restore it on recovery), `eu.exeris.kernel.community.bootstrap.CommunitySubsystemHealthWatcher` runs a background poll that reconciles each live subsystem's health into the monitor's reversible `RUNNING ↔ DEGRADED` axis. It transitions **only** that axis — never resurrecting `FAILED`/`STOPPED` nor racing the boot DAG — and treats a throwing health source as impaired.
+
+Like `HealthEndpointHandler`, the watcher is **wired by the host**, not by kernel `main` — it stays Wall-clean by knowing the *concrete* Community subsystems and pushing state through the public `markSubsystemState` (no generic subsystem-health method is added to the SPI; that is deferred to v0.10). Construct it after boot, register each subsystem's health source (e.g. persistence's `canServiceRequest()` — the same signal that deterministically denies requests under ADR-012), `start()` it, and `stop()` it on shutdown:
+
+```java
+KernelHealthMonitor monitor = bootstrap.healthMonitor();
+var watcher = new CommunitySubsystemHealthWatcher(monitor, Duration.ofSeconds(5).toNanos());
+watcher.register("persistence", persistenceEngine::canServiceRequest);
+watcher.start();                 // after the kernel reaches STARTED
+// ... on shutdown:
+watcher.stop();
+```
+
+The reconciliation + lifecycle is pinned by `CommunitySubsystemHealthWatcherTest`; the full `health-source → watcher → monitor → /healthz/readiness` path (503 + `X-Exeris-Health: DEGRADED` and recovery) by `HealthEndpointHandlerKernelMonitorIntegrationTest`.
+
 ### Kubernetes manifest snippet
 
 ```yaml

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -28,7 +28,7 @@
               mvn -pl exeris-kernel-community-kafka test -Dgroups=integration
             Default Surefire runs exclude them so the unit suite stays fast and Docker-free.
         -->
-        <excludedGroups>integration</excludedGroups>
+        <excludedGroups>integration,continuity</excludedGroups>
 
         <!--
             v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Kafka bundle.

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -41,7 +41,7 @@
             own fork because the scarce-carrier VT-scheduler args would otherwise distort
             every other test in the default execution.
         -->
-        <excludedGroups>flamegraph,integration,stress,transport-pinning-recv</excludedGroups>
+        <excludedGroups>flamegraph,integration,stress,transport-pinning-recv,continuity</excludedGroups>
 
         <!--
             v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Community bundle.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcher.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor.SubsystemState;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Community-side background watcher that turns a live subsystem's post-boot health into the Core
+ * {@link KernelHealthMonitor}'s reversible {@link SubsystemState#DEGRADED}/{@link SubsystemState#RUNNING}
+ * axis, so readiness drops (and the load balancer drains the instance) when a dependency dies after
+ * boot — and recovers when it returns.
+ *
+ * <h2>The Wall</h2>
+ * <p>This lives in Community, not Core: it knows the <em>concrete</em> Community subsystems and their
+ * health primitives (e.g. {@code CommunityPersistenceEngine#canServiceRequest()}), wired in as a
+ * {@link HealthSource} per subsystem. It only pushes state through the existing public
+ * {@code markSubsystemState} — no generic subsystem-health method is added to the SPI (that is a v0.10
+ * decision). Core stays driver-agnostic.
+ *
+ * <h2>State discipline</h2>
+ * <p>The watcher transitions <strong>only</strong> {@code RUNNING ↔ DEGRADED}. It never touches a
+ * subsystem still booting ({@code REGISTERED}/{@code INITIALIZED}), nor a terminal
+ * {@code FAILED}/{@code STOPPED} one — so it cannot resurrect a failed subsystem or race the boot DAG.
+ */
+public final class CommunitySubsystemHealthWatcher {
+
+    private static final System.Logger LOG =
+            System.getLogger(CommunitySubsystemHealthWatcher.class.getName());
+
+    private final KernelHealthMonitor monitor;
+    private final Map<String, HealthSource> sources = new ConcurrentHashMap<>();
+    private final long intervalNanos;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private volatile Thread thread;
+
+    public CommunitySubsystemHealthWatcher(KernelHealthMonitor monitor, long intervalNanos) {
+        this.monitor = Objects.requireNonNull(monitor, "monitor");
+        if (intervalNanos <= 0) {
+            throw new IllegalArgumentException("intervalNanos must be positive");
+        }
+        this.intervalNanos = intervalNanos;
+    }
+
+    /** Registers a concrete subsystem's health source under its monitor name. */
+    public void register(String subsystemName, HealthSource source) {
+        Objects.requireNonNull(subsystemName, "subsystemName");
+        Objects.requireNonNull(source, "source");
+        sources.put(subsystemName, source);
+    }
+
+    /** Starts the background poll loop on a dedicated platform thread. Idempotent. */
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+        Thread loop = Thread.ofPlatform()
+                .name("kernel/health-watcher")
+                .unstarted(this::runLoop);
+        this.thread = loop;
+        loop.start();
+    }
+
+    /** Stops the poll loop and joins the thread (best effort). Idempotent. */
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        Thread loop = this.thread;
+        if (loop != null) {
+            LockSupport.unpark(loop);
+            try {
+                loop.join(java.util.concurrent.TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void runLoop() {
+        while (running.get()) {
+            pollOnce();
+            LockSupport.parkNanos(intervalNanos);
+        }
+    }
+
+    /**
+     * Single poll pass: reconcile each source's health against the monitor's tracked state, flipping
+     * only {@code RUNNING ↔ DEGRADED}. Package-private so the contract is testable without the loop.
+     */
+    /* default */ void pollOnce() {
+        for (Map.Entry<String, HealthSource> entry : sources.entrySet()) {
+            String name = entry.getKey();
+            SubsystemState current = monitor.stateOf(name);
+            if (current != SubsystemState.RUNNING && current != SubsystemState.DEGRADED) {
+                continue;
+            }
+            boolean healthy = healthyQuietly(entry.getValue(), name);
+            if (current == SubsystemState.RUNNING && !healthy) {
+                monitor.markSubsystemState(name, SubsystemState.DEGRADED);
+            } else if (current == SubsystemState.DEGRADED && healthy) {
+                monitor.markSubsystemState(name, SubsystemState.RUNNING);
+            }
+        }
+    }
+
+    // A misbehaving health probe must not crash the watcher loop or other subsystems' reconciliation;
+    // any throw is itself an impairment signal, so the broad catch is the resilience boundary here.
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private static boolean healthyQuietly(HealthSource source, String name) {
+        try {
+            return source.healthy();
+        } catch (RuntimeException ex) {
+            // A health probe that throws is itself an impairment signal — treat as not healthy.
+            LOG.log(System.Logger.Level.DEBUG, () -> "health source threw for subsystem " + name, ex);
+            return false;
+        }
+    }
+
+    /** Health of one concrete subsystem; {@code true} = serving, {@code false} = impaired. */
+    @FunctionalInterface
+    public interface HealthSource {
+        boolean healthy();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcher.java
@@ -68,6 +68,7 @@ public final class CommunitySubsystemHealthWatcher {
         }
         Thread loop = Thread.ofPlatform()
                 .name("kernel/health-watcher")
+                .daemon(true)   // background infra thread — must never block JVM exit if stop() is skipped
                 .unstarted(this::runLoop);
         this.thread = loop;
         loop.start();

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityDegradedModeIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityDegradedModeIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.community.persistence.CommunityPersistenceProvider;
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor.KernelState;
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor.SubsystemState;
+import eu.exeris.kernel.spi.persistence.PersistenceConfig;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Operational-continuity IT (v0.9 Sprint 7, deliverable #3): a real dependency failure — the Postgres
+ * container is stopped mid-run — must drive the required {@code persistence} subsystem to
+ * {@link SubsystemState#DEGRADED} via {@link CommunitySubsystemHealthWatcher}, dropping readiness
+ * (so the load balancer drains the instance — the ADR-012 deterministic deny at the routing layer)
+ * while liveness stays UP (the process is not killed, so it can recover).
+ *
+ * <p>Community impl-level (the watcher is Community-only; no SPI surface), tagged {@code continuity}
+ * so it runs in the {@code recovery-continuity-gate} CI job, not the fast unit pass.
+ */
+@Tag("continuity")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community degraded-mode: Postgres loss drives readiness DEGRADED, liveness stays UP")
+class CommunityDegradedModeIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    @Test
+    @Timeout(120)
+    void databaseLossDrivesReadinessDegraded() {
+        PersistenceConfig cfg = new PersistenceConfig(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword(),
+                8, 1, 5_000L, 60_000L, 600_000L,
+                false, false, false, 0,
+                Map.of("run.migrations", "true"));
+        PersistenceEngine engine = new CommunityPersistenceProvider().createEngine(cfg);
+
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.RUNNING);
+        monitor.markKernelState(KernelState.INITIALIZED);
+        monitor.markKernelState(KernelState.STARTED);
+
+        CommunitySubsystemHealthWatcher watcher =
+                new CommunitySubsystemHealthWatcher(monitor, TimeUnit.MILLISECONDS.toNanos(200));
+        // Connectivity signal: healthCheckDetailed() runs conn.isValid(2) and fails when the DB is gone.
+        watcher.register("persistence", () -> engine.healthCheckDetailed().healthy());
+
+        watcher.start();
+        try {
+            awaitSubsystemState(monitor, SubsystemState.RUNNING);
+            assertThat(monitor.readiness().status()).isEqualTo("READY");
+            assertThat(monitor.readiness().healthy()).isTrue();
+
+            POSTGRES.stop();
+
+            awaitSubsystemState(monitor, SubsystemState.DEGRADED);
+            assertThat(monitor.readiness().status()).isEqualTo("DEGRADED");
+            assertThat(monitor.readiness().healthy()).as("readiness drains on DB loss").isFalse();
+            assertThat(monitor.liveness().healthy()).as("process stays alive while degraded").isTrue();
+        } finally {
+            watcher.stop();
+            engine.close();
+        }
+    }
+
+    private static void awaitSubsystemState(KernelHealthMonitor monitor, SubsystemState expected) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+        while (monitor.stateOf("persistence") != expected && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        assertThat(monitor.stateOf("persistence")).as("persistence reaches %s within deadline", expected)
+                .isEqualTo(expected);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityDegradedModeIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityDegradedModeIntegrationTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("continuity")
 @Testcontainers(disabledWithoutDocker = true)
 @DisplayName("Community degraded-mode: Postgres loss drives readiness DEGRADED, liveness stays UP")
-class CommunityDegradedModeIT {
+class CommunityDegradedModeIntegrationTest {
 
     @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityRestartRecoveryIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunityRestartRecoveryIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.community.flow.JdbcFlowSnapshotStore;
+import eu.exeris.kernel.community.persistence.CommunityPersistenceProvider;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshot;
+import eu.exeris.kernel.spi.flow.model.FlowSnapshotStore;
+import eu.exeris.kernel.spi.flow.model.FlowState;
+import eu.exeris.kernel.spi.persistence.PersistenceConfig;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Operational-continuity IT (v0.9 Sprint 7, deliverable #2): a parked saga checkpoint must survive a
+ * <em>real</em> kernel restart. Kernel instance A parks a {@link FlowState#PARKED} snapshot and then
+ * <strong>fully closes its persistence engine</strong> (pool shut down — a genuine stop, not the
+ * same-engine reopen trick the per-store TCK uses); instance B boots a fresh engine + pool against the
+ * <strong>same</strong> Postgres database and must recover the snapshot with its checkpoint intact, so
+ * the resumed flow re-enters at the same step. Tagged {@code continuity} → runs in
+ * {@code recovery-continuity-gate}, not the fast unit pass.
+ */
+@Tag("continuity")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community restart-recovery: parked saga snapshot survives a real engine restart")
+class CommunityRestartRecoveryIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    @Test
+    @Timeout(120)
+    void parkedSagaSnapshotSurvivesRealEngineRestart() {
+        UUID id = UUID.randomUUID();
+        int checkpointStep = 4;
+
+        // ── Kernel instance A: park a saga, then fully stop the engine (real restart boundary) ──
+        PersistenceEngine engineA = newEngine();
+        try {
+            FlowSnapshotStore storeA = new JdbcFlowSnapshotStore(engineA, "kernel-A");
+            storeA.save(parkedSnapshot(id, checkpointStep));
+        } finally {
+            engineA.close();
+        }
+
+        // ── Kernel instance B: fresh engine + pool against the SAME database ──
+        PersistenceEngine engineB = newEngine();
+        try {
+            FlowSnapshotStore storeB = new JdbcFlowSnapshotStore(engineB, "kernel-B");
+
+            assertThat(storeB.exists(id.getMostSignificantBits(), id.getLeastSignificantBits()))
+                    .as("parked snapshot outlives a full engine restart").isTrue();
+
+            Optional<FlowSnapshot> recovered =
+                    storeB.load(id.getMostSignificantBits(), id.getLeastSignificantBits());
+            assertThat(recovered).isPresent();
+            assertThat(recovered.get().state()).isEqualTo(FlowState.PARKED);
+            assertThat(recovered.get().currentStep())
+                    .as("flow resumes from its checkpoint step, not the start").isEqualTo(checkpointStep);
+
+            assertThat(storeB.listParked())
+                    .as("recovered saga is enumerable as parked after restart")
+                    .anyMatch(s -> s.instanceIdMost() == id.getMostSignificantBits()
+                            && s.instanceIdLeast() == id.getLeastSignificantBits());
+        } finally {
+            engineB.close();
+        }
+    }
+
+    private static PersistenceEngine newEngine() {
+        PersistenceConfig cfg = new PersistenceConfig(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword(),
+                8, 1, 5_000L, 60_000L, 600_000L,
+                false, false, false, 0,
+                Map.of("run.migrations", "true"));
+        return new CommunityPersistenceProvider().createEngine(cfg);
+    }
+
+    private static FlowSnapshot parkedSnapshot(UUID id, int currentStep) {
+        return new FlowSnapshot(
+                id.getMostSignificantBits(),
+                id.getLeastSignificantBits(),
+                "restart-recovery-saga",
+                currentStep,
+                FlowState.PARKED,
+                Instant.parse("2026-06-18T10:00:00Z"),
+                Instant.parse("2026-06-18T11:00:00Z"),
+                new int[]{1, 2, 3},
+                3,
+                new byte[]{0x0A, 0x0B},
+                FlowSnapshot.SCHEMA_VERSION_INITIAL);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcherTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcherTest.java
@@ -10,11 +10,15 @@ package eu.exeris.kernel.community.bootstrap;
 
 import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
 import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor.SubsystemState;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,6 +114,38 @@ class CommunitySubsystemHealthWatcherTest {
         }
 
         assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.RUNNING);
+    }
+
+    @Test
+    @DisplayName("RUNNING→DEGRADED flip emits a SubsystemHealthTransition JFR event")
+    void degradedTransitionEmitsJfrEvent() throws InterruptedException {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.RUNNING);
+
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("persistence", () -> false);
+
+        CountDownLatch recorded = new CountDownLatch(1);
+        AtomicReference<RecordedEvent> captured = new AtomicReference<>();
+        try (RecordingStream stream = new RecordingStream()) {
+            stream.enable("eu.exeris.kernel.bootstrap.SubsystemHealthTransition");
+            stream.onEvent("eu.exeris.kernel.bootstrap.SubsystemHealthTransition", event -> {
+                captured.set(event);
+                recorded.countDown();
+            });
+            stream.startAsync();
+
+            watcher.pollOnce(); // RUNNING → DEGRADED
+
+            assertThat(recorded.await(5, TimeUnit.SECONDS))
+                    .as("a DEGRADED transition must leave a JFR trail (ADR-005)").isTrue();
+        }
+
+        RecordedEvent event = captured.get();
+        assertThat(event.getString("subsystemName")).isEqualTo("persistence");
+        assertThat(event.getString("fromState")).isEqualTo("RUNNING");
+        assertThat(event.getString("toState")).isEqualTo("DEGRADED");
     }
 
     private static void awaitState(KernelHealthMonitor monitor, String name, SubsystemState expected) {

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcherTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemHealthWatcherTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
+import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor.SubsystemState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link CommunitySubsystemHealthWatcher} reconciliation + lifecycle. */
+class CommunitySubsystemHealthWatcherTest {
+
+    private static final long INTERVAL_NANOS = TimeUnit.MILLISECONDS.toNanos(5);
+
+    @Test
+    @DisplayName("RUNNING subsystem with an unhealthy source is marked DEGRADED")
+    void runningUnhealthyBecomesDegraded() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.RUNNING);
+
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("persistence", () -> false);
+
+        watcher.pollOnce();
+
+        assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("DEGRADED subsystem with a recovered source is marked RUNNING again (reversible)")
+    void degradedHealthyRecoversToRunning() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.RUNNING);
+
+        AtomicBoolean healthy = new AtomicBoolean(false);
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("persistence", healthy::get);
+
+        watcher.pollOnce();
+        assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.DEGRADED);
+
+        healthy.set(true);
+        watcher.pollOnce();
+        assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.RUNNING);
+    }
+
+    @Test
+    @DisplayName("FAILED subsystem is never resurrected by the watcher")
+    void failedSubsystemNotResurrected() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.FAILED);
+
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("persistence", () -> true);
+
+        watcher.pollOnce();
+
+        assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.FAILED);
+    }
+
+    @Test
+    @DisplayName("A health source that throws is treated as impaired (DEGRADED)")
+    void throwingSourceTreatedAsUnhealthy() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("events", true);
+        monitor.markSubsystemState("events", SubsystemState.RUNNING);
+
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("events", () -> {
+            throw new IllegalStateException("broker unreachable");
+        });
+
+        watcher.pollOnce();
+
+        assertThat(monitor.stateOf("events")).isEqualTo(SubsystemState.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("background loop reconciles state and stops cleanly")
+    void backgroundLoopReconcilesAndStops() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", SubsystemState.RUNNING);
+
+        AtomicBoolean healthy = new AtomicBoolean(false);
+        CommunitySubsystemHealthWatcher watcher = new CommunitySubsystemHealthWatcher(monitor, INTERVAL_NANOS);
+        watcher.register("persistence", healthy::get);
+
+        watcher.start();
+        try {
+            awaitState(monitor, "persistence", SubsystemState.DEGRADED);
+            healthy.set(true);
+            awaitState(monitor, "persistence", SubsystemState.RUNNING);
+        } finally {
+            watcher.stop();
+        }
+
+        assertThat(monitor.stateOf("persistence")).isEqualTo(SubsystemState.RUNNING);
+    }
+
+    private static void awaitState(KernelHealthMonitor monitor, String name, SubsystemState expected) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (monitor.stateOf(name) != expected && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertThat(monitor.stateOf(name)).as("state of %s within deadline", name).isEqualTo(expected);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
@@ -123,7 +123,7 @@ class HealthEndpointHandlerKernelMonitorIntegrationTest {
                     .filter(expected::equals).isPresent()) {
                 return;
             }
-            Thread.onSpinWait();
+            java.util.concurrent.locks.LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(2));
         }
         assertThat(invoke(handler, READINESS).header(HealthEndpointHandler.STATUS_HEADER))
                 .as("readiness status reaches %s within deadline", expected)

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/health/HealthEndpointHandlerKernelMonitorIntegrationTest.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.health;
 
+import eu.exeris.kernel.community.bootstrap.CommunitySubsystemHealthWatcher;
 import eu.exeris.kernel.core.bootstrap.health.KernelHealthMonitor;
 import eu.exeris.kernel.spi.bootstrap.HealthProbe;
 import eu.exeris.kernel.spi.http.HttpExchange;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -77,6 +80,54 @@ class HealthEndpointHandlerKernelMonitorIntegrationTest {
         RecordingExchange afterFailure = invoke(handler, LIVENESS);
         assertThat(afterFailure.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         assertThat(afterFailure.header(HealthEndpointHandler.STATUS_HEADER)).hasValue("DOWN");
+    }
+
+    @Test
+    @DisplayName("Health watcher drives readiness RUNNING→DEGRADED→RUNNING through the HTTP probe")
+    void watcherDrivesReadinessDegradedAndBack() {
+        KernelHealthMonitor monitor = new KernelHealthMonitor();
+        monitor.registerSubsystem("persistence", true);
+        monitor.markSubsystemState("persistence", KernelHealthMonitor.SubsystemState.RUNNING);
+        monitor.markKernelState(KernelHealthMonitor.KernelState.INITIALIZED);
+        monitor.markKernelState(KernelHealthMonitor.KernelState.STARTED);
+        HealthEndpointHandler handler = new HealthEndpointHandler(monitor);
+
+        // Stands in for CommunityPersistenceEngine#canServiceRequest(): the live health signal the
+        // watcher reconciles and the same signal that deterministically denies requests (ADR-012).
+        AtomicBoolean serving = new AtomicBoolean(true);
+        CommunitySubsystemHealthWatcher watcher =
+                new CommunitySubsystemHealthWatcher(monitor, TimeUnit.MILLISECONDS.toNanos(5));
+        watcher.register("persistence", serving::get);
+
+        assertThat(invoke(handler, READINESS).status()).isEqualTo(HttpStatus.OK);
+
+        watcher.start();
+        try {
+            serving.set(false);
+            awaitReadinessStatus(handler, "DEGRADED");
+            assertThat(invoke(handler, READINESS).status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+            assertThat(invoke(handler, LIVENESS).status()).isEqualTo(HttpStatus.OK);
+
+            serving.set(true);
+            awaitReadinessStatus(handler, "READY");
+            assertThat(invoke(handler, READINESS).status()).isEqualTo(HttpStatus.OK);
+        } finally {
+            watcher.stop();
+        }
+    }
+
+    private static void awaitReadinessStatus(HttpHandler handler, String expected) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (System.nanoTime() < deadline) {
+            if (invoke(handler, READINESS).header(HealthEndpointHandler.STATUS_HEADER)
+                    .filter(expected::equals).isPresent()) {
+                return;
+            }
+            Thread.onSpinWait();
+        }
+        assertThat(invoke(handler, READINESS).header(HealthEndpointHandler.STATUS_HEADER))
+                .as("readiness status reaches %s within deadline", expected)
+                .hasValue(expected);
     }
 
     private static RecordingExchange invoke(HttpHandler handler, String path) {

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
@@ -31,6 +31,7 @@ public final class KernelHealthMonitor implements HealthProbe {
     private static final String STATUS_STARTING = "STARTING";
     private static final String STATUS_READY = "READY";
     private static final String STATUS_FAILED = "FAILED";
+    private static final String STATUS_DEGRADED = "DEGRADED";
     private static final String STATUS_DOWN = "DOWN";
     private static final String STATUS_UP = "UP";
 
@@ -74,7 +75,13 @@ public final class KernelHealthMonitor implements HealthProbe {
         ));
     }
 
-    /** Readiness: UP only when kernel is started and every required subsystem is RUNNING. */
+    /**
+     * Readiness: READY only when the kernel is started and every required subsystem is RUNNING.
+     * A required subsystem in {@link SubsystemState#DEGRADED} (a live-but-impaired dependency, e.g.
+     * its broker died after boot) drops readiness with a distinct {@code "DEGRADED"} status so the
+     * load balancer drains this instance; a still-coming-up required subsystem outranks it for the
+     * status label ({@code "STARTING"}). An OPTIONAL subsystem degraded never sheds readiness.
+     */
     @Override
     public ProbeSnapshot readiness() {
         if (kernelFailed.get()) {
@@ -83,16 +90,25 @@ public final class KernelHealthMonitor implements HealthProbe {
         if (!kernelStarted.get() || kernelShuttingDown.get()) {
             return new ProbeSnapshot(STATUS_STARTING, false);
         }
-        boolean allRequiredRunning = true;
+        return requiredSubsystemReadiness();
+    }
+
+    private ProbeSnapshot requiredSubsystemReadiness() {
+        boolean anyStarting = false;
+        boolean anyDegraded = false;
         for (SubsystemHealth health : subsystems.values()) {
-            if (health.requiredForReadiness() && health.state() != SubsystemState.RUNNING) {
-                allRequiredRunning = false;
-                break;
+            if (!health.requiredForReadiness() || health.state() == SubsystemState.RUNNING) {
+                continue;
             }
+            anyDegraded |= health.state() == SubsystemState.DEGRADED;
+            anyStarting |= health.state() != SubsystemState.DEGRADED;
         }
-        return allRequiredRunning
-                ? new ProbeSnapshot(STATUS_READY, true)
-                : new ProbeSnapshot(STATUS_STARTING, false);
+        if (anyStarting) {
+            return new ProbeSnapshot(STATUS_STARTING, false);
+        }
+        return anyDegraded
+                ? new ProbeSnapshot(STATUS_DEGRADED, false)
+                : new ProbeSnapshot(STATUS_READY, true);
     }
 
     /** Liveness: UP after kernel init, DOWN only when kernel entered failed state. */
@@ -121,6 +137,8 @@ public final class KernelHealthMonitor implements HealthProbe {
         REGISTERED,
         INITIALIZED,
         RUNNING,
+        /** Live but impaired (e.g. a dependency failed after boot); reversible back to RUNNING. */
+        DEGRADED,
         FAILED,
         STOPPED
     }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
@@ -75,6 +75,13 @@ public final class KernelHealthMonitor implements HealthProbe {
         ));
     }
 
+    /** Current tracked state of a subsystem, or {@code null} if it is not registered. */
+    public SubsystemState stateOf(String name) {
+        Objects.requireNonNull(name, "name");
+        SubsystemHealth health = subsystems.get(name);
+        return health == null ? null : health.state();
+    }
+
     /**
      * Readiness: READY only when the kernel is started and every required subsystem is RUNNING.
      * A required subsystem in {@link SubsystemState#DEGRADED} (a live-but-impaired dependency, e.g.

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/health/KernelHealthMonitor.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.core.bootstrap.health;
 
+import eu.exeris.kernel.core.bootstrap.jfr.BootstrapJfrEvents;
 import eu.exeris.kernel.spi.bootstrap.HealthProbe;
 
 import java.util.Map;
@@ -69,10 +70,19 @@ public final class KernelHealthMonitor implements HealthProbe {
     public void markSubsystemState(String name, SubsystemState newState) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(newState, "newState");
-        subsystems.computeIfPresent(name, (ignored, previous) -> new SubsystemHealth(
-                previous.requiredForReadiness(),
-                newState
-        ));
+        SubsystemHealth[] previousHolder = new SubsystemHealth[1];
+        subsystems.computeIfPresent(name, (ignored, previous) -> {
+            previousHolder[0] = previous;
+            return new SubsystemHealth(previous.requiredForReadiness(), newState);
+        });
+        SubsystemHealth previous = previousHolder[0];
+        // JFR-first (ADR-005): a post-boot RUNNING<->DEGRADED flip has no boot lifecycle event, so
+        // emit one here so a flapping dependency leaves an SRE trail. Boot transitions don't involve
+        // DEGRADED and keep their own SubsystemInitialized/Started/Stopped events.
+        if (previous != null && previous.state() != newState
+                && (previous.state() == SubsystemState.DEGRADED || newState == SubsystemState.DEGRADED)) {
+            BootstrapJfrEvents.emitHealthTransition(name, previous.state().name(), newState.name());
+        }
     }
 
     /** Current tracked state of a subsystem, or {@code null} if it is not registered. */
@@ -107,6 +117,10 @@ public final class KernelHealthMonitor implements HealthProbe {
             if (!health.requiredForReadiness() || health.state() == SubsystemState.RUNNING) {
                 continue;
             }
+            // Any required non-RUNNING, non-DEGRADED state (still INITIALIZED/REGISTERED, or a
+            // post-boot FAILED that has not yet escalated to kernel-FAILED — checked before this
+            // method) counts as "starting": readiness is down either way, and the label favours
+            // "coming up" over "degraded" when both reasons coexist.
             anyDegraded |= health.state() == SubsystemState.DEGRADED;
             anyStarting |= health.state() != SubsystemState.DEGRADED;
         }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/jfr/BootstrapJfrEvents.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/jfr/BootstrapJfrEvents.java
@@ -117,6 +117,32 @@ public final class BootstrapJfrEvents {
     }
 
     // =========================================================================
+    // Event: SubsystemHealthTransition
+    // =========================================================================
+
+    /**
+     * Emitted on a post-boot subsystem health transition involving {@code DEGRADED}
+     * ({@code RUNNING ↔ DEGRADED}). Gives SREs a JFR trail for a flapping dependency that the
+     * boot lifecycle events do not cover. Cold path (the health watcher's reconcile pass, not the
+     * probe hot path), single-phase commit.
+     */
+    @Name("eu.exeris.kernel.bootstrap.SubsystemHealthTransition")
+    @Label("Subsystem Health Transition")
+    @Category({"Exeris Kernel", "Bootstrap"})
+    @StackTrace(false)
+    public static final class SubsystemHealthTransitionEvent extends Event {
+
+        @Label("Subsystem Name")
+        public String subsystemName;
+
+        @Label("From State")
+        public String fromState;
+
+        @Label("To State")
+        public String toState;
+    }
+
+    // =========================================================================
     // Event: KernelBootReady
     // =========================================================================
 
@@ -293,6 +319,27 @@ public final class BootstrapJfrEvents {
         }
         event.subsystemName = name;
         event.durationMs    = (System.nanoTime() - startNanos) / 1_000_000;
+        event.commit();
+    }
+
+    /**
+     * Records a post-boot subsystem health transition involving {@code DEGRADED}.
+     *
+     * @param name      subsystem name
+     * @param fromState previous {@code SubsystemState} name
+     * @param toState   new {@code SubsystemState} name
+     */
+    public static void emitHealthTransition(String name, String fromState, String toState) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        var event = new SubsystemHealthTransitionEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
+        event.subsystemName = name;
+        event.fromState     = fromState;
+        event.toState       = toState;
         event.commit();
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/CoreHealthMonitorTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/bootstrap/CoreHealthMonitorTckTest.java
@@ -51,6 +51,11 @@ class CoreHealthMonitorTckTest extends AbstractHealthMonitorTck {
             }
 
             @Override
+            public void markSubsystemDegraded(String subsystem) {
+                monitor.markSubsystemState(subsystem, KernelHealthMonitor.SubsystemState.DEGRADED);
+            }
+
+            @Override
             public boolean readinessUp() {
                 return monitor.readiness().healthy();
             }
@@ -58,6 +63,11 @@ class CoreHealthMonitorTckTest extends AbstractHealthMonitorTck {
             @Override
             public boolean livenessUp() {
                 return monitor.liveness().healthy();
+            }
+
+            @Override
+            public String readinessStatus() {
+                return monitor.readiness().status();
             }
         };
     }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/bootstrap/AbstractHealthMonitorTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/bootstrap/AbstractHealthMonitorTck.java
@@ -33,9 +33,14 @@ public abstract class AbstractHealthMonitorTck {
 
         void markSubsystemFailed(String subsystem);
 
+        void markSubsystemDegraded(String subsystem);
+
         boolean readinessUp();
 
         boolean livenessUp();
+
+        /** Diagnostic readiness status string (e.g. "READY", "STARTING", "DEGRADED", "FAILED"). */
+        String readinessStatus();
     }
 
     @Test
@@ -87,6 +92,53 @@ public abstract class AbstractHealthMonitorTck {
         monitor.markKernelStarted();
 
         assertThat(monitor.readinessUp()).isTrue();
+    }
+
+    @Test
+    @DisplayName("required subsystem degraded drops readiness with DEGRADED status, liveness stays UP")
+    void requiredDegradedDropsReadinessButNotLiveness() {
+        HealthMonitorAdapter monitor = createMonitor();
+        monitor.register("persistence", true);
+        monitor.markSubsystemRunning("persistence");
+        monitor.markKernelInitialized();
+        monitor.markKernelStarted();
+        monitor.markSubsystemDegraded("persistence");
+
+        assertThat(monitor.readinessUp()).isFalse();
+        assertThat(monitor.readinessStatus()).isEqualTo("DEGRADED");
+        assertThat(monitor.livenessUp()).isTrue();
+    }
+
+    @Test
+    @DisplayName("optional subsystem degraded does not drop readiness")
+    void optionalDegradedDoesNotDropReadiness() {
+        HealthMonitorAdapter monitor = createMonitor();
+        monitor.register("persistence", true);
+        monitor.register("events", false);
+        monitor.markSubsystemRunning("persistence");
+        monitor.markKernelInitialized();
+        monitor.markKernelStarted();
+        monitor.markSubsystemDegraded("events");
+
+        assertThat(monitor.readinessUp()).isTrue();
+        assertThat(monitor.readinessStatus()).isEqualTo("READY");
+    }
+
+    @Test
+    @DisplayName("degraded required subsystem recovers to READY (reversible)")
+    void degradedSubsystemRecoversToReady() {
+        HealthMonitorAdapter monitor = createMonitor();
+        monitor.register("persistence", true);
+        monitor.markSubsystemRunning("persistence");
+        monitor.markKernelInitialized();
+        monitor.markKernelStarted();
+
+        monitor.markSubsystemDegraded("persistence");
+        assertThat(monitor.readinessUp()).isFalse();
+
+        monitor.markSubsystemRunning("persistence");
+        assertThat(monitor.readinessUp()).isTrue();
+        assertThat(monitor.readinessStatus()).isEqualTo("READY");
     }
 
     @Test

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/health/AbstractHealthEndpointTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/health/AbstractHealthEndpointTck.java
@@ -142,6 +142,24 @@ public abstract class AbstractHealthEndpointTck {
     }
 
     @Test
+    @DisplayName("Degraded required subsystem: readiness 503 with DEGRADED status, liveness 200 UP")
+    void degradedRequiredSubsystemReadiness503LivenessOk() {
+        StubHealthProbe probe = new StubHealthProbe(
+                new ProbeSnapshot("DEGRADED", false),
+                new ProbeSnapshot("UP", true));
+
+        HttpHandler handler = newHandler(probe);
+
+        RecordingHttpExchange readiness = invoke(handler, get(READINESS_PATH));
+        RecordingHttpExchange liveness = invoke(handler, get(LIVENESS_PATH));
+
+        assertThat(readiness.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(readiness.headerValue(STATUS_HEADER)).hasValue("DEGRADED");
+        assertThat(liveness.status()).isEqualTo(HttpStatus.OK);
+        assertThat(liveness.headerValue(STATUS_HEADER)).hasValue("UP");
+    }
+
+    @Test
     @DisplayName("Both probes 503 when probe is fully unhealthy (FAILED kernel)")
     void bothProbesReturnUnavailableOnFailedKernel() {
         StubHealthProbe probe = new StubHealthProbe(


### PR DESCRIPTION
## v0.9 Sprint 7 — Upgrade/Restart/Recovery validation

Delivers the operational-continuity contract: a reversible **DEGRADED** subsystem health state, the production mechanism that drives it, the canonical HTTP surface, the restart-recovery + degraded-mode integration tests, and a dedicated CI gate.

Scoped per a prior `exeris-tck` survey + `exeris-architect` decision (the original 4-deliverable map assumed a `DEGRADED` state, a unified lifecycle enum, and `/healthz/ready` paths that don't exist). Chosen scope: **#4 health contract + #2 restart-recovery + #3 degraded-mode**; **#1 upgrade-continuity** (two-version Testcontainers fixture + persisted idempotency) is deferred to a `research/` spike.

## What's in

**DEGRADED health state (Core, Wall-safe — no SPI change)**
- `KernelHealthMonitor.SubsystemState.DEGRADED` (reversible) + readiness logic: a *required* DEGRADED subsystem → `("DEGRADED", not-ready)` (503 → drain), distinct from `STARTING`/`FAILED`; an *optional* DEGRADED never sheds readiness; liveness never goes DOWN on DEGRADED. `HealthProbe.ProbeSnapshot.status` is already an open string, so `"DEGRADED"` is a new value, not a contract change — `Subsystem` SPI untouched (a generic subsystem-health record is deferred to v0.10).
- HTTP: the canonical `HealthEndpointHandler` (`/healthz/readiness`+`/healthz/liveness`) already passes the status through, so DEGRADED surfaces as `503` + `X-Exeris-Health: DEGRADED` with no handler change.

**Production mechanism**
- `CommunitySubsystemHealthWatcher` (Community, host-wired): a background poll reconciles each concrete subsystem's health source (e.g. persistence `healthCheckDetailed()`/`canServiceRequest()`) into the monitor's `RUNNING ↔ DEGRADED` axis. Knows the concrete Community subsystems and pushes via the public `markSubsystemState` — no SPI surface. Transitions only `RUNNING ↔ DEGRADED`; never resurrects `FAILED`/`STOPPED`; a throwing source is treated as impaired.

**Tests (all verified green locally against Docker)**
- `AbstractHealthMonitorTck` + `AbstractHealthEndpointTck`: DEGRADED required/optional/reversible + HTTP 503+header cases.
- `CommunitySubsystemHealthWatcherTest` (5): reconcile/recover/FAILED-not-resurrected/throwing-source/loop.
- `HealthEndpointHandlerKernelMonitorIntegrationTest`: full `health-flip → watcher → monitor → /healthz/readiness` DEGRADED + recovery.
- `CommunityDegradedModeIntegrationTest` (`@Tag("continuity")`): **stops a real Postgres container** → persistence DEGRADED → readiness drains, liveness UP.
- `CommunityRestartRecoveryIntegrationTest` (`@Tag("continuity")`): parks a saga snapshot, **fully closes the engine**, boots a fresh engine on the same DB → snapshot recovered with checkpoint step intact.

**CI gate**
- `recovery-continuity-gate` job (mirrors persistence-rls / kafka-integration gates), chained `kafka-integration-gate → recovery-continuity-gate → transport-stress-gate`, runs `@Tag("continuity")` across community + community-kafka. Both poms exclude the `continuity` group from the fast unit pass. Verified the gate-style `-DincludedGroups=continuity` (no `-Dtest`) picks up both ITs (2/2) — the ITs are named `*IntegrationTest` because Surefire's default pattern does not match `*IT`.

**Docs**: `bootstrap.md` readiness/liveness table + DEGRADED row + host-wiring guide.

## Verification
- Core + Community: PMD + Checkstyle **0**. Health monitor TCK 8/8, endpoint TCK 9/9, watcher 5/5, integration green, both continuity ITs green against Docker.
- (community-kafka has one pre-existing PMD `UnnecessaryWarningSuppression` in `KafkaEventEngine` unrelated to this PR — not touched here.)

## Deferred (tracked follow-ups, not blockers)
- #1 upgrade-continuity (vN→vN+1 two-version fixture, persisted idempotency).
- Outbox **exactly-once** dedup across restart end-to-end through a broker (structurally backstopped today by the outbox `id UUID PRIMARY KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)