### PR TITLE
docs(spi): correct TransportStream.queueWrite ownership + blocking contract

### DIFF
--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/sse/HttpStreamEngine.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/sse/HttpStreamEngine.java
@@ -227,18 +227,18 @@ public final class HttpStreamEngine implements HttpStreamExchange {
             throw error;
         }
         try {
-            // Ownership transfers to the transport; on a dead stream queueWrite closes the buffer
-            // (the close-action returns the credit) and throws — either IllegalStateException
-            // ("stream closed") or a TransportException surfaced from a synchronous flush whose
-            // socket write faulted (broken pipe / RST after peer disconnect). Both mean the peer is
-            // gone: map them to the unchecked StreamClosedException the emit loop unwinds on.
+            // Ownership transfers to the transport. On a dead stream queueWrite throws — either
+            // IllegalStateException ("stream closed") or a TransportException surfaced from a
+            // synchronous flush whose socket write faulted (broken pipe / RST after peer
+            // disconnect). Both mean the peer is gone: map them to the unchecked
+            // StreamClosedException the emit loop unwinds on. On throw the buffer is ours to free
+            // (see the catch).
             stream.queueWrite(buffer, frameBytes);
         } catch (RuntimeException streamClosed) {
-            // Safety net for the credit accounting: the TransportStream.queueWrite contract closes the
-            // buffer before throwing (its close-action returns the credit), but close() is idempotent and
-            // the close-action runs exactly once (refcount CAS), so a defensive close() here cannot
-            // double-release — it only guarantees the credit is returned if an implementation ever throws
-            // without closing.
+            // On throw the caller owns the buffer (queueWrite releases only on success), so we close
+            // it here to return the credit via its close-action. close() is idempotent and the
+            // close-action runs exactly once (refcount CAS), so this cannot double-release even if an
+            // implementation also released the loan while unwinding.
             buffer.close();
             abortiveTeardown(StreamClosedException.peerDisconnect(eventsEmitted.get()), streamClosed);
         }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportStream.java
@@ -101,20 +101,36 @@ public interface TransportStream extends AutoCloseable {
     void write(MemorySegment source, int length);
 
     /**
-     * Queues a {@link LoanedBuffer} for asynchronous transmission.
+     * Queues a {@link LoanedBuffer} for transmission on this stream.
      *
-     * <p><strong>Ownership transfer:</strong> the transport takes ownership of the buffer.
-     * The caller MUST NOT close the buffer after this call — the transport will close it
-     * after the write completes. If this method throws any exception (including
-     * {@link IllegalStateException}), the buffer is closed by the transport before
-     * the exception propagates. The caller must NOT close the buffer after an exception.
+     * <p><strong>Ownership — callee-closes-on-success, caller-closes-on-throw:</strong>
+     * this method takes ownership of {@code buffer}.
+     * <ul>
+     *   <li><strong>On normal return</strong> the transport owns the loan and releases it —
+     *       immediately for a synchronous transmission, or after the asynchronous flush
+     *       completes. The caller MUST NOT close {@code buffer}.</li>
+     *   <li><strong>If this method throws</strong> (including {@link IllegalStateException}),
+     *       ownership returns to the caller, who MUST close {@code buffer} to avoid leaking it.
+     *       Because {@link LoanedBuffer#close()} is idempotent, this caller-close is safe even
+     *       if an implementation happened to release the loan while unwinding.</li>
+     * </ul>
+     * The rule is simply: the callee closes on success, the caller closes on throw. A caller
+     * that never frees on exception (as some earlier revisions of this doc implied) leaks one
+     * buffer per failed write against transports that release only on success.
      *
-     * <p>This method is non-blocking: data is queued and flushed by the carrier loop.
+     * <p><strong>Blocking is implementation-defined.</strong> Despite the {@code queue} in the
+     * name, the call is not guaranteed to be non-blocking: a synchronous transport completes
+     * the write before returning (blocking until the bytes are sent), while an asynchronous
+     * transport enqueues the buffer and flushes it on a carrier loop (returning before
+     * transmission). Callers MUST NOT rely on non-blocking semantics.
      *
-     * @param buffer loaned buffer to send (ownership transferred)
+     * @param buffer loaned buffer to send; ownership transferred on normal return, retained by
+     *               the caller on any thrown exception (the caller must then close it)
      * @param length number of valid bytes in the buffer (from offset 0)
-     * @throws eu.exeris.kernel.spi.exceptions.transport.TransportException on failure
-     * @throws IllegalStateException if this stream has been closed
+     * @throws eu.exeris.kernel.spi.exceptions.transport.TransportException on failure — the
+     *         caller owns and must close {@code buffer}
+     * @throws IllegalStateException if this stream has been closed — the caller owns and must
+     *         close {@code buffer}
      */
     void queueWrite(LoanedBuffer buffer, int length);
 


### PR DESCRIPTION
`TransportStream.queueWrite(LoanedBuffer, int)` documented two guarantees the synchronous (TCP/TLS) transports do not honor.

## 1. Ownership — was inverted
Old doc: *"the transport closes the loan on exception; the caller must NOT close it."*
Real contract: the transport releases the loan **on success**; **on throw the caller owns and must close it** (senders like `EnterpriseHttpClientEngine#queueFrameWrite` already free on throw; `Tcp/TlsTransportStream.queueWrite` release only after a successful write — enterprise #88 / #40).

**Risk fixed:** a caller following the old doc literally (not freeing on exception) leaks one `LoanedBuffer` per failed queued write against release-on-success transports.

Restated as **callee-closes-on-success XOR caller-closes-on-throw**, with a note that `LoanedBuffer.close()` is documented-idempotent — so the caller-close is safe even if an implementation released the loan while unwinding (reconciles enterprise "doesn't close on throw" vs Community `NativeTcpStream` "closes on some rejects").

## 2. Blocking — was unconditional
Old doc: *"This method is non-blocking."* False for synchronous transports (they block on the send / TLS-wrap + raw send). Restated as **implementation-defined** (synchronous blocks; asynchronous enqueues + flushes on the carrier loop). Kept **implementation-blind** — no impl named (SPI purity), so the non-blocking scope is expressed as "synchronous vs asynchronous transport" rather than by naming QUIC.

## Consistency (no behavior change)
- `HttpStreamEngine` (SSE, the only in-repo caller) — code already correct (defensive idempotent `close()` on throw); its two **comments** referenced the old contract and are synced here. Comment-only.
- Community `NativeTcpStream` over-closes on some throw paths — safe under the idempotent-close contract; **left unchanged** (a behavior change would be out of scope for a doc fix).
- `docs/subsystems/transport.md` carries no queueWrite contract text — untouched.

## Verification
`mvn clean install` green — nothing skipped (checkstyle `validate-architecture` + pmd `verify-complexity` on **spi + core**; 0 Checkstyle violations). No API or behavior change.

Refs: enterprise PR #88 (TCP + TLS queueWrite loan release), enterprise #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)