### PR TITLE
chore(v0.9): clear PR #207 review nits + CodeQL findings

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityJwksKeyRotationEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityJwksKeyRotationEvent.java
@@ -42,9 +42,6 @@ final class CommunityJwksKeyRotationEvent extends Event {
     @Label("Phase")
     /* default */ String phase;
 
-    @Label("New Kid")
-    /* default */ String newKid;
-
     @Label("Retired Kid")
     /* default */ String retiredKid;
 
@@ -54,7 +51,7 @@ final class CommunityJwksKeyRotationEvent extends Event {
     @Label("Previous Key Count")
     /* default */ int previousKeyCount;
 
-    /* default */ static void emit(String phase, String newKid, String retiredKid,
+    /* default */ static void emit(String phase, String retiredKid,
                                    int currentKeyCount, int previousKeyCount) {
         if (!FlightRecorder.isInitialized()) {
             return;
@@ -62,7 +59,6 @@ final class CommunityJwksKeyRotationEvent extends Event {
         CommunityJwksKeyRotationEvent event = new CommunityJwksKeyRotationEvent();
         if (event.isEnabled()) {
             event.phase = phase;
-            event.newKid = newKid;
             event.retiredKid = retiredKid;
             event.currentKeyCount = currentKeyCount;
             event.previousKeyCount = previousKeyCount;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityRotatingKeySet.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityRotatingKeySet.java
@@ -96,7 +96,7 @@ import java.util.concurrent.atomic.AtomicReference;
             // window has closed. Emitted on every such attempt (an old token in a loop will
             // re-emit), so the phase is named as a deny, not a one-shot transition.
             CommunityJwksKeyRotationEvent.emit(
-                    PHASE_CUTOVER_DENY, null, kid, gens.current().size(), gens.previous().size());
+                    PHASE_CUTOVER_DENY, kid, gens.current().size(), gens.previous().size());
             throw new SecurityAuthenticationException(JWT_TYPE, ERR_ROTATED_OUT);
         }
 
@@ -143,7 +143,7 @@ import java.util.concurrent.atomic.AtomicReference;
             Generations rotated = new Generations(newCurrent, now, gens.current(), now);
             generations.compareAndSet(gens, rotated);
             CommunityJwksKeyRotationEvent.emit(
-                    PHASE_ROTATION, null, null, newCurrent.size(), gens.current().size());
+                    PHASE_ROTATION, null, newCurrent.size(), gens.current().size());
             return generations.get();
         }
     }
@@ -155,7 +155,7 @@ import java.util.concurrent.atomic.AtomicReference;
         if (isStale(gens.currentInstalledAtMillis(), now) && !previousStillOpen) {
             int prevCount = gens.previous() == null ? 0 : gens.previous().size();
             CommunityJwksKeyRotationEvent.emit(
-                    PHASE_STALE_DENY, null, null, gens.current().size(), prevCount);
+                    PHASE_STALE_DENY, null, gens.current().size(), prevCount);
             throw new SecurityAuthenticationException(JWT_TYPE, ERR_STALE);
         }
         return gens;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -72,8 +72,7 @@ public final class NativeTcpCarrier implements TransportEngine {
     // Fairness cap on TLS records drained per readable event (see readIngress / PERF-062 in
     // docs/subsystems/transport.md). Overridable for field tuning, mirroring
     // exeris.transport.queueBackpressureEnabled.
-    private static final int MAX_TLS_RECORDS_PER_READ =
-            Integer.parseInt(System.getProperty("exeris.transport.maxTlsRecordsPerRead", "32"));
+    private static final int MAX_TLS_RECORDS_PER_READ = readMaxTlsRecordsPerRead();
 
     private final TransportConfig config;
     private final MemoryAllocator allocator;
@@ -343,6 +342,27 @@ public final class NativeTcpCarrier implements TransportEngine {
             return MIN_LISTENER_BACKLOG;
         }
         return Math.clamp(maxConnections, MIN_LISTENER_BACKLOG, MAX_LISTENER_BACKLOG);
+    }
+
+    private static int readMaxTlsRecordsPerRead() {
+        String raw = System.getProperty("exeris.transport.maxTlsRecordsPerRead", "32");
+        try {
+            int parsed = Integer.parseInt(raw);
+            // A non-positive cap would silently disable per-readable record draining (the drain loop
+            // never iterates), starving every connection on this carrier — reject it like a malformed
+            // value rather than honouring the foot-gun.
+            if (parsed <= 0) {
+                LOG.log(System.Logger.Level.WARNING,
+                        "exeris.transport.maxTlsRecordsPerRead must be positive (was \"{0}\"); using default 32", raw);
+                return 32;
+            }
+            return parsed;
+        } catch (NumberFormatException _) {
+            // A malformed tuning flag must not fail class init — fall back to the documented default.
+            LOG.log(System.Logger.Level.WARNING,
+                    "Invalid exeris.transport.maxTlsRecordsPerRead=\"{0}\"; using default 32", raw);
+            return 32;
+        }
     }
 
     private void initPaqs() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpStream.java
@@ -139,8 +139,10 @@ final class NativeTcpStream implements TransportStream {
     private final Object tlsLock = new Object();
     private final StreamRuntimeState runtime = new StreamRuntimeState();
     
-    // Phase 1B: Queue depth tracking for telemetry and backpressure
-    private volatile int lastQueueDepth;
+    // Phase 1B: Queue depth tracking for telemetry and backpressure. Read/written only on the
+    // reactor thread (offerIngress) and feeds an advisory JFR "trend" label only — not shared, so
+    // no volatile fence is warranted on this per-record hot path.
+    private int lastQueueDepth;
 
     private LoanedBuffer currentInbound;
     private int currentInboundOffset;

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityJwksKeyRotationJfrTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityJwksKeyRotationJfrTest.java
@@ -94,7 +94,7 @@ class CommunityJwksKeyRotationJfrTest {
         // Secret-safe: the declared surface is only opaque labels and counts — no key material.
         assertThat(events.getFirst().getEventType().getFields())
                 .extracting(jdk.jfr.ValueDescriptor::getName)
-                .contains("phase", "newKid", "retiredKid", "currentKeyCount", "previousKeyCount");
+                .contains("phase", "retiredKid", "currentKeyCount", "previousKeyCount");
     }
 
     /** Source that can be armed to return a new key set or to fail the next refresh. */

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -210,6 +210,8 @@ public interface TransportStream extends AutoCloseable {
      * @param errorCode caller-supplied protocol error code (advisory; transport-mapped)
      */
     default void reset(long errorCode) {
+        // The default has no abort primitive and discards the advisory code; overrides map it.
+        long _ = errorCode;
         close();
     }
 }


### PR DESCRIPTION
## Clear PR #207 review nits + CodeQL findings

Low-severity, behavior-neutral follow-ups from the v0.9.0 milestone review (#207). Targets `development/0.9.0` so it rides into `main` via #207 before the `v0.9.0` tag.

### CodeQL / code-quality bot
- **`NativeTcpCarrier` — uncaught `NumberFormatException` in static init.** `MAX_TLS_RECORDS_PER_READ` parsed `-Dexeris.transport.maxTlsRecordsPerRead` directly in the field initializer; a malformed flag would fail class load. Extracted `readMaxTlsRecordsPerRead()` with a fallback to the documented default (`32`) + a `WARNING` log. (Helper placed with the other `private static` helpers to keep PMD `FieldDeclarationsShouldBeAtStartOfClass` happy.)
- **`TransportStream.reset(long)` — "useless parameter".** The default impl deliberately discards the advisory `errorCode` and delegates to `close()`. Acknowledged via the unnamed-variable idiom (`long _ = errorCode;`) — keeps the SPI contract parameter, signals intent, no broad suppression.

### Main review nits
- **`NativeTcpStream.lastQueueDepth` — needless `volatile`.** Read/written only on the reactor thread (`offerIngress`) and feeds an advisory JFR "trend" label; dropped to a plain `int` (No Waste Compute — removes a per-record fence). Comment documents the single-thread invariant.
- **`CommunityJwksKeyRotationEvent.newKid` — permanently-null JFR column.** `null` at all three call sites: JWKS rotation adopts a key *set*, not a single new kid, and `currentKeyCount`/`previousKeyCount` already carry the set sizes. Removed the field, updated the 3 `emit` sites and the JFR field-surface assertion. `retiredKid` (populated on `CUTOVER_DENY`) is kept. The event is new in v0.9 and not yet released, so removing the dead column now avoids ever shipping it.

### Informational
- **ADR-039 ArchUnit obligation — already present.** `ExerisArchitectureTest.diagnosticsSpiIsEventFree` bans `eu.exeris.kernel.spi.diagnostics..` from depending on `jdk.jfr..` / `eu.exeris.telemetry.spec..`, citing ADR-033 Obligation 10 / ADR-039. No `@ArchIgnore`; the suite is active (10/10 green). The v0.8 "ArchTest ignored" finding was resolved during v0.9.

### Verification
`CommunityJwksKeyRotationJfrTest`, `NativeTcpCloseKeyStreamReadInterestTest`, `ExerisArchitectureTest` (10/10) green; `pmd:check` + `checkstyle:check` → 0 violations on `spi` + `community`.

🤖 Generated with Claude Code
