### PR TITLE
fix(ci): benchmarks job skips surefire; de-flake stream-loopback byte budgets (v0.10)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -607,7 +607,7 @@ jobs:
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
             -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jfr-reports/jmh-benchmarks.jfr,dumponexit=true,settings=default \
-            verify -B -e
+            verify -DskipTests -B -e
           mvn -pl exeris-kernel-core -P benchmarks \
             -Dbenchmark.forks=1 \
             -Dbenchmark.warmup=3 \
@@ -615,7 +615,7 @@ jobs:
             -Dbenchmark.warmuptime=1s \
             -Dbenchmark.iterationstime=1s \
             -Dbenchmark.jvmArgsAppend=-XX:StartFlightRecording=name=jmh,filename=target/jfr-reports/jmh-benchmarks.jfr,dumponexit=true,settings=default \
-            verify -B -e
+            verify -DskipTests -B -e
 
       - name: Upload Community benchmark results
         uses: actions/upload-artifact@v4

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -274,7 +274,6 @@
                 <benchmark.jvm.gc>-XX:+UseZGC</benchmark.jvm.gc>
                 <benchmark.jvmArgs></benchmark.jvmArgs>
                 <benchmark.jvmArgsAppend/>
-                <excludedGroups>flamegraph</excludedGroups>
             </properties>
             <build>
                 <plugins>

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamJfrTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamJfrTest.java
@@ -65,6 +65,7 @@ class CommunityHttpStreamJfrTest {
     private static final long RECORD_SETTLE_MILLIS = 1_500L;
     private static final long PARK_SLICE_MILLIS = 5L;
     private static final int CLIENT_READ_BUF = 16 * 1024;
+    private static final int CLIENT_RECV_BUF = 2 * 1024;
 
     static {
         // Small credit window + send buffer so the backpressure-park path fires deterministically.
@@ -280,6 +281,10 @@ class CommunityHttpStreamJfrTest {
     private static Socket connectClient(int port) {
         try {
             Socket socket = new Socket();
+            // Cap the kernel recv buffer BEFORE connect (fixes the TCP window): the OS default
+            // (~128 KB, autotuned) would absorb the whole backpressure flood, credit would keep
+            // returning on kernel write-accept, and the park path would never fire.
+            socket.setReceiveBufferSize(CLIENT_RECV_BUF);
             socket.connect(new InetSocketAddress("127.0.0.1", port), (int) TimeUnit.SECONDS.toMillis(5L));
             socket.setTcpNoDelay(true);
             socket.getOutputStream().write(

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpStreamExchangeTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpStreamExchangeTck.java
@@ -93,13 +93,17 @@ public abstract class AbstractHttpStreamExchangeTck {
     private static final long SLOW_PROBE_TIMEOUT_SECONDS = 30L;
 
     /**
-     * Flood size for the backpressure probe. Sized to RELIABLY force several credit-window park cycles
-     * given the binding's deliberately-tiny egress window (so the property — emit() parks then resumes
-     * then delivers everything — is genuinely proven) while draining comfortably within
-     * {@link #SLOW_PROBE_TIMEOUT_SECONDS} on a loaded box. A larger flood proves nothing more about the
-     * park/resume property; it only makes the probe throughput-bound and flaky under contention.
+     * Flood size for the backpressure probe. The park condition only trips once the kernel refuses a
+     * socket write: egress credit returns when the transport accepts a frame (buffer close), not when
+     * the client reads it. The flood must therefore dominate everything the OS can absorb with a
+     * stalled reader — server {@code SO_SNDBUF} + client {@code SO_RCVBUF} (Linux doubles both
+     * setsockopt values) — plus the credit window itself, with margin for the pre-stall drain race.
+     * 2_000 (~23 KB of {@code data: N} frames) sat below that ceiling (~36 KB with the reference
+     * binding's 8 KB/2 KB sockets and 16 KB window), so emit() could legitimately complete without
+     * ever parking on some boxes; 8_000 (~95 KB) clears it several times over while still draining
+     * well within {@link #SLOW_PROBE_TIMEOUT_SECONDS} on a loaded box.
      */
-    protected static final int BACKPRESSURE_FLOOD = 2_000;
+    protected static final int BACKPRESSURE_FLOOD = 8_000;
 
     // -------------------------------------------------------------------------
     // Mandatory binding hook — the real loopback round-trip


### PR DESCRIPTION
## Why

Unblocks the `v0.10.0` tag. After the #232 integration, `main` had exactly one red job: **JMH Benchmarks** — the only job that executed the known-2-vCPU-flaky `stream-loopback` suite at all (`build-and-verify` excludes it by default and was green on the same tree, twice).

## Root cause chain

1. **`benchmarks` profile re-included excluded groups** — `exeris-kernel-community/pom.xml` overrode `excludedGroups` to just `flamegraph`, silently re-enabling `stream-loopback`, `integration`, `stress`, `continuity`, `transport-pinning-recv` in the job's `mvn verify`. Override removed; the module default inherits.
2. **Benchmarks job re-ran the full test suite for no benefit** — it already `needs: build-and-verify`. Both benchmark `verify` invocations now pass `-DskipTests`; JMH runs via `exec-maven-plugin` at `verify` and is unaffected.
3. **The park probes had a byte-budget hole** — egress credit returns when the *kernel* accepts a write (buffer close-action), not when the client reads, so `emit()` parks only once `SO_SNDBUF` + peer `SO_RCVBUF` are full:
   - `BACKPRESSURE_FLOOD = 2000` (~23 KB) sat **below** the absorb ceiling (~36 KB: binding's 8 KB/2 KB sockets — Linux doubles both `setsockopt` values — plus the 16 KB credit window), so `emit()` could legitimately complete without ever parking → raised to `8000` (~95 KB), Javadoc rewritten with the actual budget math.
   - `CommunityHttpStreamJfrTest` never capped the client `SO_RCVBUF`, so the OS default (~128 KB autotuned) absorbed its whole 116 KB flood → capped to 2 KB **before** `connect`.

## Verification

- Pre-fix: both park cases failed **deterministically** on a large-socket-buffer box (Windows), matching the CI signature.
- Post-fix: 3 consecutive green runs, 15/15 (`CommunityHttpStreamExchangeTckTest` + `CommunityHttpStreamJfrTest`).
- Preflight: `pmd:check` + `checkstyle:check` clean on tck+community; `ExerisArchitectureTest` 11/11.
- Scope: test/CI only — zero production code. No contract change (probe calibration of an existing TCK case).

## Not in scope

The three 10s-timeout cases under CPU starvation are the already-tracked "make stream-loopback CI-gateable under scarce carriers" follow-up (community pom comment); the group stays excluded from default CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
