### PR TITLE
docs(evidence): target-vs-measured labels + EU reference profile (c7g → perf-box-amd64)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,7 +33,7 @@ sub-1% CPU overhead when enabled and zero overhead when disabled.
 
 ### Hyper-Density
 
-The system's capability to handle an extreme number of concurrent tasks (> 8,500 RPS/vCPU) with
+The system's capability to handle an extreme number of concurrent tasks (Enterprise target: > 8,500 RPS/vCPU) with
 minimal RAM and CPU overhead, achieved by eliminating object headers, GC churn, and OS thread
 context-switching via Virtual Threads and Project Valhalla.
 

--- a/docs/modules/04-enterprise.md
+++ b/docs/modules/04-enterprise.md
@@ -71,7 +71,7 @@ flowchart TD
 
 ## 🚀 Architectural Rules (L0 Enforcement)
 
-1. **Hyper-Density:** Designed for extreme throughput (>8,500 RPS/vCPU). Uses `GlobalMemoryArbiter` with pre-allocated
+1. **Hyper-Density:** Designed for extreme throughput (target: >8,500 RPS/vCPU). Uses `GlobalMemoryArbiter` with pre-allocated
    `mmap` regions for strictly off-heap, zero-GC execution across all subsystems.
 2. **Off-Heap Native Drivers (`io_uring`, QUIC):** Leverages `io_uring` (Linux) for syscall batching and QUIC
    (via advanced OpenSSL Memory BIOs) for kernel-bypass networking with zero Head-of-Line Blocking.

--- a/docs/performance-contract.md
+++ b/docs/performance-contract.md
@@ -8,7 +8,7 @@ into the current development baseline (TRL-3) and the final Enterprise goals.
 | Profile             | Hardware Context                          | Purpose                     |
 |:--------------------|:------------------------------------------|:----------------------------|
 | **L0 (Developer)**  | Ryzen 5600 (or equiv) / 1 vCPU / 4GB RAM | Daily PR validation         |
-| **L1 (Enterprise)** | AWS c7g.4xlarge (16 vCPU, 32GB RAM)       | Official Tier certification |
+| **L1 (Enterprise)** | `perf-box-amd64` — EU dedicated bare metal, Hetzner AX-class (AMD x86-64, 16 HW threads, 64 GB RAM, NVMe; Falkenstein DE / Helsinki FI) | Official Tier certification |
 
 ---
 
@@ -16,7 +16,7 @@ into the current development baseline (TRL-3) and the final Enterprise goals.
 
 ### 2.1 Network Throughput per Core
 
-Measured with a "Hello World" **1 KB payload**.
+Defined against a "Hello World" **1 KB payload** scenario; the scenario id and build tag are pinned per published run in `exeris-benchmarks`.
 
 > **Note:** For 8 KB entity payloads, we expect ~50% of the targets below due to MTU network
 > frame pressure.
@@ -24,7 +24,7 @@ Measured with a "Hello World" **1 KB payload**.
 | Stage               | Target (SLO)         | Breach Threshold | Context                              |
 |:--------------------|:---------------------|:-----------------|:-------------------------------------|
 | **Current (TRL-3)** | **> 1,500 RPS/vCPU** | < 1,000 RPS/vCPU | Standard TCP Sockets / Off-Heap      |
-| **Enterprise**      | **> 8,500 RPS/vCPU** | < 6,000 RPS/vCPU | `io_uring` / Native Kernel Bypass    |
+| **Enterprise**      | **> 8,500 RPS/vCPU** (target — not yet measured end-to-end; pending Enterprise bootstrap wiring) | < 6,000 RPS/vCPU | `io_uring` / Native Kernel Bypass    |
 
 ---
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -156,12 +156,17 @@ Community and Enterprise tiers are measured separately.
 | **Bootstrap cold start P99**        | ≤ 500 ms                 | ≤ 800 ms                   | JFR `BootstrapJfrEvents.KernelBootReadyEvent`          |
 | **Saga state transition P99**       | ≤ 5 ms (DB-bound)        | ≤ 1 µs (memory-bound)      | JMH `AbstractFlowParkWakeBenchmark`         |
 | **OpenSSL ABI symbol resolution**   | 100% (all bound symbols) | 100% (all bound symbols)   | Planned: ABI symbol TCK (OpenSSL/FFM)       |
