### PR TITLE
perf(http): stream JSON request-body encoding into pooled LoanedBuffer

### DIFF
--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityJsonRequestBodyEncoder.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityJsonRequestBodyEncoder.java
@@ -16,22 +16,22 @@ import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * Community driver: Jackson 3 implementation of {@link HttpRequestBodyEncoder}.
  *
- * <p>Serialises any non-null payload to JSON via {@link ObjectMapper#writeValueAsBytes(Object)},
- * copies the bytes into a kernel-allocated {@link LoanedBuffer}, and returns an
- * {@link HttpEncodedBody} carrying the buffer plus a {@code content-type:
- * application/json} header (the encoder owns the content-type header; the façade
- * adds {@code content-length} from the resulting buffer size).
+ * <p>Streams a non-null payload as JSON <em>straight into</em> a kernel-allocated
+ * {@link LoanedBuffer} through {@link SegmentSink} — no intermediate heap {@code byte[]} and no
+ * heap&rarr;off-heap {@code MemorySegment.copy} per request (No-Waste-Compute; mirrors the
+ * server-side {@code JsonBodyEncoder}). The sink grows to a larger buffer if the initial estimate
+ * is exceeded. The returned {@link HttpEncodedBody} carries the buffer plus a
+ * {@code content-type: application/json} header (the encoder owns the content-type; the façade adds
+ * {@code content-length} from the buffer size). Buffer ownership transfers to the returned body.
  *
- * <p>Jackson-specific exceptions are wrapped in {@link IllegalStateException} to
- * keep driver-specific types out of any SPI / Core surface (mirrors the server-side
- * {@code JsonBodyEncoder} pattern).
+ * <p>Jackson-specific exceptions are wrapped in {@link IllegalStateException} to keep driver-specific
+ * types out of any SPI / Core surface (The Wall — ADR-006).
  *
  * @since 0.8.0
  */
@@ -39,6 +39,13 @@ public final class CommunityJsonRequestBodyEncoder implements HttpRequestBodyEnc
 
     private static final List<HttpHeader> JSON_HEADERS =
             List.of(new HttpHeader("content-type", "application/json"));
+
+    /**
+     * Initial off-heap buffer size (bytes) — a conservative default; larger request bodies grow
+     * transparently via {@link SegmentSink}. Sizing is a tracked tuning follow-up (mirrors
+     * {@code JsonBodyEncoder}).
+     */
+    private static final int INITIAL_BUFFER_BYTES = 4096;
 
     private final ObjectMapper mapper;
 
@@ -57,19 +64,29 @@ public final class CommunityJsonRequestBodyEncoder implements HttpRequestBodyEnc
     }
 
     @Override
