### PR TITLE
release(0.9.0): cut v0.9.0 — notes, CHANGELOG, ROADMAP sweep, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level. Which SPI surfaces are `stable` / `preview` / `experimental`, and what each label commits to for semver, is declared in [`docs/stability-matrix.md`](docs/stability-matrix.md) — the authoritative source for the semver policy.
 
+## [0.9.0] — 2026-06-18
+
+Minor release. SPI-backwards-compatible apart from one pre-1.0 diagnostics trim (no external consumers). Detail + migration notes: [`docs/release/v0.9.0-release-notes.md`](docs/release/v0.9.0-release-notes.md).
+
+### Added
+- **Diagnostics SPI + CLI** — `eu.exeris.kernel.spi.diagnostics.*` (first explicitly-**stable** new surface) + `exeris-kernel-diagnostics-cli` artifact (ADR-033).
+- **`@Immutable`** config-key sealing — `spi.config.Immutable` + `ConfigProvider.guardImmutable` (preview); compile-time + watcher-refusal enforcement.
+- **`TransportStream.reset(long)`** — Wall-safe `default` (graceful); Community abortive (RST) override.
+- **`DEGRADED`** reversible subsystem-health state + Community health watcher (Core-internal — no SPI change) → readiness drains, liveness holds.
+- Tracked docs: `stability-matrix.md`, `support-matrix.md`, `operations/reference-deployment.md`.
+- Security: JWKS key rotation (Community). Crypto: OpenSSL 4 multi-version (3.0–4.x, ADR-008 refresh).
+- Operational-continuity CI gate (`recovery-continuity-gate`, Testcontainers restart/degraded ITs).
+
+### Changed
+- **Diagnostics SPI trimmed** (pre-1.0): `listCapabilities()` / `CompositionSnapshot` / `CapabilityDescriptor` removed.
+- TLS reactor efficiency: closed-engine read-spin fix (#202), egress frame coalescing (#199), ingress loop-drain (#197), reactor dispatch + atomic cleanup (#195/#196).
+
+### Direction (RFC — implementation in later versions)
+- **IdentityProvider SPI** — `RFC-2026-06-08` (ACCEPTED); ADR-040 reserved; SPI + driver in v0.10.
+- **HTTP streaming (SSE-first)** — `RFC-2026-06-18`; ADR-043 reserved; brought earlier than the planned v0.12 (target v0.10/v0.11).
+
 ## [0.8.1] — 2026-06-08
 
 Patch release. Backwards-compatible SPI addition; no contract removals.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1195,6 +1195,8 @@ Prior-knowledge HTTP/2 (`handlePriorKnowledge` lines 88-101) is unaffected — i
 
 **Cross-repo dependents:** `exeris-ai-bridge` 0.4.0 implements `src/transport/kernel-adapter.ts` against the CLI's stdio JSON protocol (ADR-025 §Engineering Protocol item 2 binding closure). `exeris-kernel-enterprise` 0.6 ships `EnterpriseKernelDiagnosticsProvider` (priority 100) returning the same record types with Enterprise-only fields populated where the ADR-033 §Obligation 6 use-case test applies; the Enterprise overlay is mirrored as a link stub at `exeris-kernel-enterprise/docs/adr/ADR-033.link.md`. Out-of-scope here: authenticated / remote diagnostic transport (lands in `exeris-ai-bridge` 0.6+ transport-auth work), any mutation surface, `bridge:health` synthetic derived checks (aggregator concern, not kernel SPI concern).
 
+**Status (v0.9):** **DELIVERED** in Sprint 1 (ADR-033) — `eu.exeris.kernel.spi.diagnostics.*` is the first explicitly-**stable** new SPI surface; `CommunityKernelDiagnostics` + the shaded `exeris-kernel-diagnostics-cli` artifact + `AbstractKernelDiagnosticsTck` (+ pinned JSON schema fixture) landed. **Pre-1.0 trim:** `listCapabilities()` / `CompositionSnapshot` / `CapabilityDescriptor` were removed before the SPI froze (composition is a build-time/manifest concern); `EX-DIAG-1002` retired as a reserved gap.
+
 ---
 
 ### Diagnostics: JVM Runtime Ergonomics Snapshot (Introspective) + Recommended-Flags Baseline Doc
@@ -1321,6 +1323,8 @@ the same change (Obligation 9 four-method → five-method; EP step 8 `EX-DIAG-10
 
 **Merge Gate:** Support matrix reviewed and approved with release criteria.
 
+**Status (v0.9):** **DELIVERED** in Sprint 8 (#205) — `docs/support-matrix.md` published: supported runtime baseline (JDK 26, Postgres 16, Kafka 3.6/CP 7.6, OpenSSL 3.0–4.x, HTTP/1.1+h2/h2c), per-subsystem SPI status mirroring `stability-matrix.md`, Community-tier limits, Enterprise-only out-of-scope items, and deferred capabilities (incl. the streaming shift to v0.10/v0.11). Bidirectionally cross-linked with `stability-matrix.md` + `operations/reference-deployment.md`.
+
 ---
 
 ### Upgrade / Restart / Recovery Validation
@@ -1333,6 +1337,8 @@ the same change (Obligation 9 four-method → five-method; EP step 8 `EX-DIAG-10
 
 **Merge Gate:** Operational continuity suite is green on release-candidate branch.
 
+**Status (v0.9):** **DELIVERED** in Sprint 7 (#203) — reversible **`DEGRADED`** subsystem-health state in `KernelHealthMonitor` (Core-internal; `HealthProbe` untouched, The Wall held) + Community `CommunitySubsystemHealthWatcher` driving it from live subsystem health. A required-`DEGRADED` subsystem drains readiness (`503` + `X-Exeris-Health: DEGRADED`) while liveness holds; reversible to `RUNNING`. `SubsystemHealthTransition` JFR. Degraded-mode (real Postgres stop) + restart-recovery (real engine restart → parked-saga checkpoint survives) Testcontainers ITs, gated by the new **`recovery-continuity-gate`** CI job. **Carried to v0.10:** vN→vN+1 two-version upgrade fixture + outbox exactly-once dedup across restart.
+
 ---
 
 ### Reference Deployment Preparation
@@ -1344,6 +1350,8 @@ the same change (Obligation 9 four-method → five-method; EP step 8 `EX-DIAG-10
 **Resolution:** Prepare a reference deployment path with documented topology, runtime profile, resource envelope, observability setup, and known operational limits.
 
 **Merge Gate:** Reference deployment documentation and validation checklist completed.
+
+**Status (v0.9):** **DELIVERED** in Sprint 8 (#205) — `docs/operations/reference-deployment.md`: single-node Community topology (kernel + Postgres + optional Kafka/JWKS), runtime profile (JDK 26 preview, `kernel.profile=PROD`, OpenSSL 3.0–4.x), reference resource envelope (explicitly *validate per workload*; defers measured throughput to the `exeris-benchmarks` harness), observability (health probes incl. the `DEGRADED` semantics, Prometheus pull, JFR), and the restart/degraded continuity procedure. Cross-linked with `support-matrix.md` + `bootstrap.md`.
 
 ---
 
@@ -1415,6 +1423,8 @@ the same change (Obligation 9 four-method → five-method; EP step 8 `EX-DIAG-10
 
 **Merge Gate:** SPI contract validated against at least two bindings (Jackson 3 as the canonical default + one alternative — Gson, Moshi, or native Panama binary — chosen at sprint scoping based on the first external consumer's request) so the abstract TCK reflects real contract pressure, not single-implementation guesswork. Sprint scheduling gated on either (a) a concrete external consumer requesting non-Jackson binding, or (b) a benchmark demonstrating measurable zero-allocation win for a native binary codec on the request hot path.
 
+**Status (v0.9):** **DEFERRED to v0.10** (covers this + the two sibling HTTP-client entries below — Generic-Element Decode and Retry/Backoff Policy). Per the 2026-05-18 "Path B" decision, Sprint 6 was **design-only**: the codec/retry surface shape is locked by the ADR-034 family, with **zero kernel SPI commits in v0.9**. Implementation lands when a concrete external consumer or a measured zero-alloc win materialises (the merge-gate trigger above).
+
 ---
 
 ### HTTP Client: Generic-Element Decode (`TypeReference`-style facade overload) — deferred from v0.8
@@ -1470,6 +1480,8 @@ the same change (Obligation 9 four-method → five-method; EP step 8 `EX-DIAG-10
 **Resolution:** Bind `OPENSSL_cleanse` from `libcrypto` and expose it via the OpenSSL runtime facade; audit existing call-sites that hold key material (`OffHeapTlsEngine` handshake state, native cipher contexts, JWT signing material) and route their disposal through cleanse before arena release. Promote to a `SensitiveBuffer` SPI marker if additional call-sites accumulate, with `close()` contractually guaranteeing cleanse before underlying arena release.
 
 **Merge Gate:** `OPENSSL_cleanse` binding present and invoked from every identified secret-holding path on disposal; TCK assertion via a probe segment proves zeroed buffer contents after disposal for at least one representative path.
+
+**Status (v0.9):** **DEFERRED / CARRIED** — not implemented in v0.9 (no `OPENSSL_cleanse` binding landed). Carried forward; pairs naturally with the FIPS workstream below.
 
 ---
 
@@ -1637,6 +1649,8 @@ See also: ADR-034 (`KernelWebClient` facade, superseding ADR-026), ADR-032 (`Htt
 **Resolution:** Open a short RFC (single option-comparison page) deciding between (a) **SSE-only for v1.0, WebSocket post-1.0** — minimum scope, zero new SPI, ship an SSE response-writer pattern in Community plus generator emission, or (b) **`WebSocketProvider` SPI lands in v0.12** — full `WebSocketSession`, `WebSocketFrame`, `WebSocketHandler` family in `eu.exeris.kernel.spi.http.websocket`, Community NIO driver, Enterprise `io_uring` driver track. If (b), TCK covers RFC 6455 handshake compliance, frame fragmentation, ping/pong, close-code semantics, masking, and adversarial cases (oversized frame, malformed payload, partial-message split, post-close traffic). Either way, generator emission for the `realTimeApi` flag lands in `exeris-tooling/` in the same window.
 
 **Merge Gate:** RFC accepted with one shape selected and dissenting position recorded; if (b), SPI green on TCK + Community binding green + isolation-key scoping verified (per-tenant WS rooms via `StorageContext.isolationKey`); if (a), SSE pattern documented in operator-facing docs with an explicit "WebSocket = post-1.0" note in the Support Matrix (per v0.9 §"Support Matrix Finalization").
+
+**Status (RFC opened 2026-06-18 — shifted earlier than v0.12):** the RFC is `docs/rfc/RFC-2026-06-18-http-streaming-spi.md`. Preferred direction = a variant of option (a): **SSE-first** over a **sibling `HttpStreamExchange`** (not a streaming mode on `HttpExchange`; respond-once invariant preserved), with WebSocket deferred to a later, separately-justified decision. **ADR-043 reserved.** Implementation **brought earlier to v0.10/v0.11** (not v0.12) to unblock the SDK `realTimeApi` / `@Action(streaming)` chain. The eight load-bearing design questions for ADR-043 (exchange surface + disconnect-as-throw, park-the-VT `emit()`, `LoanedBuffer` transfer ownership, streaming-lifecycle JFR, `EX-HTTP-*` taxonomy, router extension, PAQS accounting, JWT-expiry-mid-stream fail-closed) are enumerated in the RFC.
 
 ---
 

--- a/docs/release/v0.9.0-release-notes.md
+++ b/docs/release/v0.9.0-release-notes.md
@@ -1,0 +1,84 @@
+# Exeris Kernel v0.9.0 — Release Notes
+
+| | |
+|:--|:--|
+| **Version** | 0.9.0 |
+| **Date** | 2026-06-18 |
+| **Predecessor** | 0.8.1 |
+| **Framing** | Pre-1.0 / TRL-3. Minor versions may carry observable contract additions while staying SPI-backwards-compatible. Per-surface semver policy: [`docs/stability-matrix.md`](../stability-matrix.md). |
+
+## 1. Headline
+
+v0.9.0 is a **pre-1.0 hardening + consumability** milestone. It promotes the first explicitly-`stable`
+new SPI surface (Diagnostics, ADR-033), publishes the consumer-facing **stability** and **support**
+matrices and a **reference deployment**, lands **operational continuity** (a reversible `DEGRADED`
+subsystem-health axis + restart/degraded integration gate), hardens security (**JWKS key rotation**)
+and crypto (**OpenSSL 4** multi-version), seals config keys (**`@Immutable`**), and sets two SPI
+**directions by RFC** (IdentityProvider, HTTP streaming). It also closes a sustained **TLS
+reactor-efficiency** investigation. No "breaking change" framing — there are no external SPI consumers
+pre-1.0.
+
+## 2. What landed (by stream)
+
+### 2.1 Diagnostics SPI + CLI — ADR-033 (Sprint 1)
+`eu.exeris.kernel.spi.diagnostics.*` (first explicitly-**stable** surface) + `CommunityKernelDiagnostics` + the `exeris-kernel-diagnostics-cli` artifact + `AbstractKernelDiagnosticsTck` (+ JSON schema fixture). `getJvmErgonomics()` added as the runtime-ergonomics snapshot. Pre-1.0 trim: `listCapabilities()` / `CompositionSnapshot` / `CapabilityDescriptor` dropped from the SPI (composition is a build-time/manifest concern) — `EX-DIAG-1002` retired as a reserved gap.
+
+### 2.2 SPI Stability Declaration (Sprint 2)
+`docs/stability-matrix.md` — per-package maturity (`stable`/`preview`/`experimental`), since-version, anchor ADR, TCK evidence, Enterprise-overlay status, and the canonical semver policy. All subsystem + module docs carry a `## Stability` cross-reference.
+
+### 2.3 Security — JWKS key rotation (Sprint 4)
+Community-only (no SPI this milestone): format-blind `KeyRotationPolicy` (overlap window + stale-fetch budget) + `CommunityRotatingKeySet` (clock-driven overlap/cutover, ADR-012 fail-closed deny on stale refresh), behind a `JwksKeyResolver` seam. `CommunityJwksKeyRotationEvent` JFR; deny reasons → `EX-SEC-2002` (secret-safe).
+
+### 2.4 Cryptography — OpenSSL 4 migration (Sprint 4b)
+`CoreOpenSslLoader` moved to the provider-aware `SSL_CTX_new_ex` (FIPS-ready `libctx`/`propq` seam, NULL for now); `.so.4` SONAME resolution newest-major-first; version gate accepts `3 ≤ major ≤ 4`. **Floor retained at 3.0.0** for FIPS-3.1.2 loadability. `OpenSslLoadEvent` JFR; CI smoke matrix builds OpenSSL 3.5.6 + 4.0.0. ADR-008 §1 descriptively refreshed (no new ADR).
+
+### 2.5 Config — `@Immutable` enforcement (Sprint 5)
+`eu.exeris.kernel.spi.config.Immutable` (seals a `static final` key against hot-reload — the inverse of `@Dynamic`). Compile-time `ImmutableConfigProcessor` (in build-config) rejects `@Immutable`+`@Dynamic` / non-static-final; runtime `DynamicConfigFileWatcher` refuses the reload and emits `ImmutableReloadRefusedEvent` (`EX-CFG-1004`, file+key only). Stability **preview** until the TCK binding lands.
+
+### 2.6 Operational continuity (Sprint 7)
+Reversible **`DEGRADED`** subsystem-health state in `KernelHealthMonitor` (Core-only — `HealthProbe.ProbeSnapshot.status` is an already-open string, so no SPI change; The Wall held). A required `DEGRADED` subsystem drops readiness (`503` + `X-Exeris-Health: DEGRADED`) while liveness stays `200`; optional-`DEGRADED` never sheds readiness; reversible to `RUNNING`. Community `CommunitySubsystemHealthWatcher` drives the axis from live subsystem health. `SubsystemHealthTransition` JFR event. Testcontainers integration tests — degraded-mode (real Postgres stop → `DEGRADED`) and restart-recovery (real engine restart → parked-saga checkpoint survives) — gated by the new **`recovery-continuity-gate`** CI job.
+
+### 2.7 Reference docs (Sprint 8)
+`docs/support-matrix.md` (supported runtime + Community/Enterprise scope + deferred capabilities) and `docs/operations/reference-deployment.md` (single-node topology, runtime profile, resource envelope, observability, continuity), bidirectionally cross-linked.
+
+### 2.8 SPI direction by RFC (Sprints 3 + streaming)
+- **IdentityProvider** — `RFC-2026-06-08` (ACCEPTED): dedicated SPI + `SecurityProvider` dispatcher, OIDC+JWKS first driver, parsed-identity-headers outbound. **ADR-040 reserved**; SPI + implementation land v0.10.
+- **HTTP server-push / streaming** — `RFC-2026-06-18`: SSE-first over a sibling `HttpStreamExchange` (respond-once invariant preserved), WebSocket deferred. **ADR-043 reserved**; brought earlier than the originally-planned v0.12, target v0.10/v0.11.
+
+### 2.9 Transport / TLS reactor efficiency
+- `TransportStream.reset(long errorCode)` SPI — Wall-safe `default` (graceful) with Community abortive (RST) override.
+- A sustained TLS reactor-efficiency arc (transport perf): reactor dispatch off the `SelectionKey` attachment (#195), drop a redundant per-buffer atomic (#196), drain all buffered TLS records per readable event (#197), coalesce a response's frames into one socket write (#199), and the headline fix — **abortively cancel the key in `closeKeyStream`** to stop a closed-engine read-spin (#202), which removed a busy-spin that inflated TLS CPU/req.
+
+## 3. SPI surface delta
+- **Added:** `eu.exeris.kernel.spi.diagnostics.*` (**stable**, ADR-033); `eu.exeris.kernel.spi.config.Immutable` + `ConfigProvider.guardImmutable` (**preview**); `TransportStream.reset(long)` (`default`).
+- **Removed (pre-1.0 trim):** `KernelDiagnostics.listCapabilities()` + `CompositionSnapshot` + `CapabilityDescriptor` (ADR-033 refinement; no external consumers).
+- **No SPI change** for the new `DEGRADED` health state (Core-internal; `HealthProbe` untouched) — a deliberate Wall-preserving choice (a generic subsystem-health SPI record is a v0.10 decision).
+
+## 4. Telemetry / JFR delta
+New events: `SubsystemHealthTransition` (bootstrap), `CommunityJwksKeyRotationEvent`, `OpenSslLoadEvent`, `ImmutableReloadRefusedEvent`, `Http2RapidResetFloodEvent`. All single-phase commit, secret-safe payloads.
+
+## 5. Quality and gate posture
+- New CI gate **`recovery-continuity-gate`** (`@Tag("continuity")` Testcontainers ITs).
+- TCK hardening Phase 1: 28 dormant `@Test` bound + running.
+- HTTP/2 rapid-reset net-budget defense (`GOAWAY(ENHANCE_YOUR_CALM)`).
+
+## 6. Migration / upgrade notes (v0.8.x → v0.9.0)
+- **Additive at the SPI level.** The only removal is `KernelDiagnostics.listCapabilities()` (and `CompositionSnapshot`/`CapabilityDescriptor`) — pre-1.0, no external consumers; composition introspection is build-time/manifest territory.
+- **Health probes:** readiness now distinguishes a post-boot `DEGRADED` required subsystem (`503` + `X-Exeris-Health: DEGRADED`) from `STARTING`/`FAILED`; liveness is unaffected. Wire `initialDelaySeconds: 0` + a `startupProbe` per the bootstrap manifest. See [`docs/subsystems/bootstrap.md`](../subsystems/bootstrap.md).
+- **OpenSSL:** 3.0–4.x supported; 3.x floor retained for FIPS-provider compatibility.
+
+## 7. Release-cut checklist
+- [x] All v0.9 ROADMAP entries annotated `Status (v0.9)`.
+- [x] `CHANGELOG.md` `[0.9.0]` entry pointing here.
+- [x] Stability + support matrices published and cross-linked.
+- [x] Continuity gate green; full TCK/lint green.
+- [ ] Version bumped `0.9.0-SNAPSHOT` → `0.9.0` and tag `v0.9.0` cut on `development/0.9.0` (this release commit).
+
+## 8. Carry-over to v0.10
+- `IdentityProvider` SPI + first driver (`CommunityOidcIdentityProvider`), ADR-040 — consumes the v0.9 JWKS-rotation seam.
+- **HTTP streaming SSE-first** implementation (ADR-043, RFC-2026-06-18) — the SPI primitive (`HttpStreamExchange`), Core SSE framing, Community transport, `AbstractHttpStreamExchangeTck`.
+- HTTP client body-codec / retry implementation (design-only in v0.9).
+- Deferred: off-heap key zeroization, FIPS workstream, `BlobStorageProvider` / `JobScheduler` (v0.11), `CacheProvider` RFC, universe-scope tier RFC.
+
+## 9. Acknowledgements
+Open-core kernel; pre-1.0 university implementation project. Per-PR detail in the git log; the roadmap source of truth is [`docs/ROADMAP.md`](../ROADMAP.md).

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.9.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community-kafka</artifactId>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-diagnostics-cli/pom.xml
+++ b/exeris-kernel-diagnostics-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-diagnostics-cli</artifactId>

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.9.0</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.0</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
**v0.9 Sprint 9 — release cut.** Closes the v0.9 milestone.

- **`docs/release/v0.9.0-release-notes.md`** — full notes by stream (Diagnostics SPI ADR-033; stability + support matrices; reference deployment; JWKS rotation; OpenSSL 4; `@Immutable`; operational-continuity `DEGRADED` + `recovery-continuity-gate`; IdentityProvider + HTTP-streaming RFC direction; the TLS reactor-efficiency arc #195/#196/#197/#199/#202), SPI/JFR deltas, migration notes, carry-over to v0.10.
- **`CHANGELOG.md`** — `[0.9.0]` entry.
- **`docs/ROADMAP.md`** — `Status (v0.9)` swept across the v0.9 entries (Diagnostics SPI, Support Matrix, Continuity, Reference Deployment = DELIVERED; codec/retry cluster + off-heap zeroization = DEFERRED/CARRIED); recorded the streaming RFC outcome (SSE-first → ADR-043, brought to v0.10/v0.11).
- **Version bump** `0.9.0-SNAPSHOT` → `0.9.0` across all 12 reactor modules (`versions:set`); full reactor `validate` green at 0.9.0.

**Post-merge:** tag `v0.9.0` on `development/0.9.0` (per the v0.8.1 precedent), then bump dev to the next `-SNAPSHOT`. The tag is the only remaining irreversible step — held for your go after CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)