-| **Throughput (reference profile)**  | ~2,800 RPS/vCPU          | ~8,500 RPS/vCPU            | JMH + flame graph analysis          |
+| **Throughput (reference profile)**  | ~2,800 RPS/vCPU (target) | ~8,500 RPS/vCPU (target — `io_uring` path not yet measured end-to-end) | JMH + flame graph analysis          |
 
-> **Measurement context for throughput:** "RPS/vCPU" measured with synthetic HTTP/1.1 workload,
-> no persistence (in-memory mock), 10k concurrent connections. Persistence-bound workloads will
-> be lower (Community: JDBC-limited; Enterprise: native driver dependent). Flame graph–based
-> profiling was used to validate tier-specific hotspots and throughput characteristics.
+> **Throughput-row context:** the RPS/vCPU figures are **design targets**, defined against a synthetic
+> HTTP/1.1 workload (1 KB hello-world-class payload, no persistence — in-memory mock, 10k concurrent
+> connections); the concrete scenario id and build tag are pinned per published run in `exeris-benchmarks`.
+> Persistence-bound workloads will be lower (Community: JDBC-limited; Enterprise: native driver dependent).
+> Neither figure is a certified measurement yet: the Community figure awaits the reference-profile
+> (`perf-box-amd64`) validation campaign (§5.1), and the Enterprise figure's `io_uring`/native-bypass
+> transport has not been measured end-to-end (Enterprise transport benchmarks pending bootstrap wiring).
+> Flame-graph profiling to date informs hotspot analysis on the measured paths; it does not substitute
+> for those end-to-end runs.
 
 ---
 


### PR DESCRIPTION
## Summary

Evidence-labeling hygiene ahead of the `perf-box-amd64` comparative campaign. No benchmark numbers added — proper paired runs are in progress and publish separately with scenario ids + build tags.

- **whitepaper §5.2** — the throughput row's figures are now explicitly **design targets**: Community `~2,800 RPS/vCPU (target)`, Enterprise `~8,500 RPS/vCPU (target — io_uring path not yet measured end-to-end)`. The shared footnote no longer uses the word *measured*; it states that neither figure is a certified measurement yet (Community awaits the reference-profile campaign; Enterprise transport benchmarks are pending bootstrap wiring) and that scenario id + build tag are pinned per published run.
- **performance-contract** — L1 reference hardware swapped from **AWS c7g.4xlarge** to **`perf-box-amd64` (EU dedicated bare metal, Hetzner AX-class; Falkenstein DE / Helsinki FI)**, aligning the contract's coordinate system with whitepaper §5.2 and the EU-sovereignty thesis (catalog SKU, reproducible by any third party). §2.1 wording *Measured with* → *Defined against* + per-run pinning; Enterprise row carries the target/unmeasured marker.
- **glossary / modules/04-enterprise** — the 8,500 RPS/vCPU figure framed as an Enterprise **target** in the Hyper-Density definition and the module doc.

## Why

The 8,500 figure sat in a table titled as TCK-certified with a prose footnote saying *measured*, while the io_uring path has no end-to-end measurement — a label defect flagged during the evidence review. The AWS reference coordinates contradicted the EU-sovereignty positioning; docs now uniformly use the EU catalog-SKU profile.

Companion changes (same sweep, already on `exeris-docs` main): composition-model drift fixes (ADR-024 amendments), ADR-053 (manifest = JSON), edge-RSS target relabel.

## Preflight

Docs-only diff (4 markdown files): lint / arch guard / TCK — N/A; branch fresh off `development/0.11.0`; no ADR numbers claimed; no private-repo deep links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)