### PR TITLE
docs(http): SSE zero-copy emit landed in v0.10.0 — correct the follow-up bullet

### DIFF
--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -55,7 +55,7 @@ Streaming (server-push) contracts — 🚧 Planned v0.10, ratified by [ADR-043](
 
 Additional follow-ups (mechanism works; refinement deferred):
 - **Wire framing** — the SSE body is written as a raw, close-delimited HTTP/1.1 response (`Connection: close`, no `Content-Length`, no chunk framing; RFC 9112 §6.3). `Transfer-Encoding: chunked` per-event framing (so SSE streams through buffering reverse proxies / CDNs that hold length-unknown responses) and an HTTP/2 `DATA`-frame path are follow-ups. The response head is HTTP/1.1-specific today.
-- **Zero-copy emit** — `SseEventEncoder.encode` currently allocates a `StringBuilder` + `String` + `byte[]` per event before the single copy into the egress `LoanedBuffer`. Encoding field-by-field directly into the `LoanedBuffer` segment (no intermediate `String`/`byte[]`) is the No-Waste-Compute follow-up for high-rate streams.
+- ~~**Zero-copy emit**~~ — **done in v0.10.0.** `SseEventEncoder` frames each event as two passes over one shared traversal: `encodedLength(StreamEvent)` measures the UTF-8 block and `encodeInto(StreamEvent, MemorySegment, long)` writes it field-by-field straight into the egress `LoanedBuffer` — no intermediate `StringBuilder`/`String`/`byte[]` and no array→segment copy. `HttpStreamEngine` calls both on the emit path. The heap `encode(StreamEvent)` wrapper is retained for tests and non-hot-path callers only.
 
 **Test gating.** The streaming contract is verified two ways. The fast, deterministic layer gates CI: `SseEventEncoderTest` (wire framing), `HttpRouterTest` streaming-registration, and the ArchTest Wall pin. The real-NIO loopback suite (`AbstractHttpStreamExchangeTck` bound by `CommunityHttpStreamExchangeTckTest` + the JFR `RecordingStream` test, `@Tag("stream-loopback")`) is run **on demand / locally**, not in the CI gate — like the `stress`/`flamegraph` suites it starves and times out on constrained 2-vCPU CI runners (server reactor + per-stream VT + client) even though it passes deterministically on many-core boxes. Run it with `mvn test -DincludedGroups=stream-loopback -DexcludedGroups=` (or `-Dtest=CommunityHttpStreamExchangeTckTest`). Making the loopback robust under scarce carriers so it can gate CI is a tracked follow-up.
 
@@ -186,8 +186,7 @@ straight in the off-heap segment — so this is the zero-copy path *by construct
 buffer), not the `java.io`-on-hot-path case the guardrails warn about. Ownership is single-live-buffer:
 the sink transfers the buffer to the returned `HttpEncodedBody` on success and releases it on every
 failure path. The mirror-image `CommunityJsonRequestBodyEncoder` (client request bodies) streams
-through the same `SegmentSink` with identical ownership semantics; the SSE zero-copy-emit follow-up
-noted above remains open.
+through the same `SegmentSink` with identical ownership semantics.
 
 ### HTTP/2 stream admission (since v0.8 Sprint 5, HTTP-112)
 


### PR DESCRIPTION
## Why this exists as a separate PR

The correction belonged in #245 but missed the merge window — #245 was merged (`7c1b02a`, 05:41Z) between my checking its state and pushing this commit. So `development/0.11.0` currently carries the forward-port **including** the stale SSE text. This PR is that one commit, rebased onto the merged dev head.

Same change as #247 on `main`.

## What's wrong on dev today

`docs/subsystems/http.md:189-190` asserts the SSE zero-copy-emit follow-up "remains open", and `:58` (the root bullet the text came from) says `SseEventEncoder.encode` "currently allocates a `StringBuilder` + `String` + `byte[]` per event". Verified against this branch's source, neither is true:

- `SseEventEncoder` exposes `encodedLength(StreamEvent)` + `encodeInto(StreamEvent, MemorySegment, long)` — two passes over one shared `traverse()`/`ByteSink`, writing field-by-field straight into the egress `LoanedBuffer` segment. Both remaining `StringBuilder` occurrences in the file are javadoc prose describing the shape that was *replaced*.
- `HttpStreamEngine:166/:217` call `encodedLength`/`encodeInto` on the emit path — production-wired, not merely available. The heap `encode(StreamEvent)` wrapper has no production caller (`SseEventEncoderTest` only).
- `git log -S encodeInto` dates it to `1744622`, the v0.10.0 integration — it predates the 0.10.2 batch entirely.

## Change

Drops the SSE clause from the 0.10.2 subsection sentence (the request-encoder statement stands on its own) and rewrites the root `:58` bullet as done-in-v0.10.0 with the mechanism named, so it stays useful as history rather than just being deleted.

The neighbouring **wire-framing** bullet (raw close-delimited HTTP/1.1; `Transfer-Encoding: chunked` and an HTTP/2 `DATA` path still to do) is verified still accurate and left untouched — that is the genuinely open item in the area.

## Verification

Docs-only, 1 file, +2/−3 — no build, lint, or test surface. Claims checked against this branch's source, not against `main` or the document being corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)