### PR TITLE
feat(community): configurable JSON mapper via JsonMapperCustomizer seam (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level. Which SPI surfaces are `stable` / `preview` / `experimental`, and what each label commits to for semver, is declared in [`docs/stability-matrix.md`](docs/stability-matrix.md) — the authoritative source for the semver policy.
 
-## [0.10.1] — Unreleased
+## [0.10.1] — 2026-07-19
 
-Patch release. Community-internal, additive, default byte-identical (no SPI change). Detail: [ADR-052](docs/adr/ADR-052-community-json-mapper-customization-seam.md).
+Patch release. Community-internal, additive, default byte-identical (no SPI change). Detail + notes: [`docs/release/v0.10.1-release-notes.md`](docs/release/v0.10.1-release-notes.md) (ADR-052).
 
 ### Added
 - **Configurable Community JSON mapper** — `eu.exeris.kernel.community.json` `JsonMapperCustomizer` (ServiceLoader) + per-quadrant `JsonMapperScope`; `CommunityHttpProvider` / `CommunityEventProvider` source each codec's Jackson `ObjectMapper` through the seam instead of a hardcoded `new ObjectMapper()`, so an application can (e.g.) register Blackbird for `invokedynamic` accessors on the response-encode hot path. With no customizer registered every mapper is byte-for-byte the prior default; Jackson stays a Community driver detail (The Wall holds). Note: "byte-identical" is about serialized output — each HTTP quadrant now builds its own mapper instead of one shared instance, so per-mapper serializer caches are no longer shared across quadrants (bootstrap/JVM-warmup only) (ADR-052).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level. Which SPI surfaces are `stable` / `preview` / `experimental`, and what each label commits to for semver, is declared in [`docs/stability-matrix.md`](docs/stability-matrix.md) — the authoritative source for the semver policy.
 
+## [0.10.1] — Unreleased
+
+Patch release. Community-internal, additive, default byte-identical (no SPI change). Detail: [ADR-052](docs/adr/ADR-052-community-json-mapper-customization-seam.md).
+
+### Added
+- **Configurable Community JSON mapper** — `eu.exeris.kernel.community.json` `JsonMapperCustomizer` (ServiceLoader) + per-quadrant `JsonMapperScope`; `CommunityHttpProvider` / `CommunityEventProvider` source each codec's Jackson `ObjectMapper` through the seam instead of a hardcoded `new ObjectMapper()`, so an application can (e.g.) register Blackbird for `invokedynamic` accessors on the response-encode hot path. With no customizer registered every mapper is byte-for-byte the prior default; Jackson stays a Community driver detail (The Wall holds) (ADR-052).
+
 ## [0.10.0] — 2026-07-02
 
 Minor release. SPI-additive (pre-1.0; no external consumers). The **Events** subsystem gains its ordering/OCC and codec fundament; **Security** gains a dedicated identity SPI; **HTTP** gains streaming, retry, and boot-path routing. Detail + merge gates: [`docs/release/v0.10.0-release-notes.md`](docs/release/v0.10.0-release-notes.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 Patch release. Community-internal, additive, default byte-identical (no SPI change). Detail: [ADR-052](docs/adr/ADR-052-community-json-mapper-customization-seam.md).
 
 ### Added
-- **Configurable Community JSON mapper** — `eu.exeris.kernel.community.json` `JsonMapperCustomizer` (ServiceLoader) + per-quadrant `JsonMapperScope`; `CommunityHttpProvider` / `CommunityEventProvider` source each codec's Jackson `ObjectMapper` through the seam instead of a hardcoded `new ObjectMapper()`, so an application can (e.g.) register Blackbird for `invokedynamic` accessors on the response-encode hot path. With no customizer registered every mapper is byte-for-byte the prior default; Jackson stays a Community driver detail (The Wall holds) (ADR-052).
+- **Configurable Community JSON mapper** — `eu.exeris.kernel.community.json` `JsonMapperCustomizer` (ServiceLoader) + per-quadrant `JsonMapperScope`; `CommunityHttpProvider` / `CommunityEventProvider` source each codec's Jackson `ObjectMapper` through the seam instead of a hardcoded `new ObjectMapper()`, so an application can (e.g.) register Blackbird for `invokedynamic` accessors on the response-encode hot path. With no customizer registered every mapper is byte-for-byte the prior default; Jackson stays a Community driver detail (The Wall holds). Note: "byte-identical" is about serialized output — each HTTP quadrant now builds its own mapper instead of one shared instance, so per-mapper serializer caches are no longer shared across quadrants (bootstrap/JVM-warmup only) (ADR-052).
 
 ## [0.10.0] — 2026-07-02
 

--- a/docs/adr/ADR-052-community-json-mapper-customization-seam.md
+++ b/docs/adr/ADR-052-community-json-mapper-customization-seam.md
@@ -76,6 +76,12 @@ round-trip that could drift from the bare-constructor defaults. The customizing 
 only when at least one customizer opts in. Pinned by
 `CommunityJsonMappersTest.noCustomizerYieldsByteIdenticalDefaultMapper` across every scope.
 
+"Byte-identical" refers to **serialized output + default configuration**, not object identity: what *does*
+change is that each quadrant now builds its own mapper (§3) instead of the former single shared
+`DEFAULT_MAPPER`, so per-mapper serializer/deserializer caches are no longer shared across the four HTTP
+quadrants. This is a bootstrap-time / JVM-cache-warmup concern only (see the §Trade-offs note), never a
+change to what bytes go on the wire.
+
 ### 3. Provider wiring
 
 `CommunityHttpProvider` sources four mappers (one per HTTP quadrant) and `CommunityEventProvider` one
@@ -146,7 +152,9 @@ supplying its own `JsonMapperCustomizer` + the module dependency + a `META-INF/s
   the providers that now source mappers per scope.
 
 ## Engineering Protocol
-1. **ADR number reserved** in `exeris-docs/adr-index.md` (051) before content — register discipline.
+1. **ADR number reserved** in `exeris-docs/adr-index.md` (052) before content — register discipline.
+   (Originally drafted as 051; renumbered after 051 was concurrently reserved for the PAQS
+   execution-seam — the register-before-content check caught the collision pre-merge.)
 2. **Per-repo, additive.** SPI, drivers, and generated code untouched; no lockstep.
 3. **Tests (Community).** `CommunityJsonMappersTest` (default byte-identical per scope, ordering,
    `appliesTo` filtering, config application) + `CommunityJsonMapperServiceLoaderTest` (discovery via a

--- a/docs/adr/ADR-052-community-json-mapper-customization-seam.md
+++ b/docs/adr/ADR-052-community-json-mapper-customization-seam.md
@@ -1,0 +1,157 @@
+# ADR-052: Community JSON Mapper Customization Seam — `JsonMapperCustomizer` / `JsonMapperScope`
+
+| Attribute       | Value                                                                                                       |
+|:----------------|:------------------------------------------------------------------------------------------------------------|
+| **ADR #**       | **052** (reserved 2026-07-19 in `exeris-docs/adr-index.md`).                                                 |
+| **Status**      | **Accepted** — target **v0.10.1**. Per-repo (`exeris-kernel`); no `exeris-tooling` / enterprise lockstep.   |
+| **Deciders**    | Arkadiusz Przychocki                                                                                         |
+| **Date**        | 2026-07-19                                                                                                   |
+| **Scope**       | kernel/community (per-repo)                                                                                  |
+| **Owning Repo** | `exeris-kernel`                                                                                              |
+| **Compliance**  | The Wall (ADR-006); No Waste Compute; Java-26 idioms (ServiceLoader model, immutable carriers); extends the body/event codec lineage (ADR-009 / ADR-034 / ADR-036 / ADR-046) |
+
+## Context
+
+The `{request,response} × {encode,decode}` HTTP body-codec matrix (ADR-009 / ADR-034 / ADR-036) and
+the event-payload codec (ADR-046) are complete tier-neutral SPI seams, and every concrete Community
+driver already accepts an **injected** `tools.jackson.databind.ObjectMapper` in its constructor:
+
+- `JsonBodyEncoder(ObjectMapper)` — response encode (0.5.0)
+- `CommunityJsonRequestBodyEncoder(ObjectMapper)` — request encode (ADR-034)
+- `CommunityJsonResponseBodyDecoder(ObjectMapper)` — response decode (ADR-034)
+- `CommunityJsonRequestBodyDecoder(ObjectMapper)` — request decode (ADR-036)
+- `CommunityJsonEventPayloadCodec(ObjectMapper)` — events (ADR-046)
+
+The gap is **one layer below the SPI**: the providers that assemble these drivers
+(`CommunityHttpProvider`, `CommunityEventProvider`) fed them a hardcoded `new ObjectMapper()` — a bare
+mapper with no customization seam. That default uses Jackson's shared `MethodHandle`-based property
+accessors: because one `MethodHandle` field is reused across all properties and types, the accessor
+call-site is **megamorphic** and the JIT does not inline it, which benchmarks show costing a material
+slice of response-serialization CPU on the `exchange.respond(status, payload)` hot path. The classic
+remedy is the Blackbird module (`jackson-module-blackbird`), which emits a dedicated `invokedynamic`
+call-site per property via `LambdaMetafactory` — monomorphic, C2-inlineable — but there was **no way to
+register it** (or any module / feature) on the kernel-owned mapper. The application-owned `ObjectMapper`
+in a handler is a different object on a different path; it cannot influence the provider's codecs.
+
+This decision does **not** add a codec quadrant and changes **no** SPI type, driver class, or generated
+code. It records how the Community tier now *sources* the mapper it injects.
+
+## Decision
+
+**Introduce a Community-internal customization seam so the providers source each codec's `ObjectMapper`
+through a `ServiceLoader`-discovered `JsonMapperCustomizer` chain instead of `new ObjectMapper()`, scoped
+per codec quadrant. The change is strictly additive and default byte-identical; Jackson stays a Community
+driver detail (The Wall holds — no SPI type sees `ObjectMapper` or the seam).**
+
+### 1. Seam (new, in `eu.exeris.kernel.community.json`)
+
+A new leaf package shared by `community.http` and `community.events` (placing it under `community.http`
+would force `community.events` to depend on `community.http` — a subsystem inversion):
+
+```java
+public enum JsonMapperScope {
+    HTTP_RESPONSE_ENCODE, HTTP_REQUEST_ENCODE, HTTP_RESPONSE_DECODE, HTTP_REQUEST_DECODE, EVENTS
+}
+
+public interface JsonMapperCustomizer {                       // discovered via ServiceLoader
+    default boolean appliesTo(JsonMapperScope scope) { return true; }
+    void customize(JsonMapperScope scope, JsonMapper.Builder builder);   // Jackson-3 immutable-mapper idiom
+    default int order() { return 0; }                          // ascending; later overrides earlier
+}
+
+public final class CommunityJsonMappers {
+    public static ObjectMapper forScope(JsonMapperScope scope);           // applies discovered customizers
+}
+```
+
+The signature takes a Jackson-3 `JsonMapper.Builder` because a Jackson-3 `ObjectMapper` is **immutable
+once built** — all module/feature configuration must happen on the builder. Discovery order from
+`ServiceLoader` is unspecified, so `order()` makes multi-customizer resolution deterministic.
+
+### 2. Default preservation (byte-identical)
+
+`CommunityJsonMappers.forScope(scope)` returns a plain `new ObjectMapper()` whenever **no** discovered
+customizer `appliesTo(scope)` — the exact pre-0.10.1 object, with no `JsonMapper.builder().build()`
+round-trip that could drift from the bare-constructor defaults. The customizing builder path is entered
+only when at least one customizer opts in. Pinned by
+`CommunityJsonMappersTest.noCustomizerYieldsByteIdenticalDefaultMapper` across every scope.
+
+### 3. Provider wiring
+
+`CommunityHttpProvider` sources four mappers (one per HTTP quadrant) and `CommunityEventProvider` one
+(`EVENTS`), each via `forScope(...)`, replacing the single shared `DEFAULT_MAPPER`. Building per-scope
+(five default mappers at bootstrap instead of one shared) is off the hot path and immaterial; it is what
+lets a customizer target, e.g., only `HTTP_RESPONSE_ENCODE` (the benchmarked hot path) without touching
+decode.
+
+### 4. No client-facade scope; Blackbird is application-supplied
+
+There is deliberately **no** `WEB_CLIENT` scope. `KernelWebClient` lives in `exeris-kernel-core` and is
+constructed **explicitly** by applications with their chosen registries (ADR-034 §322), so a per-instance
+client mapper is already an application capability — an app that needs 2–3 clients with different mappers
+builds each client's registries with its own `ObjectMapper` today, no new surface required. The
+provider-exposed default client codecs are covered by `HTTP_REQUEST_ENCODE` + `HTTP_RESPONSE_DECODE`.
+
+Community ships **neither** `jackson-module-blackbird` **nor** a Blackbird customizer: with nothing
+registered the default is unchanged, and the artifact is not pulled unless an application opts in by
+supplying its own `JsonMapperCustomizer` + the module dependency + a `META-INF/services` entry.
+
+## Alternatives considered
+
+- **A `JsonMapper.Builder`-per-property config field on `HttpConfig` / an SPI carrier.** Rejected — a hard
+  The Wall breach. `HttpConfig`'s own Javadoc forbids implementation tuning in the record; `ObjectMapper`
+  is a `tools.jackson` type that must never enter `exeris-kernel-spi`.
+- **A named strategy knob (`-Dexeris.http.json.accessor=blackbird|default`) read at class-init.** Viable
+  (there is precedent: `http.stream.creditWindowBytes` is read directly from a system property), but it
+  is a narrow switch — it only toggles a fixed Community-shipped strategy, forcing Blackbird to become a
+  (optional) Community dependency and requiring reflective/optional loading. The ServiceLoader seam gives
+  full, open-ended configuration with no Community Jackson-module dependency.
+- **Jackson-3 module auto-discovery (`JsonMapper.builder().findAndAddModules()`).** Least code — Blackbird
+  would register by mere classpath presence. Rejected as the primary mechanism: it makes serialization
+  behavior an implicit function of classpath contents, the kind of non-determinism the kernel avoids
+  (config.md "deterministic T-0"), and gives the application no control over features or ordering. A
+  customizer may still call `findAndAddModules()` itself if an app wants that behavior explicitly.
+
+## Consequences
+
+### Positive
+- **[+] Closes the customization gap on the response-encode hot path.** An app can register Blackbird (or
+  any module/feature) so property access becomes monomorphic `invokedynamic`, per-scope.
+- **[+] The Wall holds unchanged.** No SPI type, driver class, or generated code changes; `ObjectMapper`
+  and the seam are Community-only. Per-repo — no tooling/enterprise lockstep or link stubs.
+- **[+] Default byte-identical, zero-regression.** No customizer ⇒ the same bare mapper as before,
+  test-pinned per scope.
+- **[+] Uses the sanctioned ServiceLoader model** (Hard Constraints) and needs no Community Jackson-module
+  dependency.
+
+### Trade-offs
+- **[-] Five default mappers at bootstrap** instead of one shared (per-quadrant serializer caches). Boot
+  time only, immaterial; the per-scope split is what enables targeted customization.
+- **[-] A new Community extension surface** (`JsonMapperCustomizer` / `JsonMapperScope`) to keep stable.
+
+### What is NOT in scope
+- **No perf claim is ratified here.** Whether Blackbird actually wins on a given workload is an
+  application choice, validated separately under the JMH/JFR discipline (`exeris-jfr-perf-research`); the
+  seam only makes the choice possible.
+- **No JFR event** for which customizers applied to which scope. A Glass-Box "mapper assembled with N
+  customizers" event is a reasonable follow-up but is not required for this bootstrap-time config step.
+- **No `WEB_CLIENT` scope** (see Decision §4).
+
+## Cross-references
+- ADR-006 — The Wall — `ObjectMapper` / the customizer seam stay a Community driver detail.
+- ADR-009 / ADR-034 / ADR-036 — the HTTP body-codec matrix whose drivers already take an injected mapper.
+- ADR-046 — the event-payload codec whose driver this seam also feeds.
+- `exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/` — the seam.
+- `exeris-kernel-community/.../http/CommunityHttpProvider.java`, `.../events/CommunityEventProvider.java` —
+  the providers that now source mappers per scope.
+
+## Engineering Protocol
+1. **ADR number reserved** in `exeris-docs/adr-index.md` (051) before content — register discipline.
+2. **Per-repo, additive.** SPI, drivers, and generated code untouched; no lockstep.
+3. **Tests (Community).** `CommunityJsonMappersTest` (default byte-identical per scope, ordering,
+   `appliesTo` filtering, config application) + `CommunityJsonMapperServiceLoaderTest` (discovery via a
+   real `META-INF/services` no-op customizer). No `Abstract*Tck` — the seam is Community-internal, not an
+   SPI contract.
+4. **Docs.** `docs/subsystems/http.md` and `docs/subsystems/events.md` note the seam.
+5. **Release.** Lands on `feature/v0101-configurable-json-mapper` off `main`; forward-ported to
+   `development/0.11.0`.

--- a/docs/release/v0.10.1-release-notes.md
+++ b/docs/release/v0.10.1-release-notes.md
@@ -1,0 +1,54 @@
+# Exeris Kernel v0.10.1 — Release Notes
+
+| | |
+|:--|:--|
+| **Version** | 0.10.1 |
+| **Date** | 2026-07-19 |
+| **Predecessor** | 0.10.0 |
+| **Framing** | Pre-1.0 / TRL-3. Patch release: additive, SPI-unchanged, default behaviour byte-for-byte preserved. Per-surface semver policy: [`docs/stability-matrix.md`](../stability-matrix.md). |
+
+## 1. Headline
+
+v0.10.1 is a single-feature patch: the **Community JSON mapper is now customizable** ([ADR-052](../adr/ADR-052-community-json-mapper-customization-seam.md)). Until now `CommunityHttpProvider` and `CommunityEventProvider` fed every JSON codec a hardcoded `new ObjectMapper()`, so there was no way to tune the kernel's own serialization — most notably no way to register the Blackbird module and turn the shared, megamorphic `MethodHandle` property accessor on the response-encode hot path into monomorphic, C2-inlineable `invokedynamic` call-sites. This release adds a `ServiceLoader`-discovered customization seam for that mapper, entirely within the Community tier. **Nothing changes by default** — with no customizer registered, every mapper is byte-for-byte the 0.10.0 default.
+
+## 2. What landed
+
+### 2.1 Community JSON mapper customization seam — ADR-052 (#239)
+A new leaf package `eu.exeris.kernel.community.json`:
+- **`JsonMapperCustomizer`** — a `@FunctionalInterface` discovered via `ServiceLoader`; `customize(JsonMapperScope, JsonMapper.Builder)` operates on a Jackson-3 builder (a built `ObjectMapper` is immutable), with `appliesTo(scope)` narrowing and `order()` for deterministic multi-customizer application.
+- **`JsonMapperScope`** — the five per-quadrant scopes the seam covers: `HTTP_RESPONSE_ENCODE`, `HTTP_REQUEST_ENCODE`, `HTTP_RESPONSE_DECODE`, `HTTP_REQUEST_DECODE`, `EVENTS`.
+- **`CommunityJsonMappers.forScope(scope)`** — assembles the mapper: a plain `new ObjectMapper()` when no customizer applies (exact prior default), the builder path only when one opts in.
+
+`CommunityHttpProvider` (four HTTP quadrants) and `CommunityEventProvider` (`EVENTS`) now source each codec's mapper through the seam. The codec **drivers were already mapper-injectable** (ADR-034/036/046) — this fills the one remaining gap, the provider hardcoding the mapper it injects.
+
+There is deliberately **no client-facade scope**: `KernelWebClient` is application-constructed with its own registries (ADR-034), so a per-instance client mapper is already an application capability.
+
+## 3. SPI surface delta
+- **Added:** none. This is a Community-tier internal seam — `ObjectMapper` and the customizer types never enter `exeris-kernel-spi` (The Wall holds). No driver class or generated code changed.
+- **Removed:** none.
+
+## 4. Behaviour / performance notes
+- **Default byte-identical.** No customizer registered ⇒ serialized output and default configuration are exactly as in 0.10.0 (test-pinned per scope).
+- **Instance sharing changed (bootstrap only).** Each HTTP quadrant now builds its own mapper instead of one shared `DEFAULT_MAPPER`, so per-mapper serializer/deserializer caches are no longer shared across quadrants. This is a boot-time / JVM-warmup concern, never a change to wire bytes.
+- **Blackbird is application-supplied.** Community ships neither `jackson-module-blackbird` nor a Blackbird customizer; an application opts in by adding the dependency + its own `JsonMapperCustomizer` + a `META-INF/services` entry. Whether Blackbird wins on a given workload is an application choice validated separately under JMH/JFR — the seam only makes the choice possible.
+
+## 5. Quality and gate posture
+- Full `mvn clean install` green across all reactor modules, lint-gated (Checkstyle + PMD, no skip flags).
+- New Community tests: `CommunityJsonMappersTest` (byte-identical default per scope, `order()` sorting, `appliesTo` filtering, config application) + `CommunityJsonMapperServiceLoaderTest` (real `ServiceLoader` discovery via a `META-INF/services` fixture).
+- `CommunityHttpProviderLoopbackTckTest` — real HTTP round-trip through the seam-built encoder (end-to-end byte-identical serialization).
+- `ExerisArchitectureTest` (The Wall guard) green. No new `Abstract*Tck` — no observable SPI behaviour changed.
+
+## 6. Migration / upgrade notes (v0.10.0 → v0.10.1)
+- **No action required.** Purely additive; existing deployments behave identically unless they register a `JsonMapperCustomizer`.
+- **To customize:** implement `eu.exeris.kernel.community.json.JsonMapperCustomizer`, declare it in `META-INF/services/eu.exeris.kernel.community.json.JsonMapperCustomizer`, and (for Blackbird) add `tools.jackson.module:jackson-module-blackbird` to your application POM.
+
+## 7. Release-cut checklist
+- [x] `CHANGELOG.md` `[0.10.1]` entry pointing here.
+- [x] ADR-052 accepted; number reserved before content (exeris-docs #34).
+- [x] Full reactor `mvn clean install` green at 0.10.1; The Wall guard green.
+- [x] Version bumped `0.10.0` → `0.10.1` across the reactor (PR #239).
+- [ ] Tag `v0.10.1` cut on `main` after merge.
+- [ ] Feature forward-ported to `development/0.11.0` (code only; that line stays `0.11.0-SNAPSHOT`).
+
+## 8. Acknowledgements
+Open-core kernel; pre-1.0 university implementation project. Per-PR detail in the git log; the roadmap source of truth is [`docs/ROADMAP.md`](../ROADMAP.md).

--- a/docs/release/v0.10.1-release-notes.md
+++ b/docs/release/v0.10.1-release-notes.md
@@ -44,7 +44,7 @@ There is deliberately **no client-facade scope**: `KernelWebClient` is applicati
 
 ## 7. Release-cut checklist
 - [x] `CHANGELOG.md` `[0.10.1]` entry pointing here.
-- [x] ADR-052 accepted; number reserved before content (exeris-docs #34).
+- [x] ADR-052 accepted; number reserved before content in `exeris-docs/adr-index.md`.
 - [x] Full reactor `mvn clean install` green at 0.10.1; The Wall guard green.
 - [x] Version bumped `0.10.0` → `0.10.1` across the reactor (PR #239).
 - [ ] Tag `v0.10.1` cut on `main` after merge.

--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -78,6 +78,14 @@ operates on local memory, a PostgreSQL partition, or a Kafka cluster. (The SPI i
   publisher emits `EventPayload.empty()`); the `exeris-tooling` publisher rewrite is the remaining lockstep.
   See `docs/adr/ADR-046-event-payload-codec-spi.md`.
 
+- **JSON mapper customization (since v0.10.1, ADR-052).** `CommunityEventProvider` sources the
+  `CommunityJsonEventPayloadCodec`'s `tools.jackson` `ObjectMapper` through the `EVENTS` scope of the
+  Community customization seam (`eu.exeris.kernel.community.json.CommunityJsonMappers.forScope(...)`)
+  rather than a hardcoded `new ObjectMapper()`. An application-registered `JsonMapperCustomizer`
+  (ServiceLoader) can tune the event-payload mapper (modules/features); with none registered it is
+  byte-for-byte the pre-0.10.1 default. Jackson stays a Community driver detail — the seam never enters
+  SPI. See `docs/adr/ADR-052-community-json-mapper-customization-seam.md`.
+
 **Not yet implemented (later):**
 
 - Per-subscription retry configuration on `EventBus`.

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -159,6 +159,21 @@ Current `exeris-kernel-core` HTTP package focuses on codec/wire primitives:
 - `CommunityHttpLifecycleEvent` (JFR)
 - `eu.exeris.kernel.community.http.client.CommunityWebClient` + `WebClientException` (since v0.8 Sprint 2, ADR-026) — typed HTTP verbs + Jackson 3 JSON binding façade on top of `HttpClientEngine`; the SPI surface consumed by `exeris-tooling`'s `KernelClientGenerator` for typed per-entity clients.
 
+### JSON mapper customization (since v0.10.1 — [ADR-052](../adr/ADR-052-community-json-mapper-customization-seam.md))
+
+The Community JSON codecs (`JsonBodyEncoder` + the three ADR-034/036 body codecs) each accept an
+injected `tools.jackson` `ObjectMapper`. Since v0.10.1 `CommunityHttpProvider` sources that mapper
+**per codec quadrant** through the customization seam in `eu.exeris.kernel.community.json`
+(`CommunityJsonMappers.forScope(JsonMapperScope)`), instead of a single hardcoded `new ObjectMapper()`.
+Applications register a `ServiceLoader`-discovered `JsonMapperCustomizer` to tune the mapper — e.g. add
+the Blackbird module so response-body property access compiles to monomorphic `invokedynamic` call-sites
+instead of the shared megamorphic `MethodHandle` accessor on the `respond()` hot path. With **no**
+customizer registered every mapper is byte-for-byte the pre-0.10.1 default; Jackson stays a Community
+driver detail (The Wall — the seam and `ObjectMapper` never enter SPI). Scopes: `HTTP_RESPONSE_ENCODE`,
+`HTTP_REQUEST_ENCODE`, `HTTP_RESPONSE_DECODE`, `HTTP_REQUEST_DECODE` (events uses `EVENTS`). There is no
+web-client scope — `KernelWebClient` is app-constructed with its own registries (ADR-034), so a
+per-instance client mapper is already an application capability.
+
 ### HTTP/2 stream admission (since v0.8 Sprint 5, HTTP-112)
 
 `Http2SessionContext.admitClientStreamId(int)` enforces two RFC 7540 invariants that the Community h2c session previously did not validate:

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.10.0</version>
+		<version>0.10.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community-kafka</artifactId>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/CommunityEventProvider.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/events/CommunityEventProvider.java
@@ -13,7 +13,8 @@ import eu.exeris.kernel.spi.events.EventEngineConfig;
 import eu.exeris.kernel.spi.events.EventProvider;
 import eu.exeris.kernel.spi.events.codec.EventPayloadCodecRegistry;
 import eu.exeris.kernel.spi.exceptions.events.EventProviderException;
-import tools.jackson.databind.ObjectMapper;
+import eu.exeris.kernel.community.json.CommunityJsonMappers;
+import eu.exeris.kernel.community.json.JsonMapperScope;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,12 +24,13 @@ public final class CommunityEventProvider implements EventProvider {
     private static final String PROVIDER_ID = "community";
     private static final String PROVIDER_NAME = "ExerisCommunity/Events";
 
-    // Default JSON codec (ADR-046). Mirrors CommunityHttpProvider's static mapper + registry:
-    // Jackson stays a Community driver detail behind The Wall; the registry is exposed to the
-    // bootstrapper as an SPI type and bound into KernelProviders.EVENT_PAYLOAD_CODEC_REGISTRY.
-    private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+    // Default JSON codec (ADR-046). Jackson stays a Community driver detail behind The Wall; the
+    // registry is exposed to the bootstrapper as an SPI type and bound into
+    // KernelProviders.EVENT_PAYLOAD_CODEC_REGISTRY. The mapper is sourced per-scope through the
+    // ADR-052 customization seam (bare default when no JsonMapperCustomizer is registered).
     private static final EventPayloadCodecRegistry PAYLOAD_CODEC_REGISTRY =
-            EventPayloadCodecRegistry.of(List.of(new CommunityJsonEventPayloadCodec(DEFAULT_MAPPER)));
+            EventPayloadCodecRegistry.of(List.of(new CommunityJsonEventPayloadCodec(
+                    CommunityJsonMappers.forScope(JsonMapperScope.EVENTS))));
 
     @Override
     public String providerName() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpProvider.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpProvider.java
@@ -16,7 +16,8 @@ import eu.exeris.kernel.spi.http.HttpRequestBodyEncoderRegistry;
 import eu.exeris.kernel.spi.http.HttpResponseBodyDecoderRegistry;
 import eu.exeris.kernel.spi.http.HttpResponseBodyEncoderRegistry;
 import eu.exeris.kernel.spi.http.HttpServerEngine;
-import tools.jackson.databind.ObjectMapper;
+import eu.exeris.kernel.community.json.CommunityJsonMappers;
+import eu.exeris.kernel.community.json.JsonMapperScope;
 
 import java.util.List;
 import java.util.Objects;
@@ -26,17 +27,23 @@ public final class CommunityHttpProvider implements HttpProvider {
 
     private static final String PROVIDER_ID = "community-http";
     private static final String PROVIDER_NAME = "ExerisCommunity/NativeTcpHttp";
-    private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+
+    // Each JSON codec sources its Jackson mapper per-scope through the ADR-052 customization seam.
+    // With no JsonMapperCustomizer registered, every scope yields a bare default mapper (unchanged).
     private static final HttpResponseBodyEncoderRegistry ENCODER_REGISTRY = buildDefaultRegistry();
     private static final HttpRequestBodyEncoderRegistry REQUEST_BODY_ENCODER_REGISTRY =
-            HttpRequestBodyEncoderRegistry.of(List.of(new CommunityJsonRequestBodyEncoder(DEFAULT_MAPPER)));
+            HttpRequestBodyEncoderRegistry.of(List.of(new CommunityJsonRequestBodyEncoder(
+                    CommunityJsonMappers.forScope(JsonMapperScope.HTTP_REQUEST_ENCODE))));
     private static final HttpResponseBodyDecoderRegistry RESPONSE_BODY_DECODER_REGISTRY =
-            HttpResponseBodyDecoderRegistry.of(List.of(new CommunityJsonResponseBodyDecoder(DEFAULT_MAPPER)));
+            HttpResponseBodyDecoderRegistry.of(List.of(new CommunityJsonResponseBodyDecoder(
+                    CommunityJsonMappers.forScope(JsonMapperScope.HTTP_RESPONSE_DECODE))));
     private static final HttpRequestBodyDecoderRegistry REQUEST_BODY_DECODER_REGISTRY =
-            HttpRequestBodyDecoderRegistry.of(List.of(new CommunityJsonRequestBodyDecoder(DEFAULT_MAPPER)));
+            HttpRequestBodyDecoderRegistry.of(List.of(new CommunityJsonRequestBodyDecoder(
+                    CommunityJsonMappers.forScope(JsonMapperScope.HTTP_REQUEST_DECODE))));
 
     private static HttpResponseBodyEncoderRegistry buildDefaultRegistry() {
-        JsonBodyEncoder encoder = new JsonBodyEncoder(DEFAULT_MAPPER);
+        JsonBodyEncoder encoder =
+                new JsonBodyEncoder(CommunityJsonMappers.forScope(JsonMapperScope.HTTP_RESPONSE_ENCODE));
         return payloadType -> encoder.supports(payloadType) ? encoder : null;
     }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/CommunityJsonMappers.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/CommunityJsonMappers.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+/**
+ * Assembles the {@code tools.jackson} JSON mapper for a given {@link JsonMapperScope}, applying any
+ * {@link JsonMapperCustomizer}s discovered via {@link ServiceLoader} (ADR-052).
+ *
+ * <p>The concrete Community codec drivers accept an injected {@link ObjectMapper} in their
+ * constructors; the providers call {@link #forScope(JsonMapperScope)} to obtain that mapper instead
+ * of hardcoding {@code new ObjectMapper()}, giving applications a customization seam without any
+ * change to SPI, the driver classes, or generated code.
+ *
+ * <h2>Default preservation</h2>
+ * <p>When no discovered customizer {@linkplain JsonMapperCustomizer#appliesTo(JsonMapperScope)
+ * applies} to a scope, this returns a plain {@code new ObjectMapper()} — byte-for-byte the
+ * pre-0.10.1 default, with no builder round-trip that could drift from the bare-constructor
+ * defaults. The customizing {@link JsonMapper#builder() builder} path is taken only when at least
+ * one customizer opts in.
+ *
+ * @since 0.10.1
+ */
+public final class CommunityJsonMappers {
+
+    /** Discovered once at class-init; immutable thereafter (single-writer JLS static-init guarantee). */
+    private static final List<JsonMapperCustomizer> CUSTOMIZERS = discover();
+
+    private CommunityJsonMappers() {
+    }
+
+    /**
+     * Builds the JSON mapper for {@code scope}, applying any registered customizers.
+     *
+     * @param scope the codec scope to assemble a mapper for; never {@code null}
+     * @return a configured mapper; a bare default when no customizer applies to {@code scope}
+     */
+    public static ObjectMapper forScope(JsonMapperScope scope) {
+        return apply(scope, CUSTOMIZERS);
+    }
+
+    /**
+     * Core assembly logic against an explicit customizer list (package-private for testability —
+     * bypasses {@link ServiceLoader}).
+     *
+     * @param scope       the codec scope; never {@code null}
+     * @param customizers the candidate customizers; never {@code null}
+     * @return the assembled mapper
+     */
+    /* default */ static ObjectMapper apply(JsonMapperScope scope, List<JsonMapperCustomizer> customizers) {
+        Objects.requireNonNull(scope, "scope must not be null");
+        List<JsonMapperCustomizer> applicable = customizers.stream()
+                .filter(customizer -> customizer.appliesTo(scope))
+                .sorted(Comparator.comparingInt(JsonMapperCustomizer::order))
+                .toList();
+        if (applicable.isEmpty()) {
+            // No opt-in for this scope: preserve the exact pre-0.10.1 default mapper.
+            return new ObjectMapper();
+        }
+        // A misbehaving customizer fails fast at bootstrap; the customizer class shows in the trace.
+        JsonMapper.Builder builder = JsonMapper.builder();
+        for (JsonMapperCustomizer customizer : applicable) {
+            customizer.customize(scope, builder);
+        }
+        return builder.build();
+    }
+
+    /**
+     * The customizers discovered via {@link ServiceLoader} (package-private for testability).
+     *
+     * @return an immutable snapshot of the discovered customizers
+     */
+    /* default */ static List<JsonMapperCustomizer> discovered() {
+        return CUSTOMIZERS;
+    }
+
+    private static List<JsonMapperCustomizer> discover() {
+        List<JsonMapperCustomizer> found = new ArrayList<>();
+        for (JsonMapperCustomizer customizer : ServiceLoader.load(JsonMapperCustomizer.class)) {
+            found.add(customizer);
+        }
+        return List.copyOf(found);
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperCustomizer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperCustomizer.java
@@ -77,6 +77,11 @@ public interface JsonMapperCustomizer {
     /**
      * Application order relative to other customizers applied to the same scope; lower runs first.
      *
+     * <p>Customizers with <strong>equal</strong> {@code order()} are applied in
+     * {@link java.util.ServiceLoader} discovery order, which is unspecified — so when registering
+     * two or more customizers that touch the <em>same</em> scope, assign distinct {@code order()}
+     * values to make their relative effect deterministic.
+     *
      * @return the order value (default {@code 0})
      */
     default int order() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperCustomizer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperCustomizer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Application-supplied hook for customizing the {@code tools.jackson} JSON mapper that the
+ * Community JSON codecs use, discovered via {@link java.util.ServiceLoader}.
+ *
+ * <h2>Why this exists</h2>
+ * <p>The Community codec drivers ({@code JsonBodyEncoder},
+ * {@code CommunityJsonRequestBodyEncoder}, {@code CommunityJsonResponseBodyDecoder},
+ * {@code CommunityJsonRequestBodyDecoder}, {@code CommunityJsonEventPayloadCodec}) already accept
+ * an injected {@link tools.jackson.databind.ObjectMapper}, but the providers assembling them
+ * previously hardcoded {@code new ObjectMapper()} — a bare mapper with default {@code MethodHandle}
+ * property accessors. Registering a customizer lets an application tune that mapper per
+ * {@link JsonMapperScope}, for example adding the Blackbird module
+ * ({@code jackson-module-blackbird}) so property access compiles to monomorphic
+ * {@code invokedynamic} call-sites instead of the shared, megamorphic {@code MethodHandle}
+ * accessor on the response-encode hot path (ADR-052).
+ *
+ * <h2>Registration</h2>
+ * <p>Provide an implementation on the application classpath and declare it in
+ * {@code META-INF/services/eu.exeris.kernel.community.json.JsonMapperCustomizer}. Community ships
+ * no customizer and pulls no optional Jackson module dependency: with none registered, every
+ * mapper is byte-for-byte the pre-0.10.1 default (see
+ * {@link CommunityJsonMappers#forScope(JsonMapperScope)}).
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@link #customize(JsonMapperScope, JsonMapper.Builder)} operates on a Jackson-3
+ *       {@link JsonMapper.Builder} — the mapper is immutable once built, so all configuration
+ *       (modules, features) must happen on the builder.</li>
+ *   <li>{@link #appliesTo(JsonMapperScope)} narrows a customizer to specific scopes; scopes no
+ *       customizer applies to keep the exact default mapper.</li>
+ *   <li>{@link #order()} orders customizers ascending when several apply to one scope; a
+ *       later customizer observes and may override an earlier one's builder state. This makes
+ *       resolution deterministic despite the unspecified {@code ServiceLoader} iteration order.</li>
+ *   <li>Applied once per scope at provider construction (bootstrap), never on the request path.</li>
+ * </ul>
+ *
+ * @since 0.10.1
+ */
+@FunctionalInterface
+public interface JsonMapperCustomizer {
+
+    /**
+     * Whether this customizer participates in mapper assembly for the given scope.
+     *
+     * @param scope the codec scope the mapper is being built for; never {@code null}
+     * @return {@code true} to have {@link #customize(JsonMapperScope, JsonMapper.Builder)} invoked
+     *         for this scope; the default applies the customizer to every scope
+     */
+    default boolean appliesTo(JsonMapperScope scope) {
+        return true;
+    }
+
+    /**
+     * Configures the mapper builder for the given scope.
+     *
+     * <p>Invoked only when {@link #appliesTo(JsonMapperScope)} returned {@code true} for
+     * {@code scope}. Implementations that target several scopes may branch on {@code scope} to
+     * configure each differently.
+     *
+     * @param scope   the codec scope being assembled; never {@code null}
+     * @param builder the Jackson-3 mapper builder to configure; never {@code null}
+     */
+    void customize(JsonMapperScope scope, JsonMapper.Builder builder);
+
+    /**
+     * Application order relative to other customizers applied to the same scope; lower runs first.
+     *
+     * @return the order value (default {@code 0})
+     */
+    default int order() {
+        return 0;
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperScope.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/json/JsonMapperScope.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+/**
+ * Identifies which Community JSON codec a {@link JsonMapperCustomizer} is being invoked for.
+ *
+ * <p>The scopes mirror the {@code {request,response} × {encode,decode}} HTTP body-codec matrix
+ * (ADR-009 / ADR-034 / ADR-036) plus the event-payload codec (ADR-046). Each value corresponds
+ * to exactly one provider-built default codec whose backing {@code tools.jackson} mapper is
+ * assembled by {@link CommunityJsonMappers#forScope(JsonMapperScope)}:
+ *
+ * <ul>
+ *   <li>{@link #HTTP_RESPONSE_ENCODE} — server-side response body encoder
+ *       ({@code JsonBodyEncoder}); the {@code exchange.respond(status, payload)} hot path.</li>
+ *   <li>{@link #HTTP_REQUEST_ENCODE} — client-side request body encoder
+ *       ({@code CommunityJsonRequestBodyEncoder}).</li>
+ *   <li>{@link #HTTP_RESPONSE_DECODE} — client-side response body decoder
+ *       ({@code CommunityJsonResponseBodyDecoder}).</li>
+ *   <li>{@link #HTTP_REQUEST_DECODE} — server-side request body decoder
+ *       ({@code CommunityJsonRequestBodyDecoder}).</li>
+ *   <li>{@link #EVENTS} — domain-event payload codec
+ *       ({@code CommunityJsonEventPayloadCodec}).</li>
+ * </ul>
+ *
+ * <p>There is no dedicated client-facade scope: {@code KernelWebClient} lives in
+ * {@code exeris-kernel-core} and is constructed explicitly by applications with their chosen
+ * registries (ADR-034), so a per-instance client mapper is already an application capability —
+ * an application simply builds its own codec with its own mapper. The provider-exposed default
+ * client codecs are covered by {@link #HTTP_REQUEST_ENCODE} + {@link #HTTP_RESPONSE_DECODE}.
+ *
+ * @since 0.10.1
+ */
+public enum JsonMapperScope {
+
+    /** Server-side HTTP response body encode ({@code JsonBodyEncoder}). */
+    HTTP_RESPONSE_ENCODE,
+
+    /** Client-side HTTP request body encode ({@code CommunityJsonRequestBodyEncoder}). */
+    HTTP_REQUEST_ENCODE,
+
+    /** Client-side HTTP response body decode ({@code CommunityJsonResponseBodyDecoder}). */
+    HTTP_RESPONSE_DECODE,
+
+    /** Server-side HTTP request body decode ({@code CommunityJsonRequestBodyDecoder}). */
+    HTTP_REQUEST_DECODE,
+
+    /** Domain-event payload codec ({@code CommunityJsonEventPayloadCodec}). */
+    EVENTS
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/CommunityJsonMapperServiceLoaderTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/CommunityJsonMapperServiceLoaderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the ADR-052 seam wires {@link java.util.ServiceLoader} discovery correctly: the
+ * {@link NoopJsonMapperCustomizer} registered on the test classpath (see
+ * {@code src/test/resources/META-INF/services/eu.exeris.kernel.community.json.JsonMapperCustomizer})
+ * is found by {@link CommunityJsonMappers}.
+ *
+ * <p>The test customizer's {@link JsonMapperCustomizer#appliesTo(JsonMapperScope)} returns
+ * {@code false} for every scope, so it is discovered but never applied — mappers produced during
+ * the module's test run stay byte-for-byte default and no other test is perturbed.
+ */
+class CommunityJsonMapperServiceLoaderTest {
+
+    @Test
+    void registeredCustomizerIsDiscoveredViaServiceLoader() {
+        assertThat(CommunityJsonMappers.discovered())
+                .anySatisfy(customizer -> assertThat(customizer).isInstanceOf(NoopJsonMapperCustomizer.class));
+    }
+
+    @Test
+    void discoveredButNonApplicableCustomizerLeavesMappersAtDefault() {
+        // forScope goes through the real discovered list; the noop applies to nothing, so the
+        // provider mappers stay identical to the bare default.
+        var viaSeam = CommunityJsonMappers.forScope(JsonMapperScope.HTTP_RESPONSE_ENCODE)
+                .writeValueAsBytes(java.util.Map.of("k", "v"));
+        var viaBare = new tools.jackson.databind.ObjectMapper()
+                .writeValueAsBytes(java.util.Map.of("k", "v"));
+
+        assertThat(viaSeam).isEqualTo(viaBare);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/CommunityJsonMappersTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/CommunityJsonMappersTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the ADR-052 mapper-assembly logic ({@link CommunityJsonMappers#apply}),
+ * exercised against explicit customizer lists (no {@link java.util.ServiceLoader}).
+ */
+class CommunityJsonMappersTest {
+
+    private record Sample(String name, int value) {
+    }
+
+    private static final Sample SAMPLE = new Sample("widget", 42);
+
+    @ParameterizedTest
+    @EnumSource(JsonMapperScope.class)
+    void noCustomizerYieldsByteIdenticalDefaultMapper(JsonMapperScope scope) {
+        byte[] viaSeam = CommunityJsonMappers.apply(scope, List.of()).writeValueAsBytes(SAMPLE);
+        byte[] viaBareMapper = new ObjectMapper().writeValueAsBytes(SAMPLE);
+
+        assertThat(viaSeam).isEqualTo(viaBareMapper);
+    }
+
+    @Test
+    void applicableCustomizerConfiguresTheBuilder() {
+        JsonMapperCustomizer indent = new FeatureCustomizer(0, s -> true, SerializationFeature.INDENT_OUTPUT, true);
+
+        byte[] out = CommunityJsonMappers.apply(JsonMapperScope.HTTP_RESPONSE_ENCODE, List.of(indent))
+                .writeValueAsBytes(SAMPLE);
+
+        // INDENT_OUTPUT introduces a newline; the bare default mapper produces a single compact line.
+        assertThat(new String(out)).contains("\n");
+    }
+
+    @Test
+    void customizersApplyInAscendingOrderSoLaterWins() {
+        // Lower order runs first; the higher-order customizer observes and overrides it.
+        JsonMapperCustomizer first = new FeatureCustomizer(10, s -> true, SerializationFeature.INDENT_OUTPUT, false);
+        JsonMapperCustomizer second = new FeatureCustomizer(20, s -> true, SerializationFeature.INDENT_OUTPUT, true);
+
+        // Pass them out of order to prove the helper sorts by order(), not list order.
+        byte[] out = CommunityJsonMappers.apply(JsonMapperScope.EVENTS, List.of(second, first))
+                .writeValueAsBytes(SAMPLE);
+
+        assertThat(new String(out)).contains("\n");
+    }
+
+    @Test
+    void invocationOrderFollowsOrderValue() {
+        List<Integer> log = new ArrayList<>();
+        JsonMapperCustomizer high = new RecordingCustomizer(30, log);
+        JsonMapperCustomizer low = new RecordingCustomizer(5, log);
+        JsonMapperCustomizer mid = new RecordingCustomizer(15, log);
+
+        CommunityJsonMappers.apply(JsonMapperScope.EVENTS, List.of(high, low, mid));
+
+        assertThat(log).containsExactly(5, 15, 30);
+    }
+
+    @Test
+    void nonApplicableScopeKeepsExactDefaultMapper() {
+        // A customizer scoped only to HTTP_RESPONSE_ENCODE must not touch other scopes.
+        JsonMapperCustomizer scoped = new FeatureCustomizer(
+                0, s -> s == JsonMapperScope.HTTP_RESPONSE_ENCODE, SerializationFeature.INDENT_OUTPUT, true);
+
+        byte[] untouched = CommunityJsonMappers.apply(JsonMapperScope.EVENTS, List.of(scoped))
+                .writeValueAsBytes(SAMPLE);
+        byte[] targeted = CommunityJsonMappers.apply(JsonMapperScope.HTTP_RESPONSE_ENCODE, List.of(scoped))
+                .writeValueAsBytes(SAMPLE);
+
+        assertThat(untouched).isEqualTo(new ObjectMapper().writeValueAsBytes(SAMPLE));
+        assertThat(new String(targeted)).contains("\n");
+    }
+
+    // --- test doubles -----------------------------------------------------------------------
+
+    private static final class FeatureCustomizer implements JsonMapperCustomizer {
+        private final int order;
+        private final java.util.function.Predicate<JsonMapperScope> applies;
+        private final SerializationFeature feature;
+        private final boolean enable;
+
+        FeatureCustomizer(int order, java.util.function.Predicate<JsonMapperScope> applies,
+                          SerializationFeature feature, boolean enable) {
+            this.order = order;
+            this.applies = applies;
+            this.feature = feature;
+            this.enable = enable;
+        }
+
+        @Override
+        public boolean appliesTo(JsonMapperScope scope) {
+            return applies.test(scope);
+        }
+
+        @Override
+        public void customize(JsonMapperScope scope, JsonMapper.Builder builder) {
+            builder.configure(feature, enable);
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+
+    private static final class RecordingCustomizer implements JsonMapperCustomizer {
+        private final int order;
+        private final List<Integer> log;
+
+        RecordingCustomizer(int order, List<Integer> log) {
+            this.order = order;
+            this.log = log;
+        }
+
+        @Override
+        public void customize(JsonMapperScope scope, JsonMapper.Builder builder) {
+            log.add(order);
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/NoopJsonMapperCustomizer.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/json/NoopJsonMapperCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.json;
+
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Test-only {@link JsonMapperCustomizer} registered via a {@code META-INF/services} file to verify
+ * {@link java.util.ServiceLoader} discovery (ADR-052). It intentionally applies to no scope, so its
+ * presence on the module test classpath never alters any produced mapper.
+ */
+public final class NoopJsonMapperCustomizer implements JsonMapperCustomizer {
+
+    @Override
+    public boolean appliesTo(JsonMapperScope scope) {
+        return false;
+    }
+
+    @Override
+    public void customize(JsonMapperScope scope, JsonMapper.Builder builder) {
+        // never invoked (appliesTo is always false)
+    }
+}

--- a/exeris-kernel-community/src/test/resources/META-INF/services/eu.exeris.kernel.community.json.JsonMapperCustomizer
+++ b/exeris-kernel-community/src/test/resources/META-INF/services/eu.exeris.kernel.community.json.JsonMapperCustomizer
@@ -1,0 +1,1 @@
+eu.exeris.kernel.community.json.NoopJsonMapperCustomizer

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-diagnostics-cli/pom.xml
+++ b/exeris-kernel-diagnostics-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-diagnostics-cli</artifactId>

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
## What

Makes the Community JSON mapper **configurable** (ADR-052). `CommunityHttpProvider` and
`CommunityEventProvider` previously fed every JSON codec a hardcoded `new ObjectMapper()`, so there was
no way to tune it — e.g. register the Blackbird module so response-body property access compiles to
monomorphic `invokedynamic` call-sites instead of the shared, megamorphic `MethodHandle` accessor on the
`exchange.respond(...)` hot path.

Introduces a `ServiceLoader`-discovered `JsonMapperCustomizer` + a per-quadrant `JsonMapperScope` in the
new leaf package `eu.exeris.kernel.community.json`; the providers now source each codec's mapper via
`CommunityJsonMappers.forScope(...)`.

## Why this shape

- The codec **drivers already accept an injected `ObjectMapper`** (ADR-034/036/046) — the only gap was
  the provider hardcoding the mapper it injects. This PR fills exactly that gap; **no SPI type, driver
  class, or generated code changes**.
- **The Wall holds**: `ObjectMapper` / the seam stay Community-only, never enter SPI. Per-repo — **no
  `exeris-tooling` / enterprise lockstep** and no link stubs.
- **Default byte-identical**: with no customizer registered, `forScope` returns a plain `new ObjectMapper()`
  per scope (no builder round-trip that could drift). Opt-in only.
- **No `WEB_CLIENT` scope**: `KernelWebClient` is app-constructed with its own registries (ADR-034), so a
  per-instance client mapper is already an application capability. Scopes: `HTTP_RESPONSE_ENCODE`,
  `HTTP_REQUEST_ENCODE`, `HTTP_RESPONSE_DECODE`, `HTTP_REQUEST_DECODE`, `EVENTS`.
- Blackbird is **application-supplied** — Community ships neither the dependency nor a customizer.

## Verification

- `mvn -pl exeris-kernel-community clean install` — **BUILD SUCCESS**, no skip flags (`checkstyle:check`
  + `pmd:check` executed).
- New tests **11/11**: `CommunityJsonMappersTest` (byte-identical default per scope, `order()`,
  `appliesTo` filtering, config application) + `CommunityJsonMapperServiceLoaderTest` (ServiceLoader
  discovery via a real `META-INF/services` no-op customizer).
- `CommunityHttpProviderLoopbackTckTest` **2/2** — real HTTP round-trip through the seam-built encoder
  (end-to-end byte-identical serialization).
- `ExerisArchitectureTest` **11/11** — The Wall guard green.
- (The green build predates the `ADR-051 → ADR-052` renumber, which touches only comments/Javadoc/markdown
  — no code identifier changed, so it is compile-neutral.)

## Note on the ADR number

Originally drafted as ADR-051; **renumbered to ADR-052** because ADR-051 was concurrently reserved for the
PAQS execution-seam (exeris-docs #33) — caught pre-merge by the register-before-content discipline. Index
reservation for **052** is in `exeris-docs` (companion PR).

## Release

This PR is release-ready for **0.10.1**:
- Reactor version **flipped `0.10.0` → `0.10.1`** (all module POMs / parent refs; release version, not
  `-SNAPSHOT`) — validated by a full `mvn clean install` (BUILD SUCCESS across all 8 modules, lint-gated).
- `CHANGELOG` `[0.10.1]` dated **2026-07-19** + `docs/release/v0.10.1-release-notes.md` added.

So on merge, `main` is at `0.10.1` and ready for a `v0.10.1` tag — nothing else needs to flip.

## Follow-ups (not in this PR)

- Cut the `v0.10.1` tag on `main` after merge.
- Forward-port to `development/0.11.0` (feature code only — **not** the version bump; that line stays
  `0.11.0-SNAPSHOT`).

Docs: [ADR-052](docs/adr/ADR-052-community-json-mapper-customization-seam.md), `docs/subsystems/http.md`,
`docs/subsystems/events.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
