### PR TITLE
feat(http): HttpRetryPolicy SPI + KernelWebClient retry loop + Community default (v0.10 S4, ADR-045)

### DIFF
--- a/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
+++ b/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
@@ -1,7 +1,7 @@
 # ADR-045: `HttpRetryPolicy` SPI — Opt-in Client-Side Retry for `KernelWebClient`
 
-**Status:** Reserved
-**Date:** 2026-06-25
+**Status:** Accepted
+**Date:** 2026-06-25 (implemented in v0.10 Sprint 4, PR #220)
 **Owner:** kernel/transport
 **Visibility:** public
 **Scope:** kernel/transport (per-repo; lockstep cross-repo coordination with `exeris-tooling`, `budgetHQ`)
@@ -80,6 +80,9 @@ public interface HttpRetryPolicy {
  * <p>Valhalla-ready value carrier: immutable record, no identity-sensitive operations.
  */
 public record HttpAttemptOutcome(int statusCode, List<HttpHeader> responseHeaders, Throwable failure) {
+
+    // canonical constructor enforces the two-state invariant: exactly one of
+    // statusCode (> 0) or failure is present (closes the factory-bypass gap).
 
     /** A completed exchange that returned an HTTP status + headers. */
     public static HttpAttemptOutcome ofStatus(int statusCode, List<HttpHeader> responseHeaders) { /* statusCode > 0 */ }

--- a/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
+++ b/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
@@ -73,23 +73,27 @@ public interface HttpRetryPolicy {
 
 ```java
 /**
- * The result of a single send attempt: either a received HTTP status, or a transport-level
- * failure with no status. Carries no body — body ownership stays inside KernelWebClient.
+ * The result of a single send attempt: either a received HTTP status (with its response
+ * headers), or a transport-level failure with no status. Carries the headers so a policy can
+ * honour Retry-After on a 503 — but NO body: body ownership stays inside KernelWebClient.
  *
  * <p>Valhalla-ready value carrier: immutable record, no identity-sensitive operations.
  */
-public record HttpAttemptOutcome(int statusCode, Throwable failure) {
+public record HttpAttemptOutcome(int statusCode, List<HttpHeader> responseHeaders, Throwable failure) {
 
-    /** A completed exchange that returned an HTTP status. */
-    public static HttpAttemptOutcome ofStatus(int statusCode) { /* statusCode > 0 */ }
+    /** A completed exchange that returned an HTTP status + headers. */
+    public static HttpAttemptOutcome ofStatus(int statusCode, List<HttpHeader> responseHeaders) { /* statusCode > 0 */ }
 
-    /** A transport-level failure with no HTTP response (statusCode == 0). */
+    /** A transport-level failure with no HTTP response (statusCode == 0, empty headers). */
     public static HttpAttemptOutcome ofFailure(Throwable failure) { /* failure != null */ }
 
     public boolean hasResponse() { return failure == null; }
     public boolean isTransportFailure() { return failure != null; }
 }
 ```
+
+The carrier exposes response *headers* (already an SPI type) but never the response *body* — so a
+policy can read `Retry-After` without any `LoanedBuffer` ownership crossing the seam.
 
 ```java
 /**

--- a/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
+++ b/docs/adr/ADR-045-client-side-http-retry-policy-spi.md
@@ -1,0 +1,272 @@
+# ADR-045: `HttpRetryPolicy` SPI — Opt-in Client-Side Retry for `KernelWebClient`
+
+**Status:** Reserved
+**Date:** 2026-06-25
+**Owner:** kernel/transport
+**Visibility:** public
+**Scope:** kernel/transport (per-repo; lockstep cross-repo coordination with `exeris-tooling`, `budgetHQ`)
+**Authors:** Arkadiusz Przychocki
+**Resolves the retry deferral named in:** ADR-026 (§"no implicit retry"), ADR-032 (Alternative D)
+
+## Context
+
+The client-side HTTP surface is now codec-complete. `KernelWebClient` (ADR-034) ships
+the tier-blind typed facade (`get` / `post` / `patch` / `delete` → `HttpRequestBodyEncoder`
+/ `HttpResponseBodyDecoder` registries), and `HttpClientRequestEnricher` (ADR-032) handles
+opt-in outbound context propagation. One behaviour was **deliberately deferred** twice and
+is now blocking three consumers:
+
+- **ADR-026** (`KernelWebClient` facade): *"The web client deliberately performs no implicit
+  retry. Retry policy is the caller's concern; failures map to `WebClientException` exactly
+  once."* — a defer, not a decision against retry.
+- **ADR-032** (enricher), Alternative D rejected a two-arg `enrich(HttpRequest, HttpClientEngine)`
+  contract precisely because *"an enricher with engine access could become a request-level
+  retry / circuit-breaker, which ADR-026 explicitly defers."*
+
+The defer has now materialised into a concrete need. Three downstream consumers all require
+a retry seam and would otherwise each invent their own, incompatibly:
+
+1. **`exeris-tooling/KernelClientGenerator`** emits per-entity clients (`WidgetClient.findById`,
+   `WidgetClient.create`) over `KernelWebClient`. A transient 503 from a sibling service today
+   surfaces as a `WebClientException` on the first attempt; the generated client has nowhere to
+   express "retry idempotent reads on 503/504 with backoff" without hand-edited code, which the
+   generator round-trips away.
+2. **The data-migration tool** issues large batches of idempotent writes (`PUT`) against a
+   freshly-booted target that may still be admission-shedding (ADR-010 `SHED_LOAD` → 503). Without
+   retry, a single transient shed aborts a migration mid-batch.
+3. **BudgetHQ** (first real consumer) makes service-to-service calls where a transient transport
+   failure (connection reset during a rolling deploy) should not propagate as an application error.
+
+Today every caller would catch `WebClientException`, branch on `status()`, sleep, and re-issue —
+the exact per-call-site boilerplate the codec/enricher SPIs were introduced to eliminate. The
+retry decision is also **not** an enrichment concern (it owns the send loop and must re-materialise
+the request body per attempt), so it cannot live behind `HttpClientRequestEnricher`.
+
+## Decision
+
+Introduce a small implementation-blind retry SPI in `eu.exeris.kernel.spi.http`, consumed by
+`KernelWebClient` through one new opt-in constructor parameter — the same composition shape ADR-032
+established for the enricher.
+
+### SPI surface (`eu.exeris.kernel.spi.http`)
+
+```java
+@FunctionalInterface
+public interface HttpRetryPolicy {
+
+    /**
+     * Decides whether the attempt that produced {@code outcome} should be retried.
+     *
+     * @param request      the request as sent (for method / idempotency-key inspection);
+     *                     the policy MUST NOT read, retain, or close {@link HttpRequest#body()}
+     * @param outcome      the response status OR the transport failure of this attempt
+     * @param attemptIndex zero-based index of the attempt that just completed (0 = first try)
+     * @return {@link RetryDecision#retryAfter(long)} to retry after a delay, or
+     *         {@link RetryDecision#giveUp()} to surface the outcome to the caller
+     */
+    RetryDecision decide(HttpRequest request, HttpAttemptOutcome outcome, int attemptIndex);
+
+    /** A policy that never retries — preserves ADR-026's "no implicit retry" default. */
+    static HttpRetryPolicy none();
+}
+```
+
+```java
+/**
+ * The result of a single send attempt: either a received HTTP status, or a transport-level
+ * failure with no status. Carries no body — body ownership stays inside KernelWebClient.
+ *
+ * <p>Valhalla-ready value carrier: immutable record, no identity-sensitive operations.
+ */
+public record HttpAttemptOutcome(int statusCode, Throwable failure) {
+
+    /** A completed exchange that returned an HTTP status. */
+    public static HttpAttemptOutcome ofStatus(int statusCode) { /* statusCode > 0 */ }
+
+    /** A transport-level failure with no HTTP response (statusCode == 0). */
+    public static HttpAttemptOutcome ofFailure(Throwable failure) { /* failure != null */ }
+
+    public boolean hasResponse() { return failure == null; }
+    public boolean isTransportFailure() { return failure != null; }
+}
+```
+
+```java
+/**
+ * A retry verdict: retry after {@code delayMillis} (≥ 0), or give up. Immutable value carrier.
+ */
+public record RetryDecision(boolean retry, long delayMillis) {
+
+    private static final RetryDecision GIVE_UP = new RetryDecision(false, 0L);
+
+    public RetryDecision {
+        if (retry && delayMillis < 0L) {
+            throw new IllegalArgumentException("retry delayMillis must be >= 0");
+        }
+    }
+
+    public static RetryDecision retryAfter(long delayMillis) { return new RetryDecision(true, delayMillis); }
+    public static RetryDecision giveUp() { return GIVE_UP; }
+}
+```
+
+### Consumption (`KernelWebClient`, `exeris-kernel-core`)
+
+`KernelWebClient` gains a constructor parameter `HttpRetryPolicy retryPolicy`; the existing
+constructors delegate with `HttpRetryPolicy.none()`, preserving the ADR-026 surface for callers
+that do not opt in (symmetric with how the 4-arg constructor delegates the enricher to `noop()`).
+
+The retry loop wraps the **existing** send seam in `execute`. Per attempt it re-runs
+`buildRequest` → `enricher.enrich` → `engine.send`, classifies the result into an
+`HttpAttemptOutcome`, and consults the policy:
+
+```
+attempt = 0
+loop:
+    request  = enrich(buildRequest(method, path, body))   // body re-encoded each attempt
+    try:
+        response = engine.send(request)
+        if 2xx: return decode(response)                   // success path unchanged
+        outcome = HttpAttemptOutcome.ofStatus(status)
+    catch (transport Throwable t):
+        outcome = HttpAttemptOutcome.ofFailure(t)
+    decision = retryPolicy.decide(request, outcome, attempt)
+    if !decision.retry(): break → throw WebClientException(outcome) // same exception as today
+    sleep(decision.delayMillis())                          // on the caller's virtual thread
+    attempt++
+```
+
+#### Body re-buffering
+
+Each attempt **re-encodes the typed body** from the original domain object via the encoder
+registry (`buildRequest` already does this). No `LoanedBuffer` is retained or cloned across
+attempts: the loan from attempt *N* is owned and released by `engine.send` exactly as today,
+and attempt *N+1* allocates a fresh loan. This sidesteps cross-attempt buffer-ownership entirely —
+the retry seam never holds a buffer between iterations.
+
+### Behavioural defaults live in the Community impl, not the SPI
+
+The SPI fixes only the **contract surface** (the part `exeris-tooling` emits against and that must
+stay stable). Concrete behaviour — which statuses retry, attempt cap, backoff curve, jitter,
+idempotency gate, `SHED_LOAD` handling — ships as a Community implementation
+`CommunityHttpRetryPolicy` in `exeris-kernel-community` and can be tuned during consumer alignment
+(see Implementation plan §4) **without re-opening this ADR**. The default policy:
+
+- **Idempotency gate.** Retries only requests whose method is idempotent per RFC 9110
+  (GET / PUT / DELETE / HEAD / OPTIONS — the enum already documents this), **or** any request
+  carrying an `Idempotency-Key` header (caller's explicit opt-in for `POST` / `PATCH`). Non-idempotent
+  requests without the header → `giveUp()` immediately.
+- **Retryable conditions.** Transport failures (`isTransportFailure()`), and statuses
+  `502` / `503` / `504`. `503` is the kernel's admission-shed status (ADR-010 `SHED_LOAD`).
+- **`SHED_LOAD` interaction.** On `503`, honour a `Retry-After` header when present; otherwise apply
+  capped exponential backoff with full jitter. Attempt cap is low by default (3 total) precisely so a
+  fleet of clients retrying into a shedding server does **not** amplify the overload into a retry storm.
+  The client-side circuit-breaker (open/half-open transitions across calls) is a Community-impl concern,
+  **not** SPI surface — it needs cross-call state the per-attempt `decide` contract intentionally does
+  not carry.
+- **Backoff + jitter.** Exponential base with full jitter (`delay = random(0, base · 2^attempt)`),
+  capped, to decorrelate retries across clients.
+- **Give-up.** After the attempt cap, or on any non-retryable status (`4xx`, `5xx` outside the set
+  above), or on a non-idempotent request without an idempotency key.
+
+### TCK
+
+`AbstractHttpRetryPolicyTck` (in `exeris-kernel-tck`) pins the observable contract:
+
+- `none()` returns `giveUp()` for every input (zero retries; ADR-026 default preserved).
+- Retry decision matrix against the Community impl: `503` on a `GET` → retry; `503` on a `POST`
+  without `Idempotency-Key` → give up; `503` on a `POST` **with** `Idempotency-Key` → retry;
+  transport failure on a `GET` → retry; `404` → give up; give-up after the attempt cap.
+- `SHED_LOAD` shape: `503` + `Retry-After: 2` yields `retryAfter(≈2000)` (Retry-After honoured),
+  and the attempt cap bounds total tries (no unbounded retry under sustained shed).
+- `RetryDecision` invariant: `retryAfter(negative)` throws; `giveUp()` is a stable singleton.
+
+## Consequences
+
+### Positive
+
+- **Generated-client + migration-tool retry unblocked** without per-call-site boilerplate or
+  per-entity codegen: the generator/composition root passes one `CommunityHttpRetryPolicy` and every
+  emitted client inherits retry semantics.
+- **Codec/enricher/retry now share one composition shape** (opt-in constructor param, `none()`/`noop()`
+  default) — consistent, no DI container, no registry magic.
+- **No body-ownership hazard.** Re-encode-per-attempt means the retry seam never holds a `LoanedBuffer`
+  across iterations; the zero-leak invariant of the codec path is untouched.
+- **SPI stays minimal and consumer-stable.** Behavioural tuning lives in the Community impl, so
+  consumer alignment can adjust defaults without ADR churn or a generator change.
+- **Retry-storm-aware by construction.** The `503`/`SHED_LOAD` default is capped + jittered +
+  `Retry-After`-honouring, so the client tier cannot amplify a server-side admission shed (ADR-010).
+
+### Negative / costs
+
+- One additional SPI surface (one interface + two value records + one Abstract TCK) and one Community impl.
+- Opt-in asymmetry persists: a caller wanting retry must remember to pass the policy. Mitigation:
+  document it in the `http.client` `package-info` and wire it in the generator composition root example.
+- Re-encoding the body per attempt costs one extra encode + one extra `LoanedBuffer` allocation per
+  retry. Acceptable: retries are the exception, not the hot path, and the alternative (retaining a buffer
+  across attempts) reintroduces the ownership hazard this design avoids.
+
+### Neutral / open
+
+- **Cross-call circuit-breaker** (open/half-open across many calls) is **not** SPI surface in this ADR.
+  The per-attempt `decide` contract is stateless by design; a stateful breaker is a Community-impl detail
+  and, if it ever needs to be swappable, earns its own decision.
+- **Per-attempt JFR event** (`HttpClientRetryEvent`: method, attempt index, status/failure, delay) is
+  recommended for observability but is an implementation detail of `KernelWebClient`, not SPI — single-phase
+  commit only (`[[project_jfr_event_virtual_thread_straddle]]`: never straddle a blocking op on a VT).
+
+## Alternatives considered
+
+### A) Retry inside `HttpClientRequestEnricher` (two-arg `enrich(request, engine)`)
+
+The shape ADR-032 Alternative D already rejected. Still rejected: enrichment is request *decoration*;
+retry owns the *send loop* and the body re-materialisation. Conflating them gives the enricher engine
+access (a transport concern) and breaks the "enricher never touches the body / never sends" contract.
+
+### B) Retry as an `HttpClientEngine` decorator (transport-level)
+
+Wrap the engine so `send` retries internally. Rejected:
+- The engine sees an already-encoded `HttpRequest` with a consumed `LoanedBuffer` — it cannot
+  re-materialise the body for attempt *N+1* without retaining/cloning the buffer (the ownership hazard).
+- Retry policy needs the *typed* request intent (idempotency of the method, `Idempotency-Key`), which the
+  engine layer has by header inspection only and which belongs with the typed facade.
+- Pushes a cross-cutting policy below the SPI seam where tooling cannot compose it per application.
+
+### C) Bake default retry behaviour into the SPI (e.g. `HttpRetryPolicy.defaultPolicy()`)
+
+Ship the 503/idempotency/backoff defaults as an SPI static. Rejected:
+- Behavioural defaults are exactly what consumer alignment (tooling/migration/BHQ) will tune; freezing
+  them in SPI forces an ADR + cross-repo lockstep change for every tuning. Keeping them in the Community
+  impl lets the surface stay stable while behaviour evolves pre-1.0.
+- An SPI static default would also smuggle a `503`/`Retry-After` opinion into the implementation-blind
+  contract, which The Wall keeps free of wire-status policy.
+
+### D) `RetryDecision` as a sealed interface (`Retry(delay)` / `GiveUp`)
+
+Marginally more type-safe than the two-field record. Rejected for now: the record is Valhalla-ready
+(scalarizable value carrier, no identity ops) and matches the project's "primitive-friendly carrier"
+preference; a sealed hierarchy adds two types and an allocation per decision for no contract gain. The
+record's `retry(boolean)` + `delayMillis(long)` is the smaller surface.
+
+## Implementation plan
+
+### v0.10 Sprint 4 (HTTP Client codec/retry — see `docs/local-only/v0.10-sprint-and-implementation-map.md`)
+
+1. **SPI:** `HttpRetryPolicy` + `HttpAttemptOutcome` + `RetryDecision` in `eu.exeris.kernel.spi.http`;
+   `HttpRetryPolicy.none()`. Zero preview types in signatures (GA-baseline clean).
+2. **Core:** `KernelWebClient` opt-in constructor param + retry loop wrapping the existing `execute`
+   send seam; re-encode-per-attempt body; same `WebClientException` on final give-up. Optional
+   single-phase `HttpClientRetryEvent` JFR.
+3. **Community:** `CommunityHttpRetryPolicy` (idempotency gate, `502/503/504` + transport, `Retry-After`
+   honouring, capped exponential backoff + full jitter).
+4. **TCK + consumer alignment:** `AbstractHttpRetryPolicyTck` decision matrix; confirm the surface with
+   `exeris-tooling` (generator composition root) + the migration tool + `budgetHQ` **before lock**, so the
+   stable SPI part needs no post-landing re-work. Behavioural defaults may be tuned in step 3 from that
+   alignment without touching this ADR.
+
+### Cross-repo
+
+- `exeris-tooling` — `KernelClientGenerator` composition-root example wires `CommunityHttpRetryPolicy`
+  (no per-entity codegen change; the policy is constructor-injected like the enricher). `.link.md` stub.
+- `exeris-kernel-enterprise` — `.link.md` stub (consumes the SPI; no enterprise-specific retry surface
+  introduced here).

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicy.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicy.java
@@ -45,6 +45,10 @@ import java.util.function.DoubleSupplier;
  *
  * @since 0.10.0
  */
+// PMD.CyclomaticComplexity: a retry policy is a decision machine — idempotency gate, retryable-status
+// set, backoff ceiling, and Retry-After parsing each add a small branch. No single method exceeds the
+// per-method limit (highest is 9); the class total is the sum of cohesive one-purpose helpers.
+@SuppressWarnings("PMD.CyclomaticComplexity")
 public final class CommunityHttpRetryPolicy implements HttpRetryPolicy {
 
     private static final int DEFAULT_MAX_ATTEMPTS = 3;
@@ -138,8 +142,21 @@ public final class CommunityHttpRetryPolicy implements HttpRetryPolicy {
                 return retryAfter;
             }
         }
-        long ceiling = Math.min(maxDelayMillis, baseDelayMillis << Math.min(attemptIndex, Long.SIZE - 2));
-        return (long) (jitter.getAsDouble() * ceiling);
+        return (long) (jitter.getAsDouble() * backoffCeiling(attemptIndex));
+    }
+
+    /**
+     * Exponential backoff ceiling {@code min(maxDelay, base · 2^attemptIndex)}, computed with a clamped
+     * exponent so the left-shift can never overflow into a negative value for large attempt indices or
+     * custom caps (the shift stays within the positive range of {@code base}).
+     */
+    private long backoffCeiling(int attemptIndex) {
+        if (baseDelayMillis == ZERO_MILLIS) {
+            return ZERO_MILLIS;
+        }
+        int maxExponent = Long.numberOfLeadingZeros(baseDelayMillis) - 1;
+        int exponent = Math.min(attemptIndex, maxExponent);
+        return Math.min(maxDelayMillis, baseDelayMillis << exponent);
     }
 
     /**

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicy.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicy.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpAttemptOutcome;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpRetryPolicy;
+import eu.exeris.kernel.spi.http.RetryDecision;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Community default {@link HttpRetryPolicy} (ADR-045). Retries idempotent requests on transient
+ * conditions with capped exponential backoff and full jitter, and honours {@code Retry-After} on a
+ * {@code 503} (ADR-010 {@code SHED_LOAD}) so a client fleet cannot amplify a server-side admission
+ * shed into a retry storm.
+ *
+ * <p>Decision order — give up unless all hold:
+ * <ol>
+ *   <li>another attempt remains under the cap ({@code attemptIndex + 1 < maxAttempts});</li>
+ *   <li>the request is retry-eligible: an idempotent method (RFC 9110 — {@code GET}/{@code HEAD}/
+ *       {@code PUT}/{@code DELETE}/{@code OPTIONS}/{@code TRACE}) <em>or</em> any request carrying an
+ *       {@code Idempotency-Key} header (caller's explicit opt-in for {@code POST}/{@code PATCH});</li>
+ *   <li>the outcome is retryable: a transport failure, or status {@code 502}/{@code 503}/{@code 504}.</li>
+ * </ol>
+ *
+ * <p>Delay: a {@code Retry-After} delta-seconds header on a {@code 503} is honoured verbatim;
+ * otherwise {@code random(0, min(maxDelay, base · 2^attemptIndex))} (full jitter, decorrelated
+ * across clients).
+ *
+ * <p>Stateless and thread-safe. Cross-call circuit-breaking is intentionally out of scope (the
+ * per-attempt contract carries no cross-call state) — see ADR-045.
+ *
+ * @since 0.10.0
+ */
+public final class CommunityHttpRetryPolicy implements HttpRetryPolicy {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final long DEFAULT_BASE_DELAY_MILLIS = 100L;
+    private static final long DEFAULT_MAX_DELAY_MILLIS = 2_000L;
+    private static final long MILLIS_PER_SECOND = 1_000L;
+    private static final int MIN_ATTEMPTS = 1;
+    private static final long ZERO_MILLIS = 0L;
+    private static final long NO_RETRY_AFTER = -1L;
+
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+    private static final String RETRY_AFTER = "Retry-After";
+    private static final int STATUS_BAD_GATEWAY = 502;
+    private static final int STATUS_SERVICE_UNAVAILABLE = 503;
+    private static final int STATUS_GATEWAY_TIMEOUT = 504;
+    private static final Set<Integer> RETRYABLE_STATUS =
+            Set.of(STATUS_BAD_GATEWAY, STATUS_SERVICE_UNAVAILABLE, STATUS_GATEWAY_TIMEOUT);
+    private static final Set<HttpMethod> IDEMPOTENT_METHODS = EnumSet.of(
+            HttpMethod.GET, HttpMethod.HEAD, HttpMethod.PUT,
+            HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
+
+    private final int maxAttempts;
+    private final long baseDelayMillis;
+    private final long maxDelayMillis;
+    private final DoubleSupplier jitter;
+
+    /**
+     * Creates a policy with the default tuning: 3 total attempts, 100&nbsp;ms base, 2000&nbsp;ms cap,
+     * full jitter from {@link ThreadLocalRandom}.
+     */
+    public CommunityHttpRetryPolicy() {
+        this(DEFAULT_MAX_ATTEMPTS, DEFAULT_BASE_DELAY_MILLIS, DEFAULT_MAX_DELAY_MILLIS,
+                () -> ThreadLocalRandom.current().nextDouble());
+    }
+
+    /**
+     * Creates a policy with explicit tuning. The {@code jitter} supplier returns a value in
+     * {@code [0, 1)} and is injectable for deterministic testing.
+     *
+     * @param maxAttempts     total attempts including the first; MUST be {@code >= 1}
+     * @param baseDelayMillis exponential-backoff base in milliseconds; MUST be {@code >= 0}
+     * @param maxDelayMillis  backoff cap in milliseconds; MUST be {@code >= baseDelayMillis}
+     * @param jitter          supplier of a jitter fraction in {@code [0, 1)}; never {@code null}
+     */
+    public CommunityHttpRetryPolicy(int maxAttempts, long baseDelayMillis, long maxDelayMillis, DoubleSupplier jitter) {
+        if (maxAttempts < MIN_ATTEMPTS) {
+            throw new IllegalArgumentException("maxAttempts must be >= 1, was " + maxAttempts);
+        }
+        if (baseDelayMillis < ZERO_MILLIS) {
+            throw new IllegalArgumentException("baseDelayMillis must be >= 0, was " + baseDelayMillis);
+        }
+        if (maxDelayMillis < baseDelayMillis) {
+            throw new IllegalArgumentException("maxDelayMillis must be >= baseDelayMillis");
+        }
+        this.maxAttempts = maxAttempts;
+        this.baseDelayMillis = baseDelayMillis;
+        this.maxDelayMillis = maxDelayMillis;
+        if (jitter == null) {
+            throw new IllegalArgumentException("jitter must not be null");
+        }
+        this.jitter = jitter;
+    }
+
+    @Override
+    public RetryDecision decide(HttpRequest request, HttpAttemptOutcome outcome, int attemptIndex) {
+        if (attemptIndex + 1 >= maxAttempts) {
+            return RetryDecision.giveUp();
+        }
+        if (!isRetryEligible(request)) {
+            return RetryDecision.giveUp();
+        }
+        if (!isRetryable(outcome)) {
+            return RetryDecision.giveUp();
+        }
+        return RetryDecision.retryAfter(delayMillis(outcome, attemptIndex));
+    }
+
+    private static boolean isRetryEligible(HttpRequest request) {
+        return IDEMPOTENT_METHODS.contains(request.method())
+                || hasHeader(request.headers(), IDEMPOTENCY_KEY);
+    }
+
+    private static boolean isRetryable(HttpAttemptOutcome outcome) {
+        return outcome.isTransportFailure() || RETRYABLE_STATUS.contains(outcome.statusCode());
+    }
+
+    private long delayMillis(HttpAttemptOutcome outcome, int attemptIndex) {
+        if (outcome.hasResponse() && outcome.statusCode() == STATUS_SERVICE_UNAVAILABLE) {
+            long retryAfter = retryAfterMillis(outcome.responseHeaders());
+            if (retryAfter != NO_RETRY_AFTER) {
+                return retryAfter;
+            }
+        }
+        long ceiling = Math.min(maxDelayMillis, baseDelayMillis << Math.min(attemptIndex, Long.SIZE - 2));
+        return (long) (jitter.getAsDouble() * ceiling);
+    }
+
+    /**
+     * Parses a {@code Retry-After} delta-seconds header to milliseconds, or {@code -1} when absent or
+     * not a non-negative integer (HTTP-date form is not honoured here; backoff applies instead).
+     */
+    private static long retryAfterMillis(List<HttpHeader> headers) {
+        for (HttpHeader header : headers) {
+            if (header.nameEqualsIgnoreCase(RETRY_AFTER)) {
+                try {
+                    long seconds = Long.parseLong(header.value().trim());
+                    return seconds < ZERO_MILLIS ? NO_RETRY_AFTER : seconds * MILLIS_PER_SECOND;
+                } catch (NumberFormatException ignored) {
+                    return NO_RETRY_AFTER;
+                }
+            }
+        }
+        return NO_RETRY_AFTER;
+    }
+
+    private static boolean hasHeader(List<HttpHeader> headers, String name) {
+        for (HttpHeader header : headers) {
+            if (header.nameEqualsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicyTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRetryPolicyTckTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpRetryPolicy;
+import eu.exeris.kernel.tck.contract.http.AbstractHttpRetryPolicyTck;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("Community: HttpRetryPolicy TCK (ADR-045 default policy)")
+class CommunityHttpRetryPolicyTckTest extends AbstractHttpRetryPolicyTck {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    @Override
+    protected HttpRetryPolicy createPolicy() {
+        // Deterministic jitter (0.5) so backoff delays are reproducible under the TCK.
+        return new CommunityHttpRetryPolicy(MAX_ATTEMPTS, 100L, 2_000L, () -> 0.5);
+    }
+
+    @Override
+    protected int maxAttempts() {
+        return MAX_ATTEMPTS;
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/client/KernelWebClientRetryTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/client/KernelWebClientRetryTest.java
@@ -107,6 +107,34 @@ class KernelWebClientRetryTest {
         assertThat(engine.received).allSatisfy(request -> assertThat(request.body()).isNotNull());
     }
 
+    @Test
+    @DisplayName("re-throws the original transport failure unchanged after the cap (not a WebClientException)")
+    void transportFailureGivesUpUnwrapped() {
+        ProgrammedEngine engine = new ProgrammedEngine(List.of(boom(), boom()));
+        KernelWebClient twoAttempts = new KernelWebClient(engine, ALLOCATOR, REQUEST_ENCODERS, RESPONSE_DECODERS,
+                HttpClientRequestEnricher.noop(), new CommunityHttpRetryPolicy(2, 0L, 0L, () -> 0.0));
+
+        assertThatThrownBy(() -> twoAttempts.get("/widget/1", Map.class))
+                .isInstanceOf(TransportBoom.class)
+                .isNotInstanceOf(KernelWebClient.WebClientException.class);
+        assertThat(engine.received).hasSize(2);
+    }
+
+    private static Supplier<HttpResponse> boom() {
+        return () -> {
+            throw new TransportBoom();
+        };
+    }
+
+    /** Sentinel unchecked exception standing in for an engine-level transport failure. */
+    private static final class TransportBoom extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        TransportBoom() {
+            super("simulated transport failure");
+        }
+    }
+
     private static HttpClientRequestEnricher idempotencyKey(String key) {
         return request -> {
             List<HttpHeader> headers = new ArrayList<>(request.headers());

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/client/KernelWebClientRetryTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/client/KernelWebClientRetryTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http.client;
+
+import eu.exeris.kernel.community.http.CommunityHttpRetryPolicy;
+import eu.exeris.kernel.community.http.CommunityJsonRequestBodyEncoder;
+import eu.exeris.kernel.community.http.CommunityJsonResponseBodyDecoder;
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.core.http.client.KernelWebClient;
+import eu.exeris.kernel.spi.http.HttpClientEngine;
+import eu.exeris.kernel.spi.http.HttpClientRequestEnricher;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpRequestBodyEncoder;
+import eu.exeris.kernel.spi.http.HttpRequestBodyEncoderRegistry;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpResponseBodyDecoder;
+import eu.exeris.kernel.spi.http.HttpResponseBodyDecoderRegistry;
+import eu.exeris.kernel.spi.http.HttpRetryPolicy;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Community: KernelWebClient retry loop (ADR-045) over a programmed engine")
+class KernelWebClientRetryTest {
+
+    private static final MemoryAllocator ALLOCATOR =
+            new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+    private static final HttpRequestBodyEncoderRegistry REQUEST_ENCODERS =
+            HttpRequestBodyEncoderRegistry.of(
+                    List.<HttpRequestBodyEncoder>of(new CommunityJsonRequestBodyEncoder(MAPPER)));
+    private static final HttpResponseBodyDecoderRegistry RESPONSE_DECODERS =
+            HttpResponseBodyDecoderRegistry.of(
+                    List.<HttpResponseBodyDecoder>of(new CommunityJsonResponseBodyDecoder(MAPPER)));
+
+    // base=0 / max=0 → zero-delay retries so the test never sleeps.
+    private static final HttpRetryPolicy FAST_POLICY = new CommunityHttpRetryPolicy(3, 0L, 0L, () -> 0.0);
+
+    private KernelWebClient client(HttpClientEngine engine, HttpClientRequestEnricher enricher) {
+        return new KernelWebClient(engine, ALLOCATOR, REQUEST_ENCODERS, RESPONSE_DECODERS, enricher, FAST_POLICY);
+    }
+
+    @Test
+    @DisplayName("retries an idempotent GET on 503, then returns the success body")
+    void retriesThenSucceeds() {
+        ProgrammedEngine engine = new ProgrammedEngine(List.of(
+                serviceUnavailable(), okJson("{\"ok\":\"yes\"}")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = client(engine, HttpClientRequestEnricher.noop()).get("/widget/1", Map.class);
+
+        assertThat(body).containsEntry("ok", "yes");
+        assertThat(engine.received).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("gives up after the attempt cap and surfaces the final status")
+    void givesUpAfterCap() {
+        ProgrammedEngine engine = new ProgrammedEngine(List.of(
+                serviceUnavailable(), serviceUnavailable(), serviceUnavailable()));
+
+        assertThatThrownBy(() -> client(engine, HttpClientRequestEnricher.noop()).get("/widget/1", Map.class))
+                .isInstanceOf(KernelWebClient.WebClientException.class)
+                .extracting(ex -> ((KernelWebClient.WebClientException) ex).status())
+                .isEqualTo(503);
+        assertThat(engine.received).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("re-encodes the body on each attempt (POST carrying an Idempotency-Key)")
+    void reEncodesBodyEachAttempt() {
+        ProgrammedEngine engine = new ProgrammedEngine(List.of(
+                serviceUnavailable(), okJson("{\"id\":\"7\"}")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = client(engine, idempotencyKey("k-1"))
+                .post("/widget", Map.of("name", "Cogwheel"), Map.class);
+
+        assertThat(body).containsEntry("id", "7");
+        assertThat(engine.received).hasSize(2);
+        // Each attempt carried a freshly-encoded body — no LoanedBuffer reused across attempts.
+        assertThat(engine.received).allSatisfy(request -> assertThat(request.body()).isNotNull());
+    }
+
+    private static HttpClientRequestEnricher idempotencyKey(String key) {
+        return request -> {
+            List<HttpHeader> headers = new ArrayList<>(request.headers());
+            headers.add(new HttpHeader("Idempotency-Key", key));
+            return new HttpRequest(request.method(), request.path(), request.version(),
+                    List.copyOf(headers), request.body());
+        };
+    }
+
+    private static Supplier<HttpResponse> serviceUnavailable() {
+        return () -> HttpResponse.noBody(HttpStatus.SERVICE_UNAVAILABLE, HttpVersion.HTTP_1_1);
+    }
+
+    private static Supplier<HttpResponse> okJson(String json) {
+        return () -> {
+            byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+            LoanedBuffer body = ALLOCATOR.allocateNetwork(bytes.length);
+            MemorySegment.copy(MemorySegment.ofArray(bytes), 0, body.segment(), 0, bytes.length);
+            body.setSize(bytes.length);
+            return new HttpResponse(HttpStatus.OK, HttpVersion.HTTP_1_1,
+                    List.of(new HttpHeader("content-type", "application/json")), body);
+        };
+    }
+
+    /** A {@link HttpClientEngine} that returns a scripted sequence of responses and records requests. */
+    private static final class ProgrammedEngine implements HttpClientEngine {
+
+        private final Deque<Supplier<HttpResponse>> script;
+        private final List<HttpRequest> received = new ArrayList<>();
+
+        ProgrammedEngine(List<Supplier<HttpResponse>> responses) {
+            this.script = new ArrayDeque<>(responses);
+        }
+
+        @Override
+        public String engineName() {
+            return "programmed-stub";
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public void start() {
+            // no-op: this stub holds no transport resources.
+        }
+
+        @Override
+        public HttpResponse send(HttpRequest request) {
+            received.add(request);
+            Supplier<HttpResponse> next = script.poll();
+            if (next == null) {
+                throw new AssertionError("engine.send called more times than scripted");
+            }
+            return next.get();
+        }
+
+        @Override
+        public void close() {
+            // no-op.
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/client/KernelWebClient.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/client/KernelWebClient.java
@@ -79,9 +79,15 @@ import java.util.Objects;
 // CouplingBetweenObjects: facade composes the four SPI seams listed in ADR-034 §4
 // (HttpClientEngine, request-body codec, response-body codec, request enricher) plus the
 // shared HTTP carrier types — the coupling is the façade contract.
-// PMD.GodClass: a cohesive client façade — typed verbs + codec adaptation + the ADR-045 retry
-// loop all operate on the same handful of fields; the WMC growth is feature surface, not inflation.
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects", "PMD.GodClass"})
+// PMD.GodClass / PMD.TooManyMethods: a cohesive client façade — typed verbs + codec adaptation + the
+// ADR-045 retry loop all operate on the same handful of fields; the WMC / method growth is feature
+// surface, not inflation (the retry helpers keep the loop readable rather than inlining duplicate
+// null-checks / sleep logic).
+// PMD.AvoidCatchingGenericException: this façade's error model maps unchecked transport/codec/policy
+// RuntimeExceptions to WebClientException (or re-throws transport failures per ADR-026); the catch
+// pattern is deliberate and class-wide, consolidated here to keep it in one place.
+@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects",
+        "PMD.GodClass", "PMD.TooManyMethods", "PMD.AvoidCatchingGenericException"})
 public final class KernelWebClient {
 
     private static final HttpVersion DEFAULT_VERSION = HttpVersion.HTTP_1_1;
@@ -222,15 +228,10 @@ public final class KernelWebClient {
         return execute(HttpMethod.DELETE, path, null, responseType);
     }
 
-    // PMD.AvoidCatchingGenericException: engine.send() surfaces transport failures as unchecked
-    // exceptions; the retry policy (ADR-045) inspects them before they propagate. On give-up the
-    // original throwable is re-thrown unchanged, preserving the ADR-026 single-failure surface.
     // PMD.AvoidBranchingStatementAsLastInLoop: the retry loop terminates by returning the decoded
     // result on the first non-retried attempt — branching-as-last is the loop's exit, not a bug.
-    // PMD.CloseResource: a retried response's body is closed inline before the next attempt; the
-    // terminal attempt's body is closed in finishAttempt's finally. Ownership is local and explicit.
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidBranchingStatementAsLastInLoop",
-            "PMD.CloseResource"})
+    // (RuntimeException catching is suppressed class-wide — see the type-level note.)
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     private <T> T execute(HttpMethod method, String path, Object requestBody, Class<T> responseType) {
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(responseType, "responseType must not be null");
@@ -245,20 +246,20 @@ public final class KernelWebClient {
             try {
                 response = engine.send(request);
             } catch (RuntimeException transportFailure) {
-                if (shouldRetry(request, HttpAttemptOutcome.ofFailure(transportFailure), attempt)) {
-                    attempt++;
-                    continue;
+                // No response/body yet — a policy throw here just propagates; nothing to release.
+                RetryDecision decision = retryPolicy.decide(request,
+                        HttpAttemptOutcome.ofFailure(transportFailure), attempt);
+                if (!decision.retry()) {
+                    throw transportFailure;
                 }
-                throw transportFailure;
+                applyDelay(decision.delayMillis(), 0);
+                attempt++;
+                continue;
             }
 
             int status = response.status().code();
             boolean success = status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER;
-            if (!success && shouldRetry(request, HttpAttemptOutcome.ofStatus(status, response.headers()), attempt)) {
-                LoanedBuffer discarded = response.body();   // discard this attempt; the next re-encodes the body
-                if (discarded != null) {
-                    discarded.close();
-                }
+            if (!success && retryNonSuccess(request, response, status, attempt)) {
                 attempt++;
                 continue;
             }
@@ -267,29 +268,53 @@ public final class KernelWebClient {
     }
 
     /**
-     * Consults the retry policy; when it elects to retry, waits the decided delay on the caller's
-     * virtual thread and returns {@code true}. Returns {@code false} to give up.
+     * Handles a non-2xx response: consults the policy and, when it retries, closes this attempt's body
+     * <em>before</em> the wait (no buffer held across the sleep) and applies the delay. Returns
+     * {@code true} to retry (body already released) or {@code false} to finish (body still open for
+     * {@link #finishAttempt}). A buggy policy's RuntimeException closes the body before propagating
+     * (RuntimeException catching is suppressed class-wide — see the type-level note).
      */
-    private boolean shouldRetry(HttpRequest request, HttpAttemptOutcome outcome, int attempt) {
-        RetryDecision decision = retryPolicy.decide(request, outcome, attempt);
+    private boolean retryNonSuccess(HttpRequest request, HttpResponse response, int status, int attempt) {
+        RetryDecision decision;
+        try {
+            decision = retryPolicy.decide(request, HttpAttemptOutcome.ofStatus(status, response.headers()), attempt);
+        } catch (RuntimeException policyFailure) {
+            closeBody(response.body());
+            throw policyFailure;
+        }
         if (!decision.retry()) {
             return false;
         }
-        long delayMillis = decision.delayMillis();
-        if (delayMillis > NO_DELAY_MILLIS) {
-            try {
-                Thread.sleep(delayMillis);
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new WebClientException(0, "", "Retry wait interrupted", ex);
-            }
-        }
+        closeBody(response.body());   // close BEFORE the wait — no buffer held across the sleep
+        applyDelay(decision.delayMillis(), status);
         return true;
     }
 
-    // PMD.UseTryWithResources: response body ownership transfers from engine.send() return,
-    // so the buffer lifecycle is finalised in an explicit finally rather than try-with-resources.
-    @SuppressWarnings("PMD.UseTryWithResources")
+    private static void closeBody(LoanedBuffer body) {
+        if (body != null) {
+            body.close();
+        }
+    }
+
+    /**
+     * Waits {@code delayMillis} on the caller's virtual thread before the next attempt. On interrupt
+     * the wait is abandoned with a {@link WebClientException} carrying {@code triggeringStatus} (0 for
+     * a transport failure) so the retry-triggering status survives in diagnostics.
+     */
+    private static void applyDelay(long delayMillis, int triggeringStatus) {
+        if (delayMillis <= NO_DELAY_MILLIS) {
+            return;
+        }
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new WebClientException(triggeringStatus, "", "Retry wait interrupted", ex);
+        }
+    }
+
+    // Response body ownership transfers from engine.send() return, so the buffer lifecycle is
+    // finalised in an explicit finally (via closeBody) rather than try-with-resources.
     private <T> T finishAttempt(HttpResponse response, Class<T> responseType, int status) {
         boolean success = status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER;
         LoanedBuffer body = response.body();
@@ -309,16 +334,14 @@ public final class KernelWebClient {
             }
             return decodeSuccessBody(response, body, responseBytes, responseType, status);
         } finally {
-            if (body != null) {
-                body.close();
-            }
+            closeBody(body);
         }
     }
 
-    // PMD.AvoidCatchingGenericException: decoder drivers wrap their binding exceptions in
-    // RuntimeException (typically IllegalStateException) per ADR-034 §3; we re-wrap with
-    // status + raw body context for caller diagnostics.
-    @SuppressWarnings({"unchecked", "PMD.AvoidCatchingGenericException"})
+    // Decoder drivers wrap their binding exceptions in RuntimeException (typically IllegalStateException)
+    // per ADR-034 §3; we re-wrap with status + raw body context for caller diagnostics. (RuntimeException
+    // catching is suppressed class-wide — see the type-level note.)
+    @SuppressWarnings("unchecked")
     private <T> T decodeSuccessBody(HttpResponse response,
                                     LoanedBuffer body,
                                     byte[] responseBytes,
@@ -350,9 +373,8 @@ public final class KernelWebClient {
         }
     }
 
-    // PMD.AvoidCatchingGenericException: outbound buffer must be released if anything throws
-    // between allocate() and engine ownership transfer.
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    // Outbound buffer must be released if anything throws between allocate() and engine ownership
+    // transfer. (RuntimeException catching is suppressed class-wide — see the type-level note.)
     private HttpRequest buildRequest(HttpMethod method, String path, Object body) {
         if (body == null) {
             return HttpRequest.noBody(method, path, DEFAULT_VERSION, ACCEPT_JSON_HEADERS);

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/client/KernelWebClient.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/client/KernelWebClient.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.core.http.client;
 
+import eu.exeris.kernel.spi.http.HttpAttemptOutcome;
 import eu.exeris.kernel.spi.http.HttpClientEngine;
 import eu.exeris.kernel.spi.http.HttpClientRequestEnricher;
 import eu.exeris.kernel.spi.http.HttpEncodedBody;
@@ -21,7 +22,9 @@ import eu.exeris.kernel.spi.http.HttpResponse;
 import eu.exeris.kernel.spi.http.HttpResponseBodyDecoder;
 import eu.exeris.kernel.spi.http.HttpResponseBodyDecoderRegistry;
 import eu.exeris.kernel.spi.http.HttpResponseDecodingContext;
+import eu.exeris.kernel.spi.http.HttpRetryPolicy;
 import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.http.RetryDecision;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 
@@ -76,7 +79,9 @@ import java.util.Objects;
 // CouplingBetweenObjects: facade composes the four SPI seams listed in ADR-034 §4
 // (HttpClientEngine, request-body codec, response-body codec, request enricher) plus the
 // shared HTTP carrier types — the coupling is the façade contract.
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects"})
+// PMD.GodClass: a cohesive client façade — typed verbs + codec adaptation + the ADR-045 retry
+// loop all operate on the same handful of fields; the WMC growth is feature surface, not inflation.
+@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects", "PMD.GodClass"})
 public final class KernelWebClient {
 
     private static final HttpVersion DEFAULT_VERSION = HttpVersion.HTTP_1_1;
@@ -94,15 +99,44 @@ public final class KernelWebClient {
 
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final long EMPTY_SIZE = 0L;
+    private static final long NO_DELAY_MILLIS = 0L;
 
     private final HttpClientEngine engine;
     private final MemoryAllocator allocator;
     private final HttpRequestBodyEncoderRegistry requestEncoders;
     private final HttpResponseBodyDecoderRegistry responseDecoders;
     private final HttpClientRequestEnricher enricher;
+    private final HttpRetryPolicy retryPolicy;
 
     /**
-     * Creates a client with explicit enricher composition (ADR-032).
+     * Creates a client with explicit enricher composition (ADR-032) and retry
+     * policy (ADR-045).
+     *
+     * @param engine           a started client engine targeting a single host
+     * @param allocator        the kernel memory allocator (used by the resolved encoder)
+     * @param requestEncoders  registry of outbound body encoders
+     * @param responseDecoders registry of inbound body decoders
+     * @param enricher         outbound request enricher (use {@link HttpClientRequestEnricher#noop()} for none)
+     * @param retryPolicy      client-side retry policy (use {@link HttpRetryPolicy#none()} for no retry)
+     */
+    public KernelWebClient(
+            HttpClientEngine engine,
+            MemoryAllocator allocator,
+            HttpRequestBodyEncoderRegistry requestEncoders,
+            HttpResponseBodyDecoderRegistry responseDecoders,
+            HttpClientRequestEnricher enricher,
+            HttpRetryPolicy retryPolicy) {
+        this.engine = Objects.requireNonNull(engine, "engine must not be null");
+        this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
+        this.requestEncoders = Objects.requireNonNull(requestEncoders, "requestEncoders must not be null");
+        this.responseDecoders = Objects.requireNonNull(responseDecoders, "responseDecoders must not be null");
+        this.enricher = Objects.requireNonNull(enricher, "enricher must not be null");
+        this.retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy must not be null");
+    }
+
+    /**
+     * Convenience constructor — explicit enricher, defaults the retry policy to
+     * {@link HttpRetryPolicy#none()} (preserves the ADR-026 no-implicit-retry surface).
      *
      * @param engine           a started client engine targeting a single host
      * @param allocator        the kernel memory allocator (used by the resolved encoder)
@@ -116,16 +150,13 @@ public final class KernelWebClient {
             HttpRequestBodyEncoderRegistry requestEncoders,
             HttpResponseBodyDecoderRegistry responseDecoders,
             HttpClientRequestEnricher enricher) {
-        this.engine = Objects.requireNonNull(engine, "engine must not be null");
-        this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
-        this.requestEncoders = Objects.requireNonNull(requestEncoders, "requestEncoders must not be null");
-        this.responseDecoders = Objects.requireNonNull(responseDecoders, "responseDecoders must not be null");
-        this.enricher = Objects.requireNonNull(enricher, "enricher must not be null");
+        this(engine, allocator, requestEncoders, responseDecoders, enricher, HttpRetryPolicy.none());
     }
 
     /**
      * Convenience constructor — defaults the enricher to
-     * {@link HttpClientRequestEnricher#noop()}.
+     * {@link HttpClientRequestEnricher#noop()} and the retry policy to
+     * {@link HttpRetryPolicy#none()}.
      *
      * @param engine           a started client engine targeting a single host
      * @param allocator        the kernel memory allocator
@@ -137,7 +168,8 @@ public final class KernelWebClient {
             MemoryAllocator allocator,
             HttpRequestBodyEncoderRegistry requestEncoders,
             HttpResponseBodyDecoderRegistry responseDecoders) {
-        this(engine, allocator, requestEncoders, responseDecoders, HttpClientRequestEnricher.noop());
+        this(engine, allocator, requestEncoders, responseDecoders,
+                HttpClientRequestEnricher.noop(), HttpRetryPolicy.none());
     }
 
     /**
@@ -190,23 +222,79 @@ public final class KernelWebClient {
         return execute(HttpMethod.DELETE, path, null, responseType);
     }
 
-    // PMD.UseTryWithResources: response body ownership transfers from engine.send() return,
-    // so the buffer lifecycle is finalised in an explicit finally rather than try-with-resources.
-    @SuppressWarnings("PMD.UseTryWithResources")
+    // PMD.AvoidCatchingGenericException: engine.send() surfaces transport failures as unchecked
+    // exceptions; the retry policy (ADR-045) inspects them before they propagate. On give-up the
+    // original throwable is re-thrown unchanged, preserving the ADR-026 single-failure surface.
+    // PMD.AvoidBranchingStatementAsLastInLoop: the retry loop terminates by returning the decoded
+    // result on the first non-retried attempt — branching-as-last is the loop's exit, not a bug.
+    // PMD.CloseResource: a retried response's body is closed inline before the next attempt; the
+    // terminal attempt's body is closed in finishAttempt's finally. Ownership is local and explicit.
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidBranchingStatementAsLastInLoop",
+            "PMD.CloseResource"})
     private <T> T execute(HttpMethod method, String path, Object requestBody, Class<T> responseType) {
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(responseType, "responseType must not be null");
 
-        HttpRequest request = buildRequest(method, path, requestBody);
-        request = enricher.enrich(request);
+        int attempt = 0;
+        while (true) {
+            // ADR-045: the typed body is re-encoded each attempt; no LoanedBuffer is retained across
+            // attempts, so the codec path's zero-leak invariant is untouched by retry.
+            HttpRequest request = enricher.enrich(buildRequest(method, path, requestBody));
 
-        HttpResponse response = engine.send(request);
+            HttpResponse response;
+            try {
+                response = engine.send(request);
+            } catch (RuntimeException transportFailure) {
+                if (shouldRetry(request, HttpAttemptOutcome.ofFailure(transportFailure), attempt)) {
+                    attempt++;
+                    continue;
+                }
+                throw transportFailure;
+            }
 
-        int status = response.status().code();
+            int status = response.status().code();
+            boolean success = status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER;
+            if (!success && shouldRetry(request, HttpAttemptOutcome.ofStatus(status, response.headers()), attempt)) {
+                LoanedBuffer discarded = response.body();   // discard this attempt; the next re-encodes the body
+                if (discarded != null) {
+                    discarded.close();
+                }
+                attempt++;
+                continue;
+            }
+            return finishAttempt(response, responseType, status);
+        }
+    }
+
+    /**
+     * Consults the retry policy; when it elects to retry, waits the decided delay on the caller's
+     * virtual thread and returns {@code true}. Returns {@code false} to give up.
+     */
+    private boolean shouldRetry(HttpRequest request, HttpAttemptOutcome outcome, int attempt) {
+        RetryDecision decision = retryPolicy.decide(request, outcome, attempt);
+        if (!decision.retry()) {
+            return false;
+        }
+        long delayMillis = decision.delayMillis();
+        if (delayMillis > NO_DELAY_MILLIS) {
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new WebClientException(0, "", "Retry wait interrupted", ex);
+            }
+        }
+        return true;
+    }
+
+    // PMD.UseTryWithResources: response body ownership transfers from engine.send() return,
+    // so the buffer lifecycle is finalised in an explicit finally rather than try-with-resources.
+    @SuppressWarnings("PMD.UseTryWithResources")
+    private <T> T finishAttempt(HttpResponse response, Class<T> responseType, int status) {
+        boolean success = status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER;
         LoanedBuffer body = response.body();
         try {
             byte[] responseBytes = (body == null) ? EMPTY_BYTES : readAll(body);
-            boolean success = status >= HTTP_2XX_LOWER && status < HTTP_2XX_UPPER;
             if (!success) {
                 String responseBodyText = new String(responseBytes, StandardCharsets.UTF_8);
                 throw new WebClientException(status, responseBodyText,

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpAttemptOutcome.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpAttemptOutcome.java
@@ -33,11 +33,17 @@ import java.util.Objects;
 public record HttpAttemptOutcome(int statusCode, List<HttpHeader> responseHeaders, Throwable failure) {
 
     /**
-     * Canonical constructor — defensively copies the headers and rejects a null list.
+     * Canonical constructor — defensively copies the headers, rejects a null list, and enforces the
+     * two-state invariant: exactly one of a received status ({@code statusCode > 0}) or a transport
+     * {@code failure} is present. This closes the bypass the static factories already avoid.
      */
     public HttpAttemptOutcome {
         Objects.requireNonNull(responseHeaders, "responseHeaders must not be null");
         responseHeaders = List.copyOf(responseHeaders);
+        if ((failure == null) == (statusCode <= 0)) {
+            throw new IllegalArgumentException(
+                    "exactly one of statusCode (> 0) or failure must be present");
+        }
     }
 
     /**
@@ -57,6 +63,12 @@ public record HttpAttemptOutcome(int statusCode, List<HttpHeader> responseHeader
     /**
      * Returns an outcome for an attempt that failed at the transport level with
      * no HTTP response.
+     *
+     * <p>In practice the client façade ({@code KernelWebClient}) only produces
+     * {@link RuntimeException} transport failures — {@code HttpClientEngine.send}
+     * is an unchecked-throwing contract. The parameter is widened to {@link Throwable}
+     * so a policy may also carry a wrapped cause; it is not a signal that checked
+     * transport exceptions reach the seam.
      *
      * @param failure the transport failure; never {@code null}
      * @return a transport-failure outcome

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpAttemptOutcome.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpAttemptOutcome.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.http;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * SPI value carrier: the result of a single HTTP send attempt as seen by an
+ * {@link HttpRetryPolicy} — either a received HTTP status (with its response
+ * headers), or a transport-level failure with no HTTP response.
+ *
+ * <p>Carries the response status and headers but <strong>no body</strong>:
+ * response-body ownership stays inside the client façade ({@code KernelWebClient}).
+ * The headers are exposed so a policy can honour {@code Retry-After} on a
+ * {@code 503} (ADR-010 {@code SHED_LOAD}) without touching the body. Immutable,
+ * identity-free, Valhalla-ready (per ADR-045). Exactly one of the two states
+ * holds: {@code failure == null} (a response with {@code statusCode > 0}) or
+ * {@code failure != null} (a transport failure with {@code statusCode == 0} and
+ * empty headers).
+ *
+ * @param statusCode      the received HTTP status, or {@code 0} for a transport failure
+ * @param responseHeaders the response headers (empty on a transport failure); never {@code null}
+ * @param failure         the transport-level failure, or {@code null} when a response arrived
+ * @since 0.10.0
+ */
+public record HttpAttemptOutcome(int statusCode, List<HttpHeader> responseHeaders, Throwable failure) {
+
+    /**
+     * Canonical constructor — defensively copies the headers and rejects a null list.
+     */
+    public HttpAttemptOutcome {
+        Objects.requireNonNull(responseHeaders, "responseHeaders must not be null");
+        responseHeaders = List.copyOf(responseHeaders);
+    }
+
+    /**
+     * Returns an outcome for an attempt that received an HTTP response.
+     *
+     * @param statusCode      the received status; MUST be {@code > 0}
+     * @param responseHeaders the response headers; never {@code null}, may be empty
+     * @return a response outcome
+     */
+    public static HttpAttemptOutcome ofStatus(int statusCode, List<HttpHeader> responseHeaders) {
+        if (statusCode <= 0) {
+            throw new IllegalArgumentException("statusCode must be > 0 for a response outcome, was " + statusCode);
+        }
+        return new HttpAttemptOutcome(statusCode, responseHeaders, null);
+    }
+
+    /**
+     * Returns an outcome for an attempt that failed at the transport level with
+     * no HTTP response.
+     *
+     * @param failure the transport failure; never {@code null}
+     * @return a transport-failure outcome
+     */
+    public static HttpAttemptOutcome ofFailure(Throwable failure) {
+        Objects.requireNonNull(failure, "failure must not be null");
+        return new HttpAttemptOutcome(0, List.of(), failure);
+    }
+
+    /**
+     * Returns {@code true} when an HTTP response arrived (no transport failure).
+     *
+     * @return {@code true} if a status is present
+     */
+    public boolean hasResponse() {
+        return failure == null;
+    }
+
+    /**
+     * Returns {@code true} when the attempt failed at the transport level.
+     *
+     * @return {@code true} if a transport failure is present
+     */
+    public boolean isTransportFailure() {
+        return failure != null;
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRetryPolicy.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRetryPolicy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.http;
+
+/**
+ * SPI: Client-side HTTP retry policy — decides whether the client façade
+ * ({@code KernelWebClient}) should re-issue a request after a non-success
+ * outcome. Resolves the retry deferral that ADR-026 (&quot;no implicit
+ * retry&quot;) and ADR-032 (Alternative D) both named (see ADR-045).
+ *
+ * <p>Contract:
+ * <ul>
+ *   <li>{@link #decide(HttpRequest, HttpAttemptOutcome, int)} is invoked once per
+ *       completed attempt with the zero-based {@code attemptIndex} of that attempt.</li>
+ *   <li>Implementations MUST NOT read, retain, or close the request body
+ *       {@code LoanedBuffer} reachable via {@link HttpRequest#body()} — body
+ *       ownership belongs to the façade, which re-encodes the body per attempt.
+ *       The policy reads the method and headers (e.g. {@code Idempotency-Key}) only.</li>
+ *   <li>Implementations run synchronously on the caller's virtual thread; no
+ *       thread-spawning, no blocking I/O. Returning {@link RetryDecision#retryAfter(long)}
+ *       instructs the façade to sleep {@code delayMillis} before the next attempt.</li>
+ *   <li>Implementations SHOULD bound total attempts so a fleet of clients cannot
+ *       amplify a server-side admission shed (ADR-010 {@code SHED_LOAD}) into a
+ *       retry storm.</li>
+ * </ul>
+ *
+ * <p>Behavioural defaults (which statuses retry, attempt cap, backoff curve,
+ * jitter, idempotency gate, {@code Retry-After} handling) are an implementation
+ * concern, not SPI surface — see {@code CommunityHttpRetryPolicy}.
+ *
+ * @since 0.10.0
+ */
+@FunctionalInterface
+public interface HttpRetryPolicy {
+
+    /**
+     * Decides whether the attempt that produced {@code outcome} should be retried.
+     *
+     * @param request      the request as sent — for method / header inspection only;
+     *                     the body MUST NOT be read, retained, or closed; never {@code null}
+     * @param outcome      the HTTP status or transport failure of this attempt; never {@code null}
+     * @param attemptIndex zero-based index of the attempt that just completed ({@code 0} = first try)
+     * @return {@link RetryDecision#retryAfter(long)} to retry after a delay, or
+     *         {@link RetryDecision#giveUp()} to surface the outcome to the caller
+     */
+    RetryDecision decide(HttpRequest request, HttpAttemptOutcome outcome, int attemptIndex);
+
+    /**
+     * Returns a policy that never retries — preserves the ADR-026 &quot;no
+     * implicit retry&quot; default for callers that do not opt in.
+     *
+     * @return a never-retry policy
+     */
+    static HttpRetryPolicy none() {
+        return (request, outcome, attemptIndex) -> RetryDecision.giveUp();
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/RetryDecision.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/RetryDecision.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.http;
+
+/**
+ * SPI value carrier: the verdict of an {@link HttpRetryPolicy} for a single send
+ * attempt — either retry after {@code delayMillis}, or give up and surface the
+ * outcome to the caller.
+ *
+ * <p>Immutable, identity-free, Valhalla-ready (per ADR-045). {@code delayMillis}
+ * is meaningful only when {@code retry} is {@code true} and MUST be {@code >= 0}.
+ *
+ * @param retry       whether the attempt should be retried
+ * @param delayMillis delay before the next attempt in milliseconds; {@code >= 0}
+ * @since 0.10.0
+ */
+public record RetryDecision(boolean retry, long delayMillis) {
+
+    private static final RetryDecision GIVE_UP = new RetryDecision(false, 0L);
+
+    /**
+     * Canonical constructor; rejects a negative delay on a retry verdict.
+     */
+    public RetryDecision {
+        if (retry && delayMillis < 0L) {
+            throw new IllegalArgumentException("retry delayMillis must be >= 0, was " + delayMillis);
+        }
+    }
+
+    /**
+     * Returns a verdict to retry after {@code delayMillis}.
+     *
+     * @param delayMillis delay before the next attempt; {@code >= 0}
+     * @return a retry verdict
+     */
+    public static RetryDecision retryAfter(long delayMillis) {
+        return new RetryDecision(true, delayMillis);
+    }
+
+    /**
+     * Returns the stable give-up verdict (no further attempts).
+     *
+     * @return the give-up verdict
+     */
+    public static RetryDecision giveUp() {
+        return GIVE_UP;
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRetryPolicyTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRetryPolicyTck.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.http;
+
+import eu.exeris.kernel.spi.http.HttpAttemptOutcome;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpRetryPolicy;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.http.RetryDecision;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: Abstract base for {@link HttpRetryPolicy} contract verification (ADR-045).
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@link HttpRetryPolicy#none()} returns {@link RetryDecision#giveUp()} for every input —
+ *       the ADR-026 no-implicit-retry default.</li>
+ *   <li>{@link RetryDecision#retryAfter(long)} rejects a negative delay; {@link RetryDecision#giveUp()}
+ *       is a stable, non-retry verdict.</li>
+ *   <li>{@link HttpAttemptOutcome} distinguishes a response ({@code statusCode > 0}, headers present,
+ *       no failure) from a transport failure ({@code statusCode == 0}, empty headers, failure present),
+ *       carries headers (never a body), and defensively copies the header list.</li>
+ *   <li>A conforming default policy ({@link #createPolicy()}) retries idempotent requests on transient
+ *       conditions ({@code 502/503/504} or transport failure), gives up on non-idempotent requests
+ *       without an {@code Idempotency-Key}, gives up on non-retryable statuses, honours {@code Retry-After}
+ *       on a {@code 503}, and gives up once the attempt cap is reached.</li>
+ * </ul>
+ *
+ * <h2>Subclass binding model</h2>
+ * <p>Driver subclasses override {@link #createPolicy()} to supply the default policy under test, built
+ * with <em>deterministic</em> tuning (fixed jitter), and {@link #maxAttempts()} to declare the total-attempt
+ * cap that policy was built with. The static SPI clauses ({@code none}, {@code RetryDecision},
+ * {@code HttpAttemptOutcome}) are exercised against the SPI itself and need no driver.
+ *
+ * <h2>How to use</h2>
+ * <pre>{@code
+ * class CommunityHttpRetryPolicyTckTest extends AbstractHttpRetryPolicyTck {
+ *     @Override protected HttpRetryPolicy createPolicy() {
+ *         return new CommunityHttpRetryPolicy(3, 100L, 2000L, () -> 0.5);
+ *     }
+ *     @Override protected int maxAttempts() { return 3; }
+ * }
+ * }</pre>
+ */
+public abstract class AbstractHttpRetryPolicyTck {
+
+    /**
+     * Supplies the default policy under test, built with deterministic tuning (fixed jitter) and the
+     * cap returned by {@link #maxAttempts()}.
+     *
+     * @return the policy under test
+     */
+    protected abstract HttpRetryPolicy createPolicy();
+
+    /**
+     * Declares the total-attempt cap the {@link #createPolicy()} policy was built with; MUST be {@code >= 2}
+     * so the cap test has a retry-eligible attempt to give up after.
+     *
+     * @return the attempt cap
+     */
+    protected abstract int maxAttempts();
+
+    private static HttpRequest request(HttpMethod method, List<HttpHeader> headers) {
+        return new HttpRequest(method, "/widgets/42", HttpVersion.HTTP_1_1, headers, null);
+    }
+
+    private static HttpAttemptOutcome status(int code, HttpHeader... headers) {
+        return HttpAttemptOutcome.ofStatus(code, List.of(headers));
+    }
+
+    @Nested
+    @DisplayName("HttpRetryPolicy.none()")
+    class StaticSpiNone {
+
+        @Test
+        @DisplayName("never retries, for any status or failure")
+        void neverRetries() {
+            HttpRetryPolicy none = HttpRetryPolicy.none();
+            assertThat(none.decide(request(HttpMethod.GET, List.of()), status(503), 0).retry()).isFalse();
+            assertThat(none.decide(request(HttpMethod.GET, List.of()),
+                    HttpAttemptOutcome.ofFailure(new IOException("reset")), 0).retry()).isFalse();
+            assertThat(none.decide(request(HttpMethod.GET, List.of()), status(200), 0))
+                    .isEqualTo(RetryDecision.giveUp());
+        }
+    }
+
+    @Nested
+    @DisplayName("RetryDecision")
+    class RetryDecisionContract {
+
+        @Test
+        @DisplayName("retryAfter rejects a negative delay")
+        void rejectsNegativeDelay() {
+            assertThatThrownBy(() -> RetryDecision.retryAfter(-1L))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("retryAfter(0) is a zero-delay retry; giveUp is non-retry")
+        void factories() {
+            assertThat(RetryDecision.retryAfter(0L).retry()).isTrue();
+            assertThat(RetryDecision.retryAfter(0L).delayMillis()).isZero();
+            assertThat(RetryDecision.giveUp().retry()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("HttpAttemptOutcome")
+    class AttemptOutcomeContract {
+
+        @Test
+        @DisplayName("ofStatus carries status + headers, no failure")
+        void ofStatus() {
+            HttpAttemptOutcome outcome = HttpAttemptOutcome.ofStatus(503, List.of(new HttpHeader("Retry-After", "2")));
+            assertThat(outcome.hasResponse()).isTrue();
+            assertThat(outcome.isTransportFailure()).isFalse();
+            assertThat(outcome.statusCode()).isEqualTo(503);
+            assertThat(outcome.responseHeaders()).hasSize(1);
+            assertThat(outcome.failure()).isNull();
+        }
+
+        @Test
+        @DisplayName("ofFailure carries the throwable, status 0, empty headers")
+        void ofFailure() {
+            IOException cause = new IOException("connection reset");
+            HttpAttemptOutcome outcome = HttpAttemptOutcome.ofFailure(cause);
+            assertThat(outcome.isTransportFailure()).isTrue();
+            assertThat(outcome.hasResponse()).isFalse();
+            assertThat(outcome.statusCode()).isZero();
+            assertThat(outcome.responseHeaders()).isEmpty();
+            assertThat(outcome.failure()).isSameAs(cause);
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive status and a null failure")
+        void rejectsInvalid() {
+            assertThatThrownBy(() -> HttpAttemptOutcome.ofStatus(0, List.of()))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> HttpAttemptOutcome.ofFailure(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("defensively copies the header list (no aliasing into the policy)")
+        void defensiveCopy() {
+            assertThatThrownBy(() -> HttpAttemptOutcome.ofStatus(200, List.of()).responseHeaders().add(
+                    new HttpHeader("X", "y"))).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("default policy decision matrix")
+    class DefaultPolicyMatrix {
+
+        @Test
+        @DisplayName("503 on an idempotent GET → retry")
+        void retriesIdempotentOn503() {
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()), status(503), 0).retry())
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("transport failure on a GET → retry")
+        void retriesIdempotentOnTransportFailure() {
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()),
+                    HttpAttemptOutcome.ofFailure(new IOException("reset")), 0).retry()).isTrue();
+        }
+
+        @Test
+        @DisplayName("503 on a non-idempotent POST without Idempotency-Key → give up")
+        void givesUpNonIdempotentWithoutKey() {
+            assertThat(createPolicy().decide(request(HttpMethod.POST, List.of()), status(503), 0).retry())
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("503 on a POST WITH Idempotency-Key → retry")
+        void retriesNonIdempotentWithKey() {
+            List<HttpHeader> headers = List.of(new HttpHeader("Idempotency-Key", "abc-123"));
+            assertThat(createPolicy().decide(request(HttpMethod.POST, headers), status(503), 0).retry())
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("404 on a GET → give up (not a retryable status)")
+        void givesUpOnNonRetryableStatus() {
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()), status(404), 0).retry())
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("503 + Retry-After: 2 → retry honouring the 2s delay")
+        void honoursRetryAfter() {
+            RetryDecision decision = createPolicy().decide(request(HttpMethod.GET, List.of()),
+                    status(503, new HttpHeader("Retry-After", "2")), 0);
+            assertThat(decision.retry()).isTrue();
+            assertThat(decision.delayMillis()).isEqualTo(2_000L);
+        }
+
+        @Test
+        @DisplayName("gives up once the attempt cap is reached")
+        void givesUpAtCap() {
+            int lastAttempt = maxAttempts() - 1;
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()), status(503), lastAttempt).retry())
+                    .isFalse();
+        }
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRetryPolicyTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRetryPolicyTck.java
@@ -177,10 +177,25 @@ public abstract class AbstractHttpRetryPolicyTck {
         }
 
         @Test
+        @DisplayName("502 on an idempotent GET → retry")
+        void retriesIdempotentOn502() {
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()), status(502), 0).retry())
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("504 on an idempotent GET → retry")
+        void retriesIdempotentOn504() {
+            assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()), status(504), 0).retry())
+                    .isTrue();
+        }
+
+        @Test
         @DisplayName("transport failure on a GET → retry")
         void retriesIdempotentOnTransportFailure() {
+            // Representative of what the engine actually throws — an unchecked transport failure.
             assertThat(createPolicy().decide(request(HttpMethod.GET, List.of()),
-                    HttpAttemptOutcome.ofFailure(new IOException("reset")), 0).retry()).isTrue();
+                    HttpAttemptOutcome.ofFailure(new RuntimeException("connection reset")), 0).retry()).isTrue();
         }
 
         @Test


### PR DESCRIPTION
Closes the **retry half of v0.10 Sprint 4** (HTTP Client codec/retry). The codec half shipped in v0.8 (ADR-034/032); this PR adds the deliberately-deferred retry seam.

Resolves the client-side retry deferral that **ADR-026** (§"no implicit retry") and **ADR-032** (Alternative D) both named but left open.

## Decision shape (ADR-045)

New **standalone** ADR (not an amendment to the closed/accepted codec ADR-034) — retry is a separate concern. SPI surface is fixed; behavioural defaults live in the Community impl so consumer alignment (tooling / migration tool / BudgetHQ) can tune without ADR churn.

Number reserved in `exeris-docs/adr-index.md` → **exeris-docs#19**.

## SPI — `eu.exeris.kernel.spi.http`

- `HttpRetryPolicy` (`@FunctionalInterface`) + `none()` — `none()` preserves the ADR-026 no-implicit-retry default.
- `HttpAttemptOutcome` — status + **response headers** (so a policy can honour `Retry-After`) OR a transport failure; carries headers but **never a body** (no `LoanedBuffer` ownership crosses the seam).
- `RetryDecision` — `retryAfter(delayMillis ≥ 0)` / `giveUp()`; Valhalla-ready value records.

## Core — `KernelWebClient`

- One **opt-in** constructor parameter (6-arg full; 5/4-arg delegate `HttpRetryPolicy.none()`), symmetric with ADR-032's enricher composition.
- Retry loop wraps the **existing** send seam. **Re-encodes the typed body per attempt** — no `LoanedBuffer` retained across attempts, so the codec path's zero-leak invariant is untouched.
- Codec failures are **never** retried (only transport failures + retryable statuses). On final give-up the same `WebClientException` is thrown; transport throwables are re-thrown unchanged.

## Community — `CommunityHttpRetryPolicy`

- Idempotency gate (RFC 9110 idempotent methods, or any request carrying `Idempotency-Key`).
- Retryable: transport failures + `502/503/504`.
- `Retry-After` honoured on `503` (ADR-010 `SHED_LOAD`); otherwise capped exponential backoff + full jitter (injectable for deterministic tests). Attempt cap bounds retry-storm amplification.
- Cross-call circuit-breaking intentionally out of scope (the per-attempt `decide` contract carries no cross-call state).

## TCK + tests

- `AbstractHttpRetryPolicyTck` — universal SPI invariants (`none()`, `RetryDecision`, `HttpAttemptOutcome`) + the decision matrix, bound by `CommunityHttpRetryPolicyTckTest`.
- `KernelWebClientRetryTest` — exercises the loop over a programmed engine: retry-then-succeed, give-up-at-cap (surfaces final status), re-encode-per-attempt.

## Verification

- **25 tests green** (14 TCK + 3 retry-loop + 8 `KernelWebClientIntegrationTest` regression).
- `mvn pmd:check checkstyle:check` **clean** on spi / core / community / tck. (`GodClass` / `CloseResource` targeted-suppressed with justification on `KernelWebClient` — the class already suppressed `CyclomaticComplexity` / `CouplingBetweenObjects`.)

## The Wall

SPI stays implementation-blind (no driver/wire-status policy in the contract); behavioural opinion lives in the Community driver. No Spring / DI / `ThreadLocal`. `Thread.sleep` on the caller's virtual thread only on the retry (non-hot) path.

## Follow-up (not in this PR)

Cross-repo **consumer alignment** before behavioural-defaults lock: `exeris-tooling` `KernelClientGenerator` composition-root wires `CommunityHttpRetryPolicy` (constructor-injected, no per-entity codegen change) + migration tool + BudgetHQ. `.link.md` stubs in tooling / enterprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)