### PR TITLE
fix(spi): drop the CodeQL read-and-discard silencer in TransportStream.reset default

### DIFF
--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -210,8 +210,11 @@ public interface TransportStream extends AutoCloseable {
      * @param errorCode caller-supplied protocol error code (advisory; transport-mapped)
      */
     default void reset(long errorCode) {
-        // The default has no abort primitive and discards the advisory code; overrides map it.
-        long _ = errorCode;
+        // errorCode is contract for overriders (e.g. a TCP driver maps it to a protocol RST via
+        // SO_LINGER 0); the default has no abort primitive and intentionally discards it. CodeQL
+        // "useless parameter" here is a false positive — DISMISS it. Do NOT add a read-and-discard
+        // line to silence it: that only trades the finding for an "unread local variable" on the
+        // discard (the #209 -> follow-up tail-chase). The @param Javadoc documents the discard.
         close();
     }
 }


### PR DESCRIPTION
Breaks a CodeQL tail-chase introduced in #209.

**The loop:**
- bare `close()` → CodeQL "useless parameter" (`errorCode` unused)
- `long _ = errorCode;` (added in #209) → CodeQL "unread local variable" on the discard

Every code state trips one Note-level false positive. `errorCode` is genuine SPI contract for overriders (`NativeTcpStream.reset` maps it to a protocol RST via SO_LINGER 0); the default method has no abort primitive and intentionally discards it, delegating to `close()`.

**Resolution:** clean default body (no ceremony) + **dismiss** the "useless parameter" alert as a known false positive on an interface default method whose param exists for overriders. The comment now explicitly forbids re-adding a read-and-discard line, so the loop cannot reopen.

> Action for the maintainer: dismiss the CodeQL `java/useless-parameter` alert on `TransportStream.reset` as a false positive (interface default-method contract param). Do not re-silence in code.

SPI-only, no behavior change, no boundary impact. `pmd:check` + `checkstyle:check` on `exeris-kernel-spi` clean.

🤖 Generated with Claude Code