### PR TITLE
docs(adr): fix cross-repo stub URLs + ADR-006 owner / ADR-001 filename

### DIFF
--- a/docs/adr/ADR-001.link.md
+++ b/docs/adr/ADR-001.link.md
@@ -1,6 +1,6 @@
 # ADR-001 — Cloud Native & Agnostic Infrastructure Strategy (link stub)
 
-**Authoritative copy:** `exeris-docs/adr/ADR-001 Cloud Native & Agnostic Infrastructure Strategy.md`
+**Authoritative copy:** [`exeris-docs/adr/ADR-001-cloud-native-and-agnostic-infrastructure-strategy.md`](https://github.com/exeris-systems/exeris-docs/blob/main/adr/ADR-001-cloud-native-and-agnostic-infrastructure-strategy.md)
 
 ADR-001 is a **platform-scope** decision owned by `exeris-docs`. It defines the CNCF baseline (Kubernetes, PostgreSQL, Redis, S3-compatible storage) that every Exeris repository inherits, including this one.
 

--- a/docs/adr/ADR-006.link.md
+++ b/docs/adr/ADR-006.link.md
@@ -1,8 +1,8 @@
 # ADR-006 — Spring-Free Kernel Boundary ("The Wall") (link stub)
 
-**Authoritative copy:** `exeris-spring-runtime/docs/adr/ADR-006 Spring-Free Kernel Boundary.md`
+**Authoritative copy:** [`exeris-docs/adr/ADR-006-spring-free-kernel-boundary.md`](https://github.com/exeris-systems/exeris-docs/blob/main/adr/ADR-006-spring-free-kernel-boundary.md)
 
-ADR-006 is a **cross-repo** decision owned by `exeris-spring-runtime`. It binds this kernel repository: `exeris-kernel-spi`, `exeris-kernel-core`, `exeris-kernel-community`, and `exeris-kernel-enterprise` MUST contain zero `org.springframework.*` imports and MUST NOT assume Spring at runtime.
+ADR-006 is a **cross-repo** decision owned by `exeris-docs`. It binds this kernel repository: `exeris-kernel-spi`, `exeris-kernel-core`, `exeris-kernel-community`, and `exeris-kernel-enterprise` MUST contain zero `org.springframework.*` imports and MUST NOT assume Spring at runtime.
 
 ## Why this stub exists
 

--- a/docs/adr/ADR-025.link.md
+++ b/docs/adr/ADR-025.link.md
@@ -1,6 +1,6 @@
 # ADR-025 — AI Agent Bridge / MCP Server for Ecosystem Introspection (link stub)
 
-**Authoritative copy:** [`../../../exeris-ai-bridge/docs/adr/ADR-025-ai-agent-bridge.md`](../../../exeris-ai-bridge/docs/adr/ADR-025-ai-agent-bridge.md)
+**Authoritative copy:** [`exeris-ai-bridge/docs/adr/ADR-025-ai-agent-bridge.md`](https://github.com/exeris-systems/exeris-ai-bridge/blob/main/docs/adr/ADR-025-ai-agent-bridge.md)
 
 ADR-025 is a **cross-repo** decision owned by `exeris-ai-bridge`. It binds this kernel repository because the `kernel:*` tool family in the bridge consumes a new read-only diagnostic SPI (`KernelDiagnostics`) that lives in `exeris-kernel-spi`, with provider implementations in Community.
 

--- a/docs/rfc/RFC-2026-05-18-kernel-diagnostics-spi.md
+++ b/docs/rfc/RFC-2026-05-18-kernel-diagnostics-spi.md
@@ -20,7 +20,7 @@ The answer is binary in shape: do we ship a **dedicated `KernelDiagnostics` SPI 
 
 Two concrete forcing functions land this week:
 
-1. **`exeris-ai-bridge` 0.4.0 is blocked.** [ADR-025](../../../exeris-docs/adr/ADR-025-ai-agent-bridge.md) was accepted 2026-05-15. The bridge ships three tool families — `docs:*`, `lsp:*`, `kernel:*`. The `kernel:*` family (`list_providers`, `list_capabilities`, `get_bootstrap_dag`, `describe_subsystem`) explicitly defers to a "`KernelDiagnostics` SPI RFC" called out in `ROADMAP.md` §0.4.0. Until that RFC lands, every `kernel:*` handler in the bridge returns `isError: true` with the message *"Not implemented yet — blocked on KernelDiagnostics SPI RFC."*
+1. **`exeris-ai-bridge` 0.4.0 is blocked.** [ADR-025](https://github.com/exeris-systems/exeris-ai-bridge/blob/main/docs/adr/ADR-025-ai-agent-bridge.md) was accepted 2026-05-15. The bridge ships three tool families — `docs:*`, `lsp:*`, `kernel:*`. The `kernel:*` family (`list_providers`, `list_capabilities`, `get_bootstrap_dag`, `describe_subsystem`) explicitly defers to a "`KernelDiagnostics` SPI RFC" called out in `ROADMAP.md` §0.4.0. Until that RFC lands, every `kernel:*` handler in the bridge returns `isError: true` with the message *"Not implemented yet — blocked on KernelDiagnostics SPI RFC."*
 2. **Existing diagnostic points are usable but fragmented.** Today the kernel already exposes:
    - `SubsystemOrchestrator.subsystem(String name)` and `SubsystemOrchestrator.subsystems()` — public List/Optional returns of the live bootstrap DAG nodes.
    - `MemoryStats` value record (returned by `MemoryAllocator#stats()`).


### PR DESCRIPTION
Registry-triage remediation for cross-repo ADR link stubs in `exeris-kernel`. Source: `adr-triage-report-2026-06-25.md`.

- Convert `../../../<sibling-repo>/...` filesystem-traversal links (which break on GitHub web + standalone clones) to canonical `https://github.com/exeris-systems/.../blob/main/...` URLs.
- **ADR-006 stub:** corrected the wrong owner — the authoritative copy is in `exeris-docs` (`ADR-006-spring-free-kernel-boundary.md`), not the non-existent `exeris-spring-runtime/docs/adr/ADR-006 Spring-Free Kernel Boundary.md`.
- **ADR-001 stub:** point at the kebab-case filename (the pre-rename spaced path was dead).
- **RFC-2026-05-18:** the ADR-025 reference pointed at the wrong repo (`exeris-docs` instead of `exeris-ai-bridge`) — fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)