### PR TITLE
fix(http): stream JSON response encoding into pooled LoanedBuffer

### DIFF
--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -174,6 +174,21 @@ driver detail (The Wall — the seam and `ObjectMapper` never enter SPI). Scopes
 web-client scope — `KernelWebClient` is app-constructed with its own registries (ADR-034), so a
 per-instance client mapper is already an application capability.
 
+### JSON response-body zero-copy encoding (since v0.10.2)
+
+`JsonBodyEncoder.encode` streams Jackson's output **directly into the loaned off-heap response
+segment** via `SegmentSink` — an `OutputStream` over a `LoanedBuffer` that grows to a larger buffer on
+overflow — instead of serializing to a heap `byte[]` and `MemorySegment.copy`-ing it in. This removes a
+per-response heap allocation and a full extra pass over the payload; output is byte-identical and no SPI
+surface changes (an internal Community reimplementation, The Wall holds). The `java.io.OutputStream` is
+the Jackson `writeValue(OutputStream, …)` seam only: no heap buffering happens — each write lands
+straight in the off-heap segment — so this is the zero-copy path *by construction* (the bridge, not a
+buffer), not the `java.io`-on-hot-path case the guardrails warn about. Ownership is single-live-buffer:
+the sink transfers the buffer to the returned `HttpEncodedBody` on success and releases it on every
+failure path. The mirror-image `CommunityJsonRequestBodyEncoder` (client request bodies) still
+materialises-then-copies; converting it is the No-Waste-Compute follow-up, analogous to the SSE
+zero-copy-emit follow-up above.
+
 ### HTTP/2 stream admission (since v0.8 Sprint 5, HTTP-112)
 
 `Http2SessionContext.admitClientStreamId(int)` enforces two RFC 7540 invariants that the Community h2c session previously did not validate:

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/JsonBodyEncoder.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/JsonBodyEncoder.java
@@ -38,8 +38,10 @@ final class JsonBodyEncoder implements HttpResponseBodyEncoder {
     private static final List<HttpHeader> JSON_HEADERS = List.of(new HttpHeader("content-type", "application/json"));
 
     /**
-     * Initial off-heap buffer size (bytes). Sized to hold a typical JSON response in one shot so the
-     * {@link SegmentSink} grow path is the rare exception, not the rule; larger payloads grow transparently.
+     * Initial off-heap buffer size (bytes) — a conservative default; responses larger than this grow
+     * transparently via {@link SegmentSink} (one intra-buffer copy of the bytes written so far, still far
+     * cheaper than the removed heap {@code byte[]} + full copy). The optimal value is workload-dependent;
+     * tuning it from the real response-size distribution (or making it configurable) is a tracked follow-up.
      */
     private static final int INITIAL_BUFFER_BYTES = 4096;
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/JsonBodyEncoder.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/JsonBodyEncoder.java
@@ -16,13 +16,17 @@ import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * Serializes a payload to JSON and wraps the result in an {@link HttpEncodedBody}
  * backed by a kernel-allocated {@link LoanedBuffer}.
+ *
+ * <p>Jackson streams straight into the network-registered off-heap buffer via
+ * {@link SegmentSink} — no intermediate heap {@code byte[]} and no heap&rarr;off-heap
+ * {@code MemorySegment.copy} per response (No-Waste-Compute; zero-copy transport contract).
+ * The sink grows to a larger buffer if the initial estimate is exceeded.
  *
  * <p>Buffer ownership transfers to the returned encoded body; callers must
  * not close the buffer after calling {@link #encode}.
@@ -32,6 +36,12 @@ import java.util.Objects;
 final class JsonBodyEncoder implements HttpResponseBodyEncoder {
 
     private static final List<HttpHeader> JSON_HEADERS = List.of(new HttpHeader("content-type", "application/json"));
+
+    /**
+     * Initial off-heap buffer size (bytes). Sized to hold a typical JSON response in one shot so the
+     * {@link SegmentSink} grow path is the rare exception, not the rule; larger payloads grow transparently.
+     */
+    private static final int INITIAL_BUFFER_BYTES = 4096;
 
     private final ObjectMapper mapper;
 
@@ -45,17 +55,26 @@ final class JsonBodyEncoder implements HttpResponseBodyEncoder {
     }
 
     @Override
+    // CloseResource: the sink's buffer ownership transfers to the returned HttpEncodedBody on success,
+    // and the finally releases it on every non-committed exit — no path leaks the off-heap loan.
+    @SuppressWarnings("PMD.CloseResource")
     public HttpEncodedBody encode(Object payload, HttpResponseEncodingContext context) {
-        byte[] bytes;
+        SegmentSink sink = new SegmentSink(
+                context.allocator().allocateNetwork(INITIAL_BUFFER_BYTES), context.allocator());
+        boolean committed = false;
         try {
-            bytes = mapper.writeValueAsBytes(payload);
+            mapper.writeValue(sink, payload);
+            sink.setSizeToWritten();
+            HttpEncodedBody body = new HttpEncodedBody(JSON_HEADERS, sink.buffer());
+            committed = true;
+            return body;
         } catch (JacksonException e) {
+            // Do not let a tools.jackson type cross out of the encoder (The Wall — ADR-006).
             throw new IllegalStateException("JSON serialization failed", e);
+        } finally {
+            if (!committed) {
+                sink.discard();
+            }
         }
-
-        LoanedBuffer buf = context.allocator().allocateNetwork(bytes.length);
-        MemorySegment.copy(MemorySegment.ofArray(bytes), 0, buf.segment(), 0, bytes.length);
-        buf.setSize(bytes.length);
-        return new HttpEncodedBody(JSON_HEADERS, buf);
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/SegmentSink.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/SegmentSink.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+
+import java.io.OutputStream;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Objects;
+
+/**
+ * An {@link OutputStream} that writes directly into a kernel-loaned off-heap
+ * {@link MemorySegment}, growing to a larger {@link LoanedBuffer} on overflow.
+ *
+ * <p>Purpose: let a serializer stream bytes <em>straight into</em> a network-registered
+ * segment (e.g. {@code ObjectMapper.writeValue(OutputStream, ...)}), eliminating both the
+ * intermediate heap {@code byte[]} and the heap&rarr;off-heap {@code MemorySegment.copy}
+ * that a materialize-then-copy path pays on every response (No-Waste-Compute). The
+ * {@code java.io.OutputStream} surface here is the serializer bridge only — no heap
+ * buffering happens; each write lands in the off-heap segment.
+ *
+ * <h2>Ownership (unforgiving — off-heap)</h2>
+ * <p>This sink owns exactly one live buffer at a time ({@link #buffer()}). On growth it
+ * allocates the replacement, copies the bytes written so far, then closes the old buffer —
+ * so at most one buffer is ever live. It deliberately does <strong>not</strong> release the
+ * current buffer on {@link #close()} (a serializer may auto-close its output target): the
+ * caller owns the terminal decision — {@link #setSizeToWritten()} then take {@link #buffer()}
+ * on success (ownership transfers to the caller), or {@link #discard()} on any failure.
+ */
+final class SegmentSink extends OutputStream {
+
+    private final MemoryAllocator allocator;
+    private LoanedBuffer buffer;
+    private MemorySegment segment;
+    private long written;
+
+    /* default */ SegmentSink(LoanedBuffer initial, MemoryAllocator allocator) {
+        super();
+        this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
+        this.buffer = Objects.requireNonNull(initial, "initial must not be null");
+        this.segment = initial.segment();
+    }
+
+    @Override
+    public void write(int value) {
+        ensureCapacity(written + 1L);
+        segment.set(ValueLayout.JAVA_BYTE, written, (byte) value);
+        written++;
+    }
+
+    @Override
+    public void write(byte[] data, int off, int len) {
+        Objects.checkFromIndexSize(off, len, data.length);
+        if (len == 0) {
+            return;
+        }
+        ensureCapacity(written + len);
+        MemorySegment.copy(MemorySegment.ofArray(data), off, segment, written, len);
+        written += len;
+    }
+
+    /** No-op: the buffer lifecycle is the caller's decision, not a serializer auto-closing its target. */
+    @Override
+    public void close() {
+        // intentionally empty — see class Javadoc "Ownership".
+    }
+
+    /**
+     * The current live buffer. Ownership transfers to the caller only after
+     * {@link #setSizeToWritten()}; before that, the sink still owns it.
+     *
+     * @return the buffer currently backing this sink
+     */
+    /* default */ LoanedBuffer buffer() {
+        return buffer;
+    }
+
+    /**
+     * Number of bytes written into the buffer so far.
+     *
+     * @return the write cursor in {@code [0, capacity()]}
+     */
+    /* default */ long written() {
+        return written;
+    }
+
+    /** Stamps the current buffer's logical size to the bytes written; call before handing it off. */
+    /* default */ void setSizeToWritten() {
+        buffer.setSize(written);
+    }
+
+    /** Releases the current buffer; call on the failure path so no off-heap memory leaks. */
+    /* default */ void discard() {
+        buffer.close();
+    }
+
+    // CloseResource: `grown` ownership is either transferred to `buffer` or closed on the failure path.
+    // AvoidCatchingGenericException: release the freshly-allocated replacement if the copy fails before
+    // the ownership swap, so a copy fault (impossible under our sizing invariant, but PARANOID-safe) leaks nothing.
+    @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
+    private void ensureCapacity(long need) {
+        if (need <= buffer.capacity()) {
+            return;
+        }
+        if (need > Integer.MAX_VALUE) {
+            throw new IllegalStateException("JSON response exceeds maximum encodable size: " + need);
+        }
+        long target = Math.max(need, buffer.capacity() * 2L);
+        int newCapacity = (int) Math.min(target, Integer.MAX_VALUE);
+        // Allocate first: if this throws, the old buffer is untouched and the caller discards it.
+        LoanedBuffer grown = allocator.allocateNetwork(newCapacity);
+        try {
+            MemorySegment.copy(segment, 0L, grown.segment(), 0L, written);
+        } catch (RuntimeException e) {
+            grown.close();
+            throw e;
+        }
+        buffer.close();
+        buffer = grown;
+        segment = grown.segment();
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.http.HttpEncodedBody;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponseEncodingContext;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.tck.perf.AbstractExerisBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JMH Benchmark: JSON response-body encoding, streaming vs. materialize-and-copy.
+ *
+ * <h2>Why this exists</h2>
+ * <p>The response-encode hot path had no JMH coverage — the only allocation/CPU evidence came from
+ * whole-stack perfbox runs, which cannot isolate the encoder. This benchmark measures the encode step
+ * directly, comparing the two strategies side by side in one run via {@link #strategy}:
+ * <ul>
+ *   <li>{@code STREAMING} — {@link JsonBodyEncoder} writing straight into the loaned off-heap segment
+ *       through {@link SegmentSink} (0.10.2+).</li>
+ *   <li>{@code MATERIALIZE_AND_COPY} — the pre-0.10.2 path: {@code ObjectMapper.writeValueAsBytes}
+ *       to a heap {@code byte[]}, then {@link MemorySegment#copy} into the loaned buffer. Kept here
+ *       only as the A/B baseline.</li>
+ * </ul>
+ *
+ * <h2>Metric of record</h2>
+ * <p>Run with the GC profiler ({@code -prof gc}) — {@code gc.alloc.rate.norm} (bytes allocated per op)
+ * is the primary signal: streaming should drop the per-op heap {@code byte[]} entirely. In CI the
+ * benchmarks job additionally records JFR ({@code settings=default}), from which the same per-op
+ * allocation is derivable. Throughput ({@code ops/s}) is the secondary signal — the removed copy pass.
+ *
+ * <p>Payload is a list of small records approximating a benchmark {@code /users} response (a few KB of
+ * JSON), so the streaming path exercises {@link SegmentSink}'s grow once past the initial estimate.
+ */
+public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
+
+    /** Encoding strategy under measurement; JMH runs one trial per value. */
+    @Param({"STREAMING", "MATERIALIZE_AND_COPY"})
+    public Strategy strategy;
+
+    private static final List<HttpHeader> JSON_HEADERS =
+            List.of(new HttpHeader("content-type", "application/json"));
+
+    private ObjectMapper mapper;
+    private MemoryAllocator allocator;
+    private HttpResponseEncodingContext context;
+    private JsonBodyEncoder streamingEncoder;
+    private Object payload;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        mapper = new ObjectMapper();
+        allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        HttpRequest request = new HttpRequest(HttpMethod.GET, "/users", HttpVersion.HTTP_1_1, List.of(), null);
+        context = new HttpResponseEncodingContext(request, allocator);
+        streamingEncoder = new JsonBodyEncoder(mapper);
+        payload = sampleUsers(50);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    @Benchmark
+    public void encode(Blackhole bh) {
+        HttpEncodedBody body = switch (strategy) {
+            case STREAMING -> streamingEncoder.encode(payload, context);
+            case MATERIALIZE_AND_COPY -> encodeMaterializeAndCopy(payload);
+        };
+        // Read the produced bytes (forces the write) then release the loan so the pool recycles —
+        // symmetric downstream cost for both strategies, so the delta is the encode step itself.
+        bh.consume(body.body().size());
+        body.body().close();
+    }
+
+    /** Pre-0.10.2 baseline path, inlined here for A/B only — not used by production code. */
+    private HttpEncodedBody encodeMaterializeAndCopy(Object value) {
+        byte[] bytes = mapper.writeValueAsBytes(value);
+        LoanedBuffer buffer = context.allocator().allocateNetwork(bytes.length);
+        MemorySegment.copy(MemorySegment.ofArray(bytes), 0, buffer.segment(), 0, bytes.length);
+        buffer.setSize(bytes.length);
+        return new HttpEncodedBody(JSON_HEADERS, buffer);
+    }
+
+    private static List<UserRow> sampleUsers(int count) {
+        List<UserRow> users = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            users.add(new UserRow(
+                    i,
+                    "user-" + i,
+                    "user-" + i + "@example.com",
+                    List.of("interest-" + i, "topic-" + (i % 7), "tag-" + (i % 13))));
+        }
+        return users;
+    }
+
+    /** Small DTO approximating a row of the benchmark {@code /users} response. */
+    public record UserRow(long id, String name, String email, List<String> interests) {
+    }
+
+    /** The two encode strategies compared in one run. */
+    public enum Strategy {
+        STREAMING,
+        MATERIALIZE_AND_COPY
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.http.HttpEncodedBody;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponseEncodingContext;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit contract for {@link JsonBodyEncoder}: streaming into the loaned off-heap buffer must produce
+ * byte-for-byte the same JSON as {@code writeValueAsBytes}, must handle the buffer-grow path, and must
+ * leave zero outstanding off-heap loans on both the success and the failure paths (ADR-043 ownership).
+ */
+final class JsonBodyEncoderTest {
+
+    /** Bare mapper — matches the Community default ({@code CommunityJsonMappers.forScope} with no customizer). */
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonBodyEncoder encoder = new JsonBodyEncoder(mapper);
+
+    private MemoryAllocator realAllocator;
+    private LeakTrackingAllocator allocator;
+
+    @BeforeEach
+    void setUp() {
+        realAllocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        allocator = new LeakTrackingAllocator(realAllocator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        realAllocator.close();
+    }
+
+    private HttpResponseEncodingContext context() {
+        HttpRequest request = new HttpRequest(HttpMethod.GET, "/users", HttpVersion.HTTP_1_1, List.of(), null);
+        return new HttpResponseEncodingContext(request, allocator);
+    }
+
+    private static byte[] readBack(HttpEncodedBody encoded) {
+        LoanedBuffer body = encoded.body();
+        int size = Math.toIntExact(body.size());
+        byte[] out = new byte[size];
+        MemorySegment.copy(body.segment(), 0L, MemorySegment.ofArray(out), 0L, size);
+        return out;
+    }
+
+    @Test
+    @DisplayName("small payload: bytes identical to writeValueAsBytes, JSON content-type, zero leak after close")
+    void encodesSmallPayloadIdenticalToWriteValueAsBytes() {
+        Object payload = Map.of("id", 42, "name", "ada");
+        byte[] expected = mapper.writeValueAsBytes(payload);
+
+        HttpEncodedBody encoded = encoder.encode(payload, context());
+
+        assertArrayEquals(expected, readBack(encoded));
+        assertEquals(List.of(new HttpHeader("content-type", "application/json")), encoded.headers());
+        assertEquals(1L, allocator.outstanding(), "body must own exactly one live buffer");
+        encoded.body().close();
+        assertEquals(0L, allocator.outstanding(), "closing the body must release the loan");
+    }
+
+    @Test
+    @DisplayName("large payload (> initial estimate): grow path yields identical bytes and one net live buffer")
+    void encodesLargePayloadForcingGrowPath() {
+        // Each element ~120 bytes of JSON; 200 elements comfortably exceeds the 4096-byte initial buffer.
+        List<String> payload = java.util.stream.IntStream.range(0, 200)
+                .mapToObj(i -> "element-" + i + "-" + "x".repeat(100))
+                .toList();
+        byte[] expected = mapper.writeValueAsBytes(payload);
+        assertTrue(expected.length > 4096, "test payload must exceed the initial buffer to exercise grow");
+
+        HttpEncodedBody encoded = encoder.encode(payload, context());
+
+        assertArrayEquals(expected, readBack(encoded));
+        assertEquals(1L, allocator.outstanding(), "grow must close superseded buffers — one net live buffer");
+        encoded.body().close();
+        assertEquals(0L, allocator.outstanding());
+    }
+
+    @Test
+    @DisplayName("null payload encodes as JSON null, identical to writeValueAsBytes")
+    void nullPayloadEncodesAsJsonNull() {
+        byte[] expected = mapper.writeValueAsBytes(null);
+
+        HttpEncodedBody encoded = encoder.encode(null, context());
+
+        assertArrayEquals(expected, readBack(encoded));
+        encoded.body().close();
+        assertEquals(0L, allocator.outstanding());
+    }
+
+    @Test
+    @DisplayName("serialization failure releases the loan (no leak)")
+    void noLeakWhenSerializationFails() {
+        assertThrows(IllegalStateException.class, () -> encoder.encode(new Exploding(), context()));
+        assertEquals(0L, allocator.outstanding(), "failed serialization must not leak the loaned buffer");
+    }
+
+    @Test
+    @DisplayName("failure AFTER the buffer has grown releases the grown loan (no leak)")
+    void noLeakWhenFailureOccursAfterGrow() {
+        // First element forces a grow (> 4096 bytes); the second element then throws mid-serialization.
+        List<Object> payload = List.of("x".repeat(5000), new Exploding());
+
+        assertThrows(IllegalStateException.class, () -> encoder.encode(payload, context()));
+        assertEquals(0L, allocator.outstanding(),
+                "the grown buffer (not just the initial one) must be released on failure");
+    }
+
+    /** A bean whose only property throws during serialization, forcing a mid-write Jackson failure. */
+    public static final class Exploding {
+        @SuppressWarnings("PMD.UnusedMethodParameter")
+        public String getBoom() {
+            throw new IllegalStateException("boom");
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`JsonBodyEncoder.encode` serialized the response payload to a heap `byte[]` via
`ObjectMapper.writeValueAsBytes`, then `MemorySegment.copy`'d it into the loaned,
registered network buffer. That is a per-response heap allocation **plus** a
full extra pass over the payload — the copy exists only to bridge Jackson's heap output
into the off-heap response buffer. In a perfbox JFR pair this response-encode path was a
large share of allocation (growable `ByteArrayBuilder` + `toByteArray` + the copy).

## Fix
Jackson now streams straight into the loaned segment through a new `SegmentSink`
(an `OutputStream` over a `LoanedBuffer` with grow-on-overflow), so `writeValue` writes
directly off-heap. Both the intermediate `byte[]` and the `MemorySegment.copy` are gone.

- **Output is byte-identical**; **no SPI change** — this is an internal reimplementation
  of one Community encoder, so The Wall (ADR-006) holds untouched.
- `SegmentSink` keeps **at most one live buffer**: on overflow it allocates a larger one,
  copies, closes the old. `close()` is a no-op (a serializer may auto-close its target);
  the caller owns the terminal decision — `setSizeToWritten()`+transfer on success, or
  `discard()` on failure — so **every path is leak-safe**.

## Evidence
- **JMH** (`JsonBodyEncoderBenchmark`, `-prof gc`, 50-row payload): allocation per encode
  **~11432 → ~1192 B/op (~90% less)**, `gc.alloc.rate.norm` stdev ~0.4 B/op (rock-solid).
  Throughput directional-only at smoke iteration counts. The residual ~1192 B/op is
  per-response wrapper objects (LoanedBuffer handle, HttpEncodedBody) — a candidate for a
  later pooling pass, out of scope here.
- **Unit** (`JsonBodyEncoderTest`, 5): byte-equality vs `writeValueAsBytes` (small/large/
  null), the **grow** path, and **two leak paths** (serialization failure; failure *after*
  a grow) asserted via `LeakTrackingAllocator.outstanding() == 0`.
- **Lint**: `mvn -pl exeris-kernel-community pmd:check checkstyle:check` → 0/0.
- **Wall guard**: `ExerisArchitectureTest` 11/11.
- Full `http` package + all 782 community unit tests green.

> **Local caveat:** a full `mvn clean install` on this Windows/JDK-26 box crashes the
> forked VM in the native `Argon2idPasswordEncoderTckTest` (passes in isolation) — a known
> native flake unrelated to this change (no crypto touched). CI (Linux) is the authority.

## Scope
The virtual-thread-friendly Jackson recycler pool (which would trim the ~1192 B/op
residual on carrier vthreads) is deliberately **not** in this PR: per ADR-052 that is an
application concern via the existing `JsonMapperCustomizer` ServiceLoader seam, not kernel
code. This PR is purely the streaming rewrite.

## Follow-ups
- Forward-port to `development/0.11.0`.
- Version bump `0.10.1 → 0.10.2` + CHANGELOG/`docs/release` entry at release-integration
  time (kept out of this feature PR per the terse-CHANGELOG convention).
- Re-run the perfbox campaign with the fix (and a `fix-on @ 256 MB heap` variant) to
  quantify the p99-tail effect from reduced allocation independent of heap sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
