### PR TITLE
docs(events): ADR-049 — Events log-ordering & OCC boundary decision (v0.10)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1591,6 +1591,8 @@ Sourcing (per-aggregate strict ordering + optimistic-concurrency append + infini
 
 **Merge Gate:** Ordering/concurrency boundary recorded in `docs/subsystems/events.md`; `EventStreamAppender` contract states its sequencing semantics; `AbstractEventStreamReaderTck` / `AppenderTck` bound and green on ≥2 bindings; `AbstractEventBusTck` either asserts the documented ordering or documents its absence; additive only (no breaking-change framing per pre-1.0 / TRL-3 stance); The Wall preserved (no broker/JDBC types leak into the Events SPI).
 
+**Status (v0.10):** **DECISION LANDED (ADR-049, Accepted 2026-07-01).** The ownership boundary is settled: per-`StreamId` total ordering + optimistic-concurrency **append-with-expected-version** are owned by the Events SPI durable-log surface (`EventStreamAppender`); the transient `EventBus` stays **unordered by design**; `FlowSnapshot.schemaVersion` CAS stays Persistence-owned (ADR-013) as a distinct mechanism. This decision-only slice ships ADR-049 + the `events.md` boundary record + the `EventStreamAppender` Javadoc; it also corrected a stale doc note that attributed event OCC to a non-existent `PersistenceEngine.append(streamId, expectedVersion)`. **Remaining (implementation slice, still v0.10):** the `EventStreamAppender` signature change (`expectedVersion` + `AppendResult`), `EX-EVENT-6008` (version conflict), and binding `AbstractEventStreamAppenderTck` / `AbstractEventStreamReaderTck` on ≥2 durable bindings (Community Postgres outbox + Kafka) — the merge gate for the fundament.
+
 See also: [Events Subsystem](./subsystems/events.md); v0.7 EVENT-203 (skeleton delivery); ADR-013 (FlowSnapshot OCC); v0.12 §"Runtime: KV-as-Projection".
 
 ---

--- a/docs/adr/ADR-049-events-log-ordering-and-optimistic-concurrency-boundary.md
+++ b/docs/adr/ADR-049-events-log-ordering-and-optimistic-concurrency-boundary.md
@@ -1,0 +1,89 @@
+# ADR-049: Events Log-Ordering & Optimistic-Concurrency Boundary — the durable log owns append-with-expected-version
+
+| Attribute       | Value                                                                                                                                                                                       |
+|:----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **ADR #**       | **049** (reserved 2026-07-01 in `exeris-docs/adr-index.md`).                                                                                                                              |
+| **Status**      | **Accepted** — decision-only slice on the kernel v0.10 train. This slice ships the decision (this ADR), the `events.md` boundary record, and the `EventStreamAppender` contract Javadoc. The SPI signature change, the `EX-EVENT-6008` error code, and the TCK bindings are the deferred **implementation slice** (still v0.10). Reaches `main` with the 0.10 release. |
+| **Deciders**    | Arkadiusz Przychocki                                                                                                                                                                       |
+| **Date**        | 2026-07-01                                                                                                                                                                                 |
+| **Scope**       | kernel/events                                                                                                                                                                             |
+| **Owning Repo** | `exeris-kernel`                                                                                                                                                                            |
+| **Driven By**   | The "one log, four views" sourcing/streaming fundament (v0.10 ROADMAP §"Events: Log-Ordering & Optimistic-Concurrency Boundary"); the gate on v0.12 KV-as-projection + distributed; downstream dogfooding (Stellar-Tactics, 2026-06). |
+| **Compliance**  | The Wall (ADR-006); No Waste Compute; Java-26 idioms (immutable carriers, `ScopedValue`); distinct from — and consistent with — the `FlowSnapshot` CAS (ADR-013).                          |
+
+## Context and Problem Statement
+
+The kernel's Events surface is the substrate for the "one log, four views" shape: *streaming* (the log read forward as transport), *sourcing* (the log as source of truth, state = fold over replay), *KV* (the log compacted to last-value-per-key), and *distributed* (the same log replicated across nodes). All four derivations require one explicit consistency boundary — per-stream ordering plus an optimistic-concurrency append — that they can all rely on. Today that boundary is **not decided and not on the Events SPI**.
+
+Verified against the current source tree:
+
+- **The append surface is versionless.** `EventStreamAppender.append(StreamId, EventDescriptor, EventPayload)` (`exeris-kernel-spi/.../events/EventStreamAppender.java:62`) takes no expected-version / sequence parameter and returns nothing — fire-and-forget. `EventStreamReader` / `EventStreamAppender` / `EventStream` are unbound skeletons (`@since 0.7.0`, zero main-source implementors; the `KernelProviders.EVENT_STREAM_READER` / `EVENT_STREAM_APPENDER` `ScopedValue` slots are wired but unbound).
+- **The transient bus is intentionally unordered.** `InMemoryEventBus.publish()` (`exeris-kernel-core/.../events/InMemoryEventBus.java`) starts one virtual thread per handler — concurrent fan-out, fire-and-forget — so there is no per-key / per-aggregate delivery order by construction, and `AbstractEventBusTck` asserts none.
+- **The only optimistic-concurrency mechanism that exists is flow-scoped and Persistence-owned.** `FlowSnapshot.schemaVersion` (`exeris-kernel-spi/.../flow/model/FlowSnapshot.java:71`) enforced by `JdbcFlowSnapshotStore` `SQL_UPDATE_OCC` (`exeris-kernel-community/.../flow/JdbcFlowSnapshotStore.java`) is a compare-and-set on *flow snapshot state* (ADR-013). It is **not** a general event-log append OCC.
+- **The subsystem doc points at a method that does not exist.** `docs/subsystems/events.md:166` claims "optimistic concurrency version enforcement is a Persistence SPI concern (`PersistenceEngine.append(streamId, expectedVersion, …)`)". There is **no** `PersistenceEngine.append(StreamId, long expectedVersion, …)` anywhere in the persistence SPI — the documented owner is a phantom.
+
+Sourcing (per-aggregate strict ordering + optimistic-concurrency append + long retention) and streaming (fan-out throughput + consumer offset + time/size retention) want *different* guarantees from the *same* log, and KV and distributed both build on the ordered log. The kernel has not decided **where the ordering + append-OCC guarantee lives**, so the fundament that gates the whole family is missing.
+
+**This ADR answers: where does per-`StreamId` ordering + optimistic-concurrency append live, and is the guarantee mandatory or binding-defined?**
+
+## 🏁 The Decision
+
+**Per-`StreamId` total ordering and the optimistic-concurrency append-with-expected-version contract are owned by the Events SPI on the durable-log surface (`EventStreamAppender`); the transient `EventBus` stays unordered by design; and the `FlowSnapshot` CAS stays a distinct, Persistence-owned flow-state mechanism.**
+
+The kernel already carries the clean surface split this decision needs: `EventStreamAppender`'s own contract distinguishes the *in-process pub/sub* path (`EventBus.publish`, no durability) from the *durable append to the shared distributed log*. The ordering/OCC guarantee is a property of the **log**, so it belongs on the log-append contract — not on the bus, and not on Persistence.
+
+**Concrete obligations:**
+
+1. **The append surface gains expected-version + a committed-sequence result (implementation slice).** The target shape is
+   ```java
+   AppendResult append(StreamId streamId, long expectedVersion,
+                       EventDescriptor descriptor, EventPayload payload);
+   record AppendResult(long committedSequence) {}
+   long ANY_VERSION = -1L; // opt out of the OCC check for append-only / non-CAS callers
+   ```
+   A reviewer can assert: after the impl slice, `EventStreamAppender.append` carries an `expectedVersion` argument and returns the committed sequence; the versionless single-argument form is gone.
+2. **Per-`StreamId` total ordering is mandatory for every `EventStreamAppender` binding.** Concurrent appends to the same `StreamId` are linearized and assigned strictly monotonic sequence numbers; `EventStreamReader.replayFromVersion(streamId, fromVersion)` reads them back in that order. A binding that cannot provide per-stream ordering does not implement `EventStreamAppender`.
+3. **Expected-version conflict fails closed.** When `expectedVersion != ANY_VERSION` and it does not equal the stream's current head sequence, the append is rejected with the new structured `EX-EVENT-6008` (event-log append version conflict; `rawArgs [0] String streamType, [1] long expectedVersion, [2] long actualVersion`). No silent overwrite, no out-of-order append.
+4. **The transient `EventBus` stays unordered by design.** `EventBus.publish` keeps its concurrent per-handler fan-out; no per-key ordering guarantee is added. `AbstractEventBusTck` records the *absence* of an ordering promise (a documented no-ordering note), rather than asserting ordering. Ordering is a property of the durable-log surface only — this keeps the intentionally-unordered in-memory bus unchanged (additive, no reshaping of `InMemoryEventBus.publish`).
+5. **`FlowSnapshot.schemaVersion` CAS stays Persistence-owned and separate.** It remains the flow-snapshot state concurrency mechanism (`JdbcFlowSnapshotStore` `SQL_UPDATE_OCC`, ADR-013). It is **not** merged with, and **not** the same as, the event-log append OCC. `docs/subsystems/events.md` is corrected to stop attributing event OCC to a (non-existent) `PersistenceEngine.append(streamId, expectedVersion)`.
+6. **The Wall holds.** No JDBC / Kafka / broker types enter the Events SPI. Each binding realizes ordering/OCC in its own layer: Kafka routes on `streamId` as the message key for per-partition order and maintains a per-stream sequence for the version check; the Postgres outbox uses a per-stream sequence column + an `INSERT … WHERE expected = current` CAS; the Enterprise off-heap log uses its native sequence.
+7. **Verification is the merge gate for the fundament (implementation slice).** Bind `AbstractEventStreamAppenderTck` and `AbstractEventStreamReaderTck` on ≥2 durable bindings — the Community Postgres outbox path and the Kafka driver — asserting per-stream monotonic ordering, `expectedVersion` conflict → `EX-EVENT-6008`, and the `ANY_VERSION` append-only path. Add the `EventBus` no-ordering note to `AbstractEventBusTck`.
+
+## Consequences
+
+### ✅ Positive Outcomes
+
+- **[+] One portable contract the four views rely on.** Sourcing (fold over ordered replay) and KV (compacted last-value-per-key) get their substrate; distributed replicates an already-ordered log. The v0.12 KV-as-projection and distributed items are unblocked at the contract level.
+- **[+] The guarantee lives where it is true.** Ordering/OCC is a log property, expressed on the log-append contract — not smeared across Persistence (a phantom method) or forced onto a pub/sub bus that was never meant to order.
+- **[+] No reshaping of the hot in-memory path.** The unordered `EventBus` is unchanged; only durable-log bindings carry the new obligation.
+- **[+] The Wall is preserved.** Binding-private realization (Kafka key/sequence, Postgres CAS) keeps broker/JDBC detail out of the SPI.
+- **[+] Additive, pre-1.0.** Zero external SPI consumers; the appender has no main-source implementors and its slot is unbound, so evolving the signature is safe (TRL-3 — no "breaking change" framing applies).
+
+### ⚠️ Trade-offs
+
+- **[-] Durable-log bindings must maintain a per-stream sequence.** Real implementation cost — notably Kafka, whose offsets are per-partition, needs a side per-stream sequence to honour the version check; it is not free from broker semantics alone.
+- **[-] The `@FunctionalInterface` append signature changes.** Acceptable pre-1.0 (no implementors, unbound slot), but it does retire the current single-argument form and adds `AppendResult` + `ANY_VERSION` to the SPI surface.
+- **[-] A new error code (`EX-EVENT-6008`) and TCK surface.** Small, additive verification debt carried into the implementation slice.
+- **[-] An in-memory "log" appender (if ever built) must still provide ordering** or simply not implement `EventStreamAppender` — the unordered bus cannot double as a log.
+
+### 📋 What is NOT in scope
+
+- **The concrete SPI signature change, `EX-EVENT-6008`, and the TCK bindings** — those are the implementation slice (still v0.10); this ADR records the decision and the target contract only.
+- **The Events `topic` seam** (a separate v0.10 roadmap item) and the **Event-Payload Codec** (ADR-046, already landed) — orthogonal additive events-SPI seams.
+- **Any change to `FlowSnapshot` / `JdbcFlowSnapshotStore` CAS** (ADR-013) — it stays as-is, documented as a distinct mechanism.
+- **Compaction / keyed projection state** (v0.12 KV-as-projection) — this ADR is the fundament they depend on, not the KV implementation.
+- **`EventDescriptor.flags` `ORDERED`** semantics beyond noting it as an advisory routing hint, not the ordering guarantee.
+
+## Cross-references
+
+- ADR-013 (Distributed Saga State Distribution Model) — the `FlowSnapshot.schemaVersion` CAS that stays Persistence-owned and separate from this event-log OCC.
+- ADR-046 (Event-Payload Codec SPI) — sibling additive events-SPI seam; the `EVENT_STREAM_*` slot precedent this decision builds on.
+- ADR-006 (Spring-Free Kernel Boundary / The Wall) — the boundary the binding-private ordering realization respects.
+- `exeris-kernel/docs/subsystems/events.md` — the boundary record updated by this slice.
+- `exeris-kernel/docs/ROADMAP.md` §"Events: Log-Ordering & Optimistic-Concurrency Boundary" (v0.10) and §"Runtime: KV-as-Projection" (v0.12).
+
+## Engineering Protocol
+
+1. **This slice (decision-only):** this ADR; the `events.md` boundary record + the corrected Responsibilities line (no more phantom `PersistenceEngine.append`); the `EventStreamAppender` Javadoc stating the sequencing/OCC semantics. No signature change yet. Global index row registered in `exeris-docs/adr-index.md` as a separate commit.
+2. **Implementation slice (still v0.10):** change `EventStreamAppender` to `AppendResult append(StreamId, long expectedVersion, EventDescriptor, EventPayload)` with `ANY_VERSION`; add `EX-EVENT-6008`; state the per-stream ordering contract on `EventStreamReader`; bind `AbstractEventStreamAppenderTck` / `AbstractEventStreamReaderTck` on the Community Postgres outbox + Kafka bindings; add the `EventBus` no-ordering note to `AbstractEventBusTck`. That TCK pass on ≥2 bindings is the merge gate.
+3. **Downstream (v0.12):** KV-as-projection and the distributed replicated-log work consume this contract; they do not reopen it.

--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -163,7 +163,7 @@ in the `EventDescriptor` primitive layout.
 1. Define `EventDescriptor` (primitive-only routing metadata) and `EventPayload` (ref-counted off-heap bytes).
 2. Provide `EventStreamReader` and `EventStreamAppender` interfaces (since 0.7.0, EVENT-203) plus the `StreamId` / `EventStream` carriers used to query and stream events. Implementation-blind — bindings (PostgreSQL outbox, Kafka driver, Enterprise off-heap log) provide the cursor.
 3. Define `EventRegistry` ordinal contract for O(1) type routing.
-4. Define conflict-resolution routing via `EventDescriptor.flags` (PERSISTENT, ORDERED, ASYNC, BROADCAST). Note: optimistic concurrency version enforcement is a Persistence SPI concern (`PersistenceEngine.append(streamId, expectedVersion, …)`), not an Events routing concern.
+4. Define conflict-resolution routing via `EventDescriptor.flags` (PERSISTENT, ORDERED, ASYNC, BROADCAST) — advisory routing hints, **not** the ordering guarantee itself. Per **[ADR-049](../adr/ADR-049-events-log-ordering-and-optimistic-concurrency-boundary.md)**, per-`StreamId` total ordering and optimistic-concurrency **append-with-expected-version** are owned by the Events SPI on the durable-log surface (`EventStreamAppender`) — **not** by the transient `EventBus` (unordered by design) and **not** by Persistence. The separate `FlowSnapshot.schemaVersion` CAS (`JdbcFlowSnapshotStore`, ADR-013) is flow-snapshot state concurrency — a distinct mechanism, not the event-log append OCC. (There is no `PersistenceEngine.append(streamId, expectedVersion, …)`; the earlier note here pointed at a method that does not exist.)
 
 **What Events Core DOES:**
 
@@ -172,6 +172,19 @@ in the `EventDescriptor` primitive layout.
 3. Handle event serialization/deserialization using the Kernel's binary formats (no JSON on hot-path).
 4. Manage local **Projections** via `ProjectionEngine` — subscribes typed `ProjectionHandler<S>` instances to the bus and maintains their immutable state via lock-free `AtomicReference.updateAndGet`.
 5. Provide binary `EventDescriptorCodec` for off-heap serialisation of `EventDescriptor` structs (Panama FFM `StructLayout`, little-endian).
+
+---
+
+## Log-Ordering & Optimistic-Concurrency Boundary (ADR-049)
+
+The "one log, four views" family — streaming, sourcing, KV, distributed — all derive from a single durable log and must honour one consistency boundary. **[ADR-049](../adr/ADR-049-events-log-ordering-and-optimistic-concurrency-boundary.md)** settles where that boundary lives:
+
+- **Durable log (`EventStreamAppender`) — ordering + OCC owned here (mandatory).** Every binding provides **per-`StreamId` total ordering** (concurrent appends to one stream are linearized and assigned strictly monotonic sequences; `EventStreamReader.replayFromVersion` reads them back in order) and honours an **append-with-expected-version** optimistic-concurrency check. Target append shape (implementation slice): `AppendResult append(StreamId, long expectedVersion, EventDescriptor, EventPayload)` with an `ANY_VERSION` sentinel for append-only callers; a version mismatch fails closed with `EX-EVENT-6008` (no silent overwrite).
+- **Transient bus (`EventBus.publish`) — unordered by design.** The in-memory bus keeps its concurrent per-handler fan-out and makes **no** per-key / per-aggregate ordering promise. Ordering is a property of the durable-log surface only.
+- **`FlowSnapshot.schemaVersion` CAS — a separate, Persistence-owned mechanism.** It is flow-snapshot state concurrency (ADR-013), not the event-log append OCC. The two are distinct and are not merged.
+- **The Wall holds.** Bindings realize ordering/OCC privately (Kafka: `streamId`-keyed partition order + a per-stream sequence; Postgres outbox: per-stream sequence column + `INSERT … WHERE expected = current` CAS; Enterprise off-heap log: native sequence). No broker/JDBC type enters the Events SPI.
+
+**Current state:** decision landed (ADR-049, this v0.10 slice). The `EventStreamAppender` signature change, `EX-EVENT-6008`, and the `AbstractEventStreamAppenderTck` / `AbstractEventStreamReaderTck` bindings on ≥2 durable bindings are the deferred implementation slice — see the Testing Strategy "Order Integrity" note.
 
 ---
 
@@ -185,6 +198,8 @@ in the `EventDescriptor` primitive layout.
 | `EX-EVENT-6002` | Bus Publish Failure   | `[0] String eventType, [1] long queueDepth, [2] long queueCapacity`    |
 | `EX-EVENT-6003` | Registry Conflict     | `[0] String eventType, [1] int ordinal`                                |
 | `EX-EVENT-6004` | Provider Boot Failure | `[0] String providerName, [1] String reason`                           |
+
+> **Proposed (ADR-049):** `EX-EVENT-6008` — event-log append version conflict on `EventStreamAppender.append(…, expectedVersion, …)`; `rawArgs [0] String streamType, [1] long expectedVersion, [2] long actualVersion`. Lands with the append-with-expected-version implementation slice.
 
 **Backpressure note for `EX-EVENT-6002`:** When thrown, the publisher MUST NOT retry inline. The
 `EventBus` must propagate this exception to the caller's `StructuredTaskScope` boundary, allowing
@@ -310,6 +325,9 @@ public interface EventStreamReader extends AutoCloseable {
 @FunctionalInterface
 public interface EventStreamAppender {
     // Same RAII ownership transfer as EventBus.publish(...)
+    // ADR-049: the implementation slice changes this to
+    //   AppendResult append(StreamId, long expectedVersion, EventDescriptor, EventPayload)
+    // (ANY_VERSION opts out of the OCC check; mismatch -> EX-EVENT-6008). Versionless form shown is pre-slice.
     void append(StreamId streamId, EventDescriptor descriptor, EventPayload payload);
 }
 

--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -197,7 +197,10 @@ The "one log, four views" family — streaming, sourcing, KV, distributed — al
 | `EX-EVENT-6001` | Generic Engine Failure| `[0] String message`                                                   |
 | `EX-EVENT-6002` | Bus Publish Failure   | `[0] String eventType, [1] long queueDepth, [2] long queueCapacity`    |
 | `EX-EVENT-6003` | Registry Conflict     | `[0] String eventType, [1] int ordinal`                                |
-| `EX-EVENT-6004` | Provider Boot Failure | `[0] String providerName, [1] String reason`                           |
+| `EX-EVENT-6004` | Provider Boot Failure | `[0] String providerName, [1] String reason` |
+| `EX-EVENT-6005` | Outbox Event → DLQ | `[0] String eventType, [1] String reason, [2] int retryCount` |
+| `EX-EVENT-6006` | Projection Handler Failure | `[0] String projectionName, [1] int eventTypeOrdinal` |
+| `EX-EVENT-6007` | Event-Loop VT Uncaught | `[0] String loopName, [1] String exceptionType`                           |
 
 > **Proposed (ADR-049):** `EX-EVENT-6008` — event-log append version conflict on `EventStreamAppender.append(…, expectedVersion, …)`; `rawArgs [0] String streamType, [1] long expectedVersion, [2] long actualVersion`. Lands with the append-with-expected-version implementation slice.
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamAppender.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventStreamAppender.java
@@ -35,6 +35,28 @@ package eu.exeris.kernel.spi.events;
  * {@code payload} on entry. After the call returns (success or thrown exception),
  * the caller MUST NOT call {@link EventPayload#close()} on the same reference.
  *
+ * <h2>Sequencing &amp; Optimistic Concurrency (ADR-049)</h2>
+ * <p>The durable log is the kernel's ordering / optimistic-concurrency boundary. Per
+ * <b>ADR-049</b>, every {@code EventStreamAppender} binding MUST provide, for each
+ * {@link StreamId}, a <b>per-stream total order</b>: concurrent appends to the same stream
+ * are linearized and assigned strictly monotonic sequence numbers, and
+ * {@link EventStreamReader#replayFromVersion(StreamId, long)} reads them back in that order.
+ * This is the contract that log-derived views (event sourcing, KV-as-projection, the
+ * replicated distributed log) rely on; it is owned <b>here</b>, on the Events SPI — not by
+ * the transient {@link EventBus} (unordered by design) and not by Persistence. The separate
+ * {@link eu.exeris.kernel.spi.flow.model.FlowSnapshot} {@code schemaVersion} CAS (ADR-013)
+ * is flow-snapshot state concurrency, a distinct mechanism — not the event-log append OCC.
+ *
+ * <p><b>Optimistic-concurrency append (implementation slice).</b> The append surface will
+ * gain an {@code expectedVersion} parameter and return the committed sequence — target shape
+ * {@code AppendResult append(StreamId, long expectedVersion, EventDescriptor, EventPayload)}
+ * with an {@code ANY_VERSION} sentinel that opts append-only callers out of the check. When
+ * {@code expectedVersion} does not match the stream head, the append fails closed with
+ * {@code EX-EVENT-6008} (version conflict) — no silent overwrite. This ADR-049 slice records
+ * the decision and the contract; the signature change, the error code, and the
+ * {@code AbstractEventStreamAppenderTck} binding on &ge;2 durable bindings land in the
+ * implementation slice. The current single-argument {@link #append} is the pre-slice shape.
+ *
  * @since 0.7.0
  * @see EventStreamReader
  */


### PR DESCRIPTION
## What

Decision-only slice for the v0.10 **Events: Log-Ordering & Optimistic-Concurrency Boundary** fundament (the "settle-it-first" item that gates KV-as-projection + distributed in v0.12).

Founder-ruled both hinges:
- **H1** — the append-with-expected-version + per-`StreamId` total-ordering contract is owned by the **Events SPI durable-log surface** (`EventStreamAppender`). `FlowSnapshot.schemaVersion` CAS stays **Persistence-owned** (ADR-013) as a distinct mechanism.
- **H2** — ordering/OCC is **mandatory on the durable log**, and the transient `EventBus` stays **unordered by design** (no breaking change to `InMemoryEventBus`).

## Changes

- `docs/adr/ADR-049-…boundary.md` — new ADR (Accepted, decision-only).
- `docs/subsystems/events.md` — new "Log-Ordering & OCC Boundary" section; **corrected a phantom doc reference** (line 166 claimed OCC lived on `PersistenceEngine.append(streamId, expectedVersion)` — that method does not exist); proposed `EX-EVENT-6008`; annotated the replay-API code sample.
- `exeris-kernel-spi/.../events/EventStreamAppender.java` — Javadoc states the sequencing & OCC semantics (**no signature change** this slice).
- `docs/ROADMAP.md` — `Status (v0.10): DECISION LANDED (ADR-049)` on the Events ordering entry.

## Deferred to the implementation slice (still v0.10)

The `EventStreamAppender` signature change (`expectedVersion` + `AppendResult` + `ANY_VERSION`), the `EX-EVENT-6008` error code, and binding `AbstractEventStreamAppenderTck` / `AbstractEventStreamReaderTck` on ≥2 durable bindings (Community Postgres outbox + Kafka) — that TCK pass is the merge gate for the fundament.

## Preflight (exeris-pr-preflight)

- Branch hygiene — PASS (fresh branch off `development/0.10.0`)
- Lint (PMD + Checkstyle, not in `verify`) — PASS (0 violations on `exeris-kernel-spi`)
- Architecture guard (`ExerisArchitectureTest`) — PASS
- Contract change → TCK — N/A (Javadoc-only; TCK obligation deferred to impl slice, recorded in ADR + roadmap)
- Docs/ADR drift — PASS (ADR authored + reserved in the global index)

## Notes

- Global ADR-index reservation for **049** is a paired PR in `exeris-systems/exeris-docs` (`docs/adr-049-reserve`).
- The untracked `SyscallLoopbackRoundTripIT` (transport FFM-syscall work) is **intentionally excluded** from this slice — it belongs on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)