### PR TITLE
docs(changelog): add 0.9.0 Fixed entry for the saga recovery stale-write fence (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Minor release. SPI-backwards-compatible apart from one pre-1.0 diagnostics trim 
 - **Diagnostics SPI trimmed** (pre-1.0): `listCapabilities()` / `CompositionSnapshot` / `CapabilityDescriptor` removed.
 - TLS reactor efficiency: closed-engine read-spin fix (#202), egress frame coalescing (#199), ingress loop-drain (#197), reactor dispatch + atomic cleanup (#195/#196).
 
+### Fixed
+- **Saga recovery stale-write fence** (#208) — a worker abandoned past `close()` on a closed `CoreFlowRuntime` could re-persist a `PARKED` checkpoint after a rebuilt runtime had already reclaimed the row on `complete()`, resurrecting it (surfaced as a load-sensitive flake on 2-vCPU CI). `persistSnapshot` now fences non-terminal writes from a non-active runtime (`!isActiveLifecycle && !isTerminal`); terminal finalizations are exempt.
+
 ### Direction (RFC — implementation in later versions)
 - **IdentityProvider SPI** — `RFC-2026-06-08` (ACCEPTED); ADR-040 reserved; SPI + driver in v0.10.
 - **HTTP streaming (SSE-first)** — `RFC-2026-06-18`; ADR-043 reserved; brought earlier than the planned v0.12 (target v0.10/v0.11).


### PR DESCRIPTION
Satisfies the **PR #207 conditional-approval** doc note. #208 (saga recovery stale-write fence) landed after the release cut (#206) and is a real Core behavior change (`persistSnapshot` generation write-fence), so it warrants a one-line `### Fixed` entry under `[0.9.0]`.

This was meant to ride PR #209, but #209 merged before the changelog commit landed — so this is a standalone follow-up onto `development/0.9.0`, which flows into #207 on merge. The #209 nits carry no behavior change and are omitted from the changelog by intent.

Doc-only; no code change.

🤖 Generated with Claude Code