### PR TITLE
test(http): record Jackson writer-reuse as allocation-neutral (negative result)

### DIFF
--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
@@ -58,13 +59,14 @@ import java.util.List;
 public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
 
     /** Encoding strategy under measurement; JMH runs one trial per value. */
-    @Param({"STREAMING", "MATERIALIZE_AND_COPY"})
+    @Param({"STREAMING", "STREAMING_REUSED_WRITER", "MATERIALIZE_AND_COPY"})
     public Strategy strategy;
 
     private static final List<HttpHeader> JSON_HEADERS =
             List.of(new HttpHeader("content-type", "application/json"));
 
     private ObjectMapper mapper;
+    private ObjectWriter writer;
     private MemoryAllocator allocator;
     private HttpResponseEncodingContext context;
     private JsonBodyEncoder streamingEncoder;
@@ -73,6 +75,7 @@ public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
     @Setup(Level.Trial)
     public void setUp() {
         mapper = new ObjectMapper();
+        writer = mapper.writer();
         allocator = new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
         HttpRequest request = new HttpRequest(HttpMethod.GET, "/users", HttpVersion.HTTP_1_1, List.of(), null);
         context = new HttpResponseEncodingContext(request, allocator);
@@ -91,12 +94,36 @@ public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
     public void encode(Blackhole bh) {
         HttpEncodedBody body = switch (strategy) {
             case STREAMING -> streamingEncoder.encode(payload, context);
+            case STREAMING_REUSED_WRITER -> encodeStreamingReusedWriter(payload);
             case MATERIALIZE_AND_COPY -> encodeMaterializeAndCopy(payload);
         };
         // Read the produced bytes (forces the write) then release the loan so the pool recycles —
         // symmetric downstream cost for both strategies, so the delta is the encode step itself.
         bh.consume(body.body().size());
         body.body().close();
+    }
+
+    /**
+     * Streaming through a pre-built (reused) {@link ObjectWriter}. <b>Documented negative result:</b>
+     * measured allocation-neutral vs {@code STREAMING} (~1192 vs ~1192 B/op under {@code -prof gc}) —
+     * Jackson allocates the per-call generator + write/IO/serialization contexts regardless of whether
+     * the call goes through the {@code ObjectMapper} or a reused {@code ObjectWriter}, so writer reuse is
+     * <em>not</em> a lever on the residual encode allocation. Kept so the finding is not re-litigated.
+     */
+    private HttpEncodedBody encodeStreamingReusedWriter(Object value) {
+        SegmentSink sink = new SegmentSink(context.allocator().allocateNetwork(4096), context.allocator());
+        boolean committed = false;
+        try {
+            writer.writeValue(sink, value);
+            sink.setSizeToWritten();
+            HttpEncodedBody body = new HttpEncodedBody(JSON_HEADERS, sink.buffer());
+            committed = true;
+            return body;
+        } finally {
+            if (!committed) {
+                sink.discard();
+            }
+        }
     }
 
     /** Pre-0.10.2 baseline path, inlined here for A/B only — not used by production code. */
@@ -127,6 +154,7 @@ public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
     /** The two encode strategies compared in one run. */
     public enum Strategy {
         STREAMING,
+        STREAMING_REUSED_WRITER,
         MATERIALIZE_AND_COPY
     }
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/JsonBodyEncoderBenchmark.java
@@ -38,10 +38,13 @@ import java.util.List;
  * <h2>Why this exists</h2>
  * <p>The response-encode hot path had no JMH coverage — the only allocation/CPU evidence came from
  * whole-stack perfbox runs, which cannot isolate the encoder. This benchmark measures the encode step
- * directly, comparing the two strategies side by side in one run via {@link #strategy}:
+ * directly, comparing the three strategies side by side in one run via {@link #strategy}:
  * <ul>
  *   <li>{@code STREAMING} — {@link JsonBodyEncoder} writing straight into the loaned off-heap segment
  *       through {@link SegmentSink} (0.10.2+).</li>
+ *   <li>{@code STREAMING_REUSED_WRITER} — streaming through a pre-built, reused {@link ObjectWriter}; a
+ *       documented <em>negative result</em> (allocation-neutral vs {@code STREAMING}) — writer reuse is
+ *       not a lever on the residual. See {@link #encodeStreamingReusedWriter(Object)}.</li>
  *   <li>{@code MATERIALIZE_AND_COPY} — the pre-0.10.2 path: {@code ObjectMapper.writeValueAsBytes}
  *       to a heap {@code byte[]}, then {@link MemorySegment#copy} into the loaned buffer. Kept here
  *       only as the A/B baseline.</li>
@@ -151,7 +154,7 @@ public class JsonBodyEncoderBenchmark extends AbstractExerisBenchmark {
     public record UserRow(long id, String name, String email, List<String> interests) {
     }
 
-    /** The two encode strategies compared in one run. */
+    /** The three encode strategies compared in one run (see the class Javadoc for each). */
     public enum Strategy {
         STREAMING,
         STREAMING_REUSED_WRITER,


### PR DESCRIPTION
## Summary
Benchmark-only. While scoping the residual encode allocation (~1192 B/op after #241/#242), the obvious
next lever seemed to be reusing a Jackson `ObjectWriter` instead of calling `mapper.writeValue` per
request. **Measured, it does nothing.**

| strategy | `gc.alloc.rate.norm` |
|---|---|
| `STREAMING` | ~1192 B/op |
| `STREAMING_REUSED_WRITER` | ~1192 B/op |
| `MATERIALIZE_AND_COPY` (pre-#241) | ~11432 B/op |

Jackson allocates the per-call generator + `JsonWriteContext`/`IOContext`/`SerializationContextExt`
regardless of whether the call goes through the `ObjectMapper` or a reused `ObjectWriter`. Writer reuse
is **not** a lever on the residual.

This PR adds the `STREAMING_REUSED_WRITER` strategy to `JsonBodyEncoderBenchmark` and documents the
finding in-code, so nobody re-litigates writer-reuse as a production change. No production code touched.

The residual breakdown (from `-prof jfr` alloc-by-class): ~62% Jackson per-call machinery (intrinsic,
not reducible by reuse), ~35% per-response carrier/allocator objects. Of the latter, `HttpEncodedBody`
pooling is out (immutable SPI value-carrier); the allocator-side `CommunityReleaseAction` per-buffer
object is being addressed separately as a memory-subsystem change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