+    // CloseResource: the sink's buffer ownership transfers to the returned HttpEncodedBody on success,
+    // and the finally releases it on every non-committed exit — no path leaks the off-heap loan.
+    @SuppressWarnings("PMD.CloseResource")
     public HttpEncodedBody encode(Object payload, HttpRequestEncodingContext context) {
         Objects.requireNonNull(payload, "payload must not be null");
         Objects.requireNonNull(context, "context must not be null");
-        byte[] bytes;
+        SegmentSink sink = new SegmentSink(
+                context.allocator().allocateNetwork(INITIAL_BUFFER_BYTES), context.allocator());
+        boolean committed = false;
         try {
-            bytes = mapper.writeValueAsBytes(payload);
+            mapper.writeValue(sink, payload);
+            sink.setSizeToWritten();
+            HttpEncodedBody body = new HttpEncodedBody(JSON_HEADERS, sink.buffer());
+            committed = true;
+            return body;
         } catch (JacksonException ex) {
+            // Do not let a tools.jackson type cross out of the encoder (The Wall — ADR-006).
             throw new IllegalStateException(
                     "JSON serialization failed for payload type " + payload.getClass().getName(), ex);
+        } finally {
+            if (!committed) {
+                sink.discard();
+            }
         }
-        LoanedBuffer buf = context.allocator().allocateNetwork(bytes.length);
-        MemorySegment.copy(MemorySegment.ofArray(bytes), 0, buf.segment(), 0, bytes.length);
-        buf.setSize(bytes.length);
-        return new HttpEncodedBody(JSON_HEADERS, buf);
     }
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityJsonRequestBodyEncoderTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityJsonRequestBodyEncoderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.http.HttpEncodedBody;
+import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequestEncodingContext;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit contract for {@link CommunityJsonRequestBodyEncoder} streaming: byte-for-byte equivalence to
+ * {@code writeValueAsBytes}, the buffer-grow path, and zero outstanding off-heap loans on both success
+ * and failure (ADR-043 ownership). The {@link AbstractHttpRequestBodyEncoderTck} binding covers the SPI
+ * envelope/content-type/header-invariance contract; this fills the streaming-specific gaps it does not.
+ */
+final class CommunityJsonRequestBodyEncoderTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final CommunityJsonRequestBodyEncoder encoder = new CommunityJsonRequestBodyEncoder(mapper);
+
+    private MemoryAllocator realAllocator;
+    private LeakTrackingAllocator allocator;
+
+    @BeforeEach
+    void setUp() {
+        realAllocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+        allocator = new LeakTrackingAllocator(realAllocator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        realAllocator.close();
+    }
+
+    private HttpRequestEncodingContext context() {
+        return new HttpRequestEncodingContext(HttpMethod.POST, "/widgets", allocator);
+    }
+
+    private static byte[] readBack(HttpEncodedBody encoded) {
+        LoanedBuffer body = encoded.body();
+        int size = Math.toIntExact(body.size());
+        byte[] out = new byte[size];
+        MemorySegment.copy(body.segment(), 0L, MemorySegment.ofArray(out), 0L, size);
+        return out;
+    }
+
+    @Test
+    @DisplayName("small payload: bytes identical to writeValueAsBytes, JSON content-type, zero leak after close")
+    void encodesSmallPayloadIdenticalToWriteValueAsBytes() {
+        Object payload = Map.of("id", 7, "name", "grace");
+        byte[] expected = mapper.writeValueAsBytes(payload);
+
+        HttpEncodedBody encoded = encoder.encode(payload, context());
+
+        assertArrayEquals(expected, readBack(encoded));
+        assertEquals(List.of(new HttpHeader("content-type", "application/json")), encoded.headers());
+        assertEquals(1L, allocator.outstanding(), "body must own exactly one live buffer");
+        encoded.body().close();
+        assertEquals(0L, allocator.outstanding(), "closing the body must release the loan");
+    }
+
+    @Test
+    @DisplayName("large payload (> initial estimate): grow path yields identical bytes and one net live buffer")
+    void encodesLargePayloadForcingGrowPath() {
+        List<String> payload = java.util.stream.IntStream.range(0, 200)
+                .mapToObj(i -> "element-" + i + "-" + "x".repeat(100))
+                .toList();
+        byte[] expected = mapper.writeValueAsBytes(payload);
+        assertTrue(expected.length > 4096, "test payload must exceed the initial buffer to exercise grow");
+
+        HttpEncodedBody encoded = encoder.encode(payload, context());
+
+        assertArrayEquals(expected, readBack(encoded));
+        assertEquals(1L, allocator.outstanding(), "grow must close superseded buffers — one net live buffer");
+        encoded.body().close();
+        assertEquals(0L, allocator.outstanding());
+    }
+
+    @Test
+    @DisplayName("serialization failure releases the loan (no leak)")
+    void noLeakWhenSerializationFails() {
+        assertThrows(IllegalStateException.class, () -> encoder.encode(new Exploding(), context()));
+        assertEquals(0L, allocator.outstanding(), "failed serialization must not leak the loaned buffer");
+    }
+
+    @Test
+    @DisplayName("failure AFTER the buffer has grown releases the grown loan (no leak)")
+    void noLeakWhenFailureOccursAfterGrow() {
+        List<Object> payload = List.of("x".repeat(5000), new Exploding());
+
+        assertThrows(IllegalStateException.class, () -> encoder.encode(payload, context()));
+        assertEquals(0L, allocator.outstanding(),
+                "the grown buffer (not just the initial one) must be released on failure");
+    }
+
+    /** A bean whose only property throws during serialization, forcing a mid-write Jackson failure. */
+    public static final class Exploding {
+        @SuppressWarnings("PMD.UnusedMethodParameter")
+        public String getBoom() {
+            throw new IllegalStateException("boom");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Step 2 of the 0.10.2 batch — the client-side mirror of #241. `CommunityJsonRequestBodyEncoder.encode`
used the same materialize-then-copy pattern removed from the response path: serialize to a heap
`byte[]` via `writeValueAsBytes`, then `MemorySegment.copy` into the loaned request buffer. It now
streams Jackson straight into the off-heap segment through the existing `SegmentSink` (grow-on-overflow),
removing the per-request heap `byte[]` and the copy.

## Preserved / scope
- **Byte-identical output**; **no SPI change** (`HttpRequestBodyEncoder`/`HttpEncodedBody` untouched, The Wall holds).
- Non-null-payload rejection and the payload-class-name exception message are preserved.
- Reuses `SegmentSink` from #241 (single-live-buffer ownership; leak-safe transfer/discard) — no new bridge code.

## Tests
- `AbstractHttpRequestBodyEncoderTck` binding stays green (byte-identical contract).
- The TCK's sample payload is `Map.of("k","v")`, so it does not exercise the streaming-specific paths;
  new `CommunityJsonRequestBodyEncoderTest` adds: byte-equality vs `writeValueAsBytes` (small/large),
  the **grow** path, and **two leak paths** (serialization failure; failure *after* a grow) via
  `LeakTrackingAllocator.outstanding() == 0`.
- Local: new test 4/4 + TCK binding 9/9 green; `pmd:check checkstyle:check` 0/0; `ExerisArchitectureTest` 11/11.

> Same Windows/JDK-26 caveat as #241: a full `mvn clean install` crashes the forked VM in the native
> `Argon2idPasswordEncoderTckTest` (passes in isolation, no crypto touched) — CI (Linux) is authority.

## Batch context (0.10.2, not released yet)
1. ✅ Response encoder streaming (#241, merged)
2. ✅ **Request encoder streaming (this PR)**
3. ⏳ Reuse Jackson generator (~62% of the residual per-encode allocation)
4. ⏳ Pool per-response objects (`HttpEncodedBody`, allocator close-action)
5. ⏳ Bump 0.10.2 + CHANGELOG/release-notes
6. ⏳ Forward-port the whole batch to `development/0.11.0` (single op, after 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
