### PR TITLE
release(0.10.2): bump reactor to 0.10.2 + CHANGELOG + release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This file is intentionally terse: it lists what landed, with a pointer to the re
 
 Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project versions follow [SemVer](https://semver.org/spec/v2.0.0.html), with the pre-1.0 caveat that minor versions may carry observable contract additions while remaining backwards-compatible at the SPI level. Which SPI surfaces are `stable` / `preview` / `experimental`, and what each label commits to for semver, is declared in [`docs/stability-matrix.md`](docs/stability-matrix.md) — the authoritative source for the semver policy.
 
+## [0.10.2] — 2026-07-19
+
+Patch release. Community-internal allocation discipline on the JSON-encode and memory-allocator hot paths; additive, SPI-unchanged, default byte-identical. Detail + notes: [`docs/release/v0.10.2-release-notes.md`](docs/release/v0.10.2-release-notes.md).
+
+### Changed
+- **Zero-copy JSON body encoding** — `JsonBodyEncoder` (#241) and `CommunityJsonRequestBodyEncoder` (#242) stream Jackson straight into the loaned off-heap buffer via `SegmentSink`, dropping the per-request heap `byte[]` + `MemorySegment.copy` (~11432 → ~1192 B/op/encode; byte-identical output, no SPI change).
+- **Allocator release accounting** — `CommunityMemoryAllocator` folds per-buffer release bookkeeping into `CommunityLoanedBuffer.onRelease()` via a shared `CommunityReleaseAccounting`, dropping the per-buffer close-action object (−80 B/op per allocation, system-wide; `stats()`/JFR identical) (#244).
+
+### Added
+- **JSON-encode JMH benchmark** — `JsonBodyEncoderBenchmark` (streaming vs materialize-and-copy), plus a documented negative result that Jackson `ObjectWriter` reuse is allocation-neutral (#243).
+
 ## [0.10.1] — 2026-07-19
 
 Patch release. Community-internal, additive, default byte-identical (no SPI change). Detail + notes: [`docs/release/v0.10.1-release-notes.md`](docs/release/v0.10.1-release-notes.md) (ADR-052).

--- a/docs/release/v0.10.2-release-notes.md
+++ b/docs/release/v0.10.2-release-notes.md
@@ -1,0 +1,43 @@
+# Exeris Kernel v0.10.2 — Release Notes
+
+| | |
+|:--|:--|
+| **Version** | 0.10.2 |
+| **Date** | 2026-07-19 |
+| **Predecessor** | 0.10.1 |
+| **Framing** | Pre-1.0 / TRL-3. Patch release: additive, SPI-unchanged, default behaviour byte-for-byte preserved. Per-surface semver policy: [`docs/stability-matrix.md`](../stability-matrix.md). |
+
+## 1. Headline
+
+v0.10.2 is an **allocation-discipline patch** on two Community hot paths — JSON body encoding and the memory allocator's release accounting. Serialized output and observable behaviour are unchanged (byte-for-byte); the wins are purely in per-request / per-allocation heap churn, verified by a new JMH benchmark. No SPI surface changes.
+
+## 2. What landed
+
+### 2.1 Zero-copy JSON response encoding — #241
+`JsonBodyEncoder.encode` previously serialized to a heap `byte[]` via `ObjectMapper.writeValueAsBytes` and then `MemorySegment.copy`'d it into the loaned, io_uring-registered response buffer — a per-response heap allocation plus a full extra pass over the payload. Jackson now streams straight into the off-heap segment through a new `SegmentSink` (an `OutputStream` over a `LoanedBuffer` that grows on overflow, with single-live-buffer ownership and leak-safe transfer/discard). Both the heap `byte[]` and the copy are gone. JMH (`JsonBodyEncoderBenchmark`, `-prof gc`, 50-row payload): **~11432 → ~1192 B/op** allocated per encode.
+
+### 2.2 Zero-copy JSON request encoding — #242
+`CommunityJsonRequestBodyEncoder` (client request bodies) carried the same materialize-then-copy pattern; it now reuses `SegmentSink` for the identical streaming path. Non-null-payload rejection and the payload-class exception message are preserved.
+
+### 2.3 Allocator release accounting folded into `onRelease` — #244
+`CommunityMemoryAllocator` allocated a per-buffer `CommunityReleaseAction` (a `Runnable`) and registered it via `addCloseAction`, purely to carry the buffer's byte count and the allocator's shared counters/JFR config into the release path. The only per-instance state was the byte count — which the buffer already knows. Replaced with a single per-allocator `CommunityReleaseAccounting` holder that `CommunityLoanedBuffer.onRelease()` invokes with its own capacity. No per-buffer bookkeeping object and no `addCloseAction` write+fence on the allocation hot path — a **system-wide** reduction (every allocation, not just JSON): measured **−80 B/op** per allocation on the encode benchmark.
+
+### 2.4 Benchmark coverage + a documented negative result — #243
+`JsonBodyEncoderBenchmark` (new in this line) gains a `STREAMING_REUSED_WRITER` strategy documenting that reusing a pre-built Jackson `ObjectWriter` is **allocation-neutral** vs plain streaming (~1192 vs ~1192 B/op): Jackson allocates the per-call generator + contexts regardless of `ObjectMapper`-vs-`ObjectWriter`, so writer reuse is not a lever on the residual. Recorded so it is not re-litigated.
+
+## 3. SPI surface delta
+- **Added:** none.
+- **Removed:** none.
+
+All changes are Community-tier internal reimplementations; no `tools.jackson` type and no allocator-internal type enters `exeris-kernel-spi` (The Wall holds). `HttpResponseBodyEncoder` / `HttpRequestBodyEncoder` / `HttpEncodedBody` and the `MemoryAllocator` / `LoanedBuffer` contracts are untouched.
+
+## 4. Behaviour / performance notes
+- **Output byte-identical.** Encoded JSON bytes and response headers are unchanged (test-pinned against `writeValueAsBytes`).
+- **`stats()` and JFR unchanged.** Allocator `MemoryStats` (`allocatedBytes` / `releaseCount`) and the sampled `CommunityReleaseEvent` are identical after the accounting fold — the release value equals the value the matching allocation added, so no drift.
+- **Off-heap ownership.** `SegmentSink` keeps at most one live buffer (grow = allocate-copy-close-old); the buffer transfers to the returned `HttpEncodedBody` on success and is released on every failure path (leak-tested).
+- **Residual, and what it is not.** After 2.1–2.3 the per-encode residual is ~1192 B/op, dominated (~62%) by Jackson's intrinsic per-call machinery — not reducible by writer reuse (2.4). The one production-relevant lever left is the virtual-thread-friendly Jackson recycler pool, which is an application concern via the ADR-052 `JsonMapperCustomizer` seam, not kernel code.
+
+## 5. Quality and gate posture
+- Lint-gated on changed modules (Checkstyle + PMD, no skip flags): 0 violations.
+- `ExerisArchitectureTest` (The Wall guard) green. No new `Abstract*Tck` — no observable SPI behaviour changed; the existing `AbstractHttpRequestBodyEncoderTck`, `AbstractMemoryAllocatorTck` (incl. `MemoryStatsContract`), and `AbstractLoanedBufferTck` (PARANOID leak) bindings stay green.
+- New tests: `JsonBodyEncoderTest` and `CommunityJsonRequestBodyEncoderTest` (byte-equality small/large/null, the buffer-grow path, and two off-heap leak paths — serialization failure and failure-after-grow), plus the `JsonBodyEncoderBenchmark` JMH harness.

--- a/exeris-kernel-bom/pom.xml
+++ b/exeris-kernel-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
     </parent>
 
     <artifactId>exeris-kernel-bom</artifactId>

--- a/exeris-kernel-build-config/pom.xml
+++ b/exeris-kernel-build-config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.exeris</groupId>
 		<artifactId>exeris-kernel-root</artifactId>
-		<version>0.10.1</version>
+		<version>0.10.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/exeris-kernel-community-kafka/pom.xml
+++ b/exeris-kernel-community-kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community-kafka</artifactId>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-community</artifactId>

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-diagnostics-cli/pom.xml
+++ b/exeris-kernel-diagnostics-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
     <artifactId>exeris-kernel-diagnostics-cli</artifactId>

--- a/exeris-kernel-parent/pom.xml
+++ b/exeris-kernel-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-root</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/exeris-kernel-tck/pom.xml
+++ b/exeris-kernel-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>eu.exeris</groupId>
         <artifactId>exeris-kernel-parent</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
         <relativePath>../exeris-kernel-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.exeris</groupId>
     <artifactId>exeris-kernel-root</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packaging>pom</packaging>
 
     <name>Exeris Kernel :: Root</name>


### PR DESCRIPTION
## ⚠️ Release-prep — do not merge until you intend to publish 0.10.2
Merging to `main` triggers the GitHub Packages publish (downstream repos consume the BOM). Per the "don't
release immediately" call, this PR is prepared and left for you to merge when you're ready to cut 0.10.2.

## Summary
The 0.10.2 allocation batch already merged to `main` at version 0.10.1 (#241, #242, #243, #244). This PR
does only the release bookkeeping — **no code change**:
- Flips all **11 reactor coordinates** `0.10.1 → 0.10.2` (root + parent + bom + build-config + spi + tck +
  core + community + community-kafka + community-testkit + diagnostics-cli). Grep-verified: 0 left at
  0.10.1, 11 at 0.10.2.
- `docs/release/v0.10.2-release-notes.md` — the v0.7.x–v0.10.1 pattern; describes only published behaviour.
- Terse `CHANGELOG.md` `[0.10.2]` entry pointing at the notes.

## What 0.10.2 contains (already on main)
- Zero-copy JSON **response** (#241) and **request** (#242) encoding via `SegmentSink` — no heap `byte[]`,
  no `MemorySegment.copy`; ~11432 → ~1192 B/op per encode, byte-identical output.
- Allocator release accounting folded into `onRelease` (#244) — −80 B/op per allocation, system-wide;
  `stats()`/JFR identical.
- `JsonBodyEncoderBenchmark` + documented writer-reuse negative result (#243).

## Verification
- `mvn validate` green (POM version graph consistent across all 11 coordinates; Checkstyle@validate clean).
- No SPI change, no code change → no new arch/TCK surface; the batch's own gates were verified in #241–#244.

## Forward-port
Already opened separately: #245 forward-ports the same four commits onto `development/0.11.0`
(no version bump), per the #240 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
