### PR TITLE
docs(security): KernelIsolationClaims Javadoc still mandated the fail-OPEN downgrade (v0.11 S1)

### DIFF
--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/StorageContextBridge.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/StorageContextBridge.java
@@ -39,18 +39,19 @@ import eu.exeris.kernel.spi.security.StorageContext;
  *
  * <p>For advanced isolation modes ({@link StorageContext.IsolationStrategy#SEPARATED_SCHEMA},
  * {@link StorageContext.IsolationStrategy#DEDICATED}), the correct
- * {@link StorageContext} is produced directly by the {@link eu.exeris.kernel.spi.security.SecurityProvider}
- * during authentication and bound by the Security Interceptor. This bridge
- * serves the common SHARED/RLS case and the tenant-less global path.
+ * {@link StorageContext} is produced from verified token claims by
+ * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims} and
+ * bound by the Security Interceptor. This bridge serves the common SHARED/RLS case
+ * and the tenant-less global path.
  *
  * <h2>SHARED-only path</h2>
  * <p>This bridge derives only SHARED contexts. For
  * {@link StorageContext.IsolationStrategy#SEPARATED_SCHEMA} and
  * {@link StorageContext.IsolationStrategy#DEDICATED} strategies the
  * {@link StorageContext} is produced exclusively by
- * {@link eu.exeris.kernel.spi.security.SecurityProvider#authenticate} and
- * bound by the Security Interceptor. Callers that require a non-SHARED
- * context MUST NOT call this bridge.
+ * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims} — the single
+ * kernel-owned fail-closed mapping site (ADR-040 §2.4, ADR-012 §4a) — and bound by the Security
+ * Interceptor. Callers that require a non-SHARED context MUST NOT call this bridge.
  *
  * <h2>JFR-First</h2>
  * <p>Every derivation emits a {@code StorageContextDerived} JFR event.

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelIsolationClaims.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelIsolationClaims.java
@@ -30,12 +30,20 @@ package eu.exeris.kernel.spi.security;
  *   </td></tr>
  * </table>
  *
- * <h2>Fail-Closed Default</h2>
- * <p>If {@link #ISOLATION_STRATEGY} is absent or contains an unrecognised value,
- * the Security layer MUST fall back to
- * {@link ImmutableStorageContext#shared(long, long)} — a SHARED/RLS context.
- * This prevents an attacker from escaping tenant isolation by supplying a
- * crafted or malformed strategy claim.
+ * <h2>Fail-Closed Rule (ADR-012 §4a, amended 2026-06-10 — S-P0-07)</h2>
+ * <p>Absence and breakage are <b>not</b> the same case:
+ * <ul>
+ *   <li><b>Absent/blank</b> {@link #ISOLATION_STRATEGY} — no isolation intent was expressed, so the
+ *       mapping falls back to {@link ImmutableStorageContext#shared(long, long)} (a SHARED/RLS context).
+ *       This is the <i>only</i> permissive fall-through.</li>
+ *   <li><b>Declared but unhonourable</b> — an unrecognised strategy value, a wrong-typed claim, or a
+ *       missing/blank required sub-claim — is a <b>terminal deny</b>
+ *       ({@code SecurityAuthenticationException}, {@code EX-SEC-2002}), never a downgrade.</li>
+ * </ul>
+ * <p>Producing {@code SHARED} for a declared-but-broken strategy is <b>fail-OPEN</b>: it silently drops
+ * the tenant to the weakest isolation tier and grants a session on malformed or injected security input.
+ * The mapping is implemented once, in
+ * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims}.
  *
  * <h2>The Wall</h2>
  * <p>This class is part of {@code exeris-kernel-spi} and carries no runtime
@@ -52,8 +60,9 @@ public final class KernelIsolationClaims {
      * JWT claim that encodes the desired {@link StorageContext.IsolationStrategy}.
      *
      * <p>Value is the enum name string: {@code "SHARED"}, {@code "SEPARATED_SCHEMA"},
-     * or {@code "DEDICATED"}. If absent or unrecognised, the Security layer MUST
-     * default to {@code SHARED} (fail-closed).
+     * or {@code "DEDICATED"}. If <b>absent or blank</b>, the mapping defaults to {@code SHARED}
+     * (no isolation intent expressed). An <b>unrecognised or wrong-typed</b> value is a terminal
+     * deny ({@code EX-SEC-2002}), not a downgrade — see the class-level fail-closed rule.
      *
      * <p>This claim is consumed exclusively by the Security edge during token parsing.
      * The Persistence subsystem sees only the resulting {@link StorageContext}.
@@ -68,8 +77,9 @@ public final class KernelIsolationClaims {
      * {@code SET search_path TO &lt;schemaName&gt;}. Must be a valid PostgreSQL
      * identifier (lowercase letters, digits, underscores; max 63 characters).
      *
-     * <p>If this claim is absent when {@link #ISOLATION_STRATEGY} is
-     * {@code "SEPARATED_SCHEMA"}, the Security layer MUST fall back to {@code SHARED}.
+     * <p>If this claim is absent or blank when {@link #ISOLATION_STRATEGY} is
+     * {@code "SEPARATED_SCHEMA"}, the declared strategy cannot be honoured and the mapping MUST
+     * <b>deny</b> ({@code EX-SEC-2002}) — falling back to {@code SHARED} here would be fail-OPEN.
      */
     public static final String SCHEMA_NAME = "x-exeris-isolation-schema";
 
@@ -79,8 +89,9 @@ public final class KernelIsolationClaims {
      *
      * <p>The value must exactly match a key present in
      * {@link eu.exeris.kernel.spi.persistence.PersistenceConfig#dedicatedDataSources()}.
-     * If this claim is absent when {@link #ISOLATION_STRATEGY} is {@code "DEDICATED"},
-     * the Security layer MUST fall back to {@code SHARED}.
+     * If this claim is absent or blank when {@link #ISOLATION_STRATEGY} is {@code "DEDICATED"},
+     * the declared strategy cannot be honoured and the mapping MUST <b>deny</b>
+     * ({@code EX-SEC-2002}) — falling back to {@code SHARED} here would be fail-OPEN.
      *
      * <p>If the key is present in the JWT but not found in the configured
      * {@code dedicatedDataSources} map at connection time, the Persistence layer

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelIsolationClaims.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/KernelIsolationClaims.java
@@ -42,8 +42,21 @@ package eu.exeris.kernel.spi.security;
  * </ul>
  * <p>Producing {@code SHARED} for a declared-but-broken strategy is <b>fail-OPEN</b>: it silently drops
  * the tenant to the weakest isolation tier and grants a session on malformed or injected security input.
- * The mapping is implemented once, in
- * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims}.
+ *
+ * <h3>Which layer enforces which case — driver implementors read this</h3>
+ * <p>The deny is mandatory in every case above, but it is <b>not</b> enforced in one place:
+ * <ul>
+ *   <li><b>Unrecognised strategy value</b> and <b>missing/blank sub-claim</b> — enforced by
+ *       {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims}, the single
+ *       kernel-owned mapping every {@code IdentityProvider} routes through. Drivers get this for free.</li>
+ *   <li><b>Wrong-typed claim</b> (present but not representable as a single string) — a
+ *       <b>{@code TokenValidator} obligation</b>, <i>not</i> covered by {@code fromClaims}. Per
+ *       {@link eu.exeris.kernel.spi.security.identity.VerifiedClaims#claim(String)} such a claim is
+ *       reported as <i>absent</i>, so it reaches the mapping as the permissive no-intent case and would
+ *       resolve to {@code SHARED}. A driver that does not type-check the claim during validation
+ *       therefore re-creates the fail-OPEN downgrade at its own layer. The first-party Community driver
+ *       discharges this in its token validator; every other driver MUST do the equivalent.</li>
+ * </ul>
  *
  * <h2>The Wall</h2>
  * <p>This class is part of {@code exeris-kernel-spi} and carries no runtime
@@ -61,8 +74,10 @@ public final class KernelIsolationClaims {
      *
      * <p>Value is the enum name string: {@code "SHARED"}, {@code "SEPARATED_SCHEMA"},
      * or {@code "DEDICATED"}. If <b>absent or blank</b>, the mapping defaults to {@code SHARED}
-     * (no isolation intent expressed). An <b>unrecognised or wrong-typed</b> value is a terminal
-     * deny ({@code EX-SEC-2002}), not a downgrade — see the class-level fail-closed rule.
+     * (no isolation intent expressed). An <b>unrecognised</b> value is a terminal deny
+     * ({@code EX-SEC-2002}) in the mapping; a <b>wrong-typed</b> value must be denied by the driver's
+     * {@code TokenValidator} before the mapping sees it — neither is ever a downgrade. See the
+     * class-level fail-closed rule for which layer owns which case.
      *
      * <p>This claim is consumed exclusively by the Security edge during token parsing.
      * The Persistence subsystem sees only the resulting {@link StorageContext}.


### PR DESCRIPTION
Javadoc-only. **No bytecode change**, no behaviour change, no test change.

## What is wrong

`KernelIsolationClaims` is the normative definition of the storage-isolation claim names — it is what an
implementor reads to learn the contract. In **four** separate places it still instructed implementations to
fall back to `SHARED` on a declared-but-broken strategy:

| Location | Stale text |
|---|---|
| class-level `<h2>Fail-Closed Default</h2>` | "absent **or contains an unrecognised value** … MUST fall back to `shared(long, long)`" |
| `ISOLATION_STRATEGY` | "If absent **or unrecognised**, the Security layer MUST default to `SHARED` (fail-closed)" |
| `SCHEMA_NAME` | "If this claim is absent when `ISOLATION_STRATEGY` is `SEPARATED_SCHEMA`, the Security layer MUST fall back to `SHARED`" |
| `DATASOURCE_KEY` | same |

That is the **S-P0-07 fail-OPEN rule**, superseded by the ADR-012 §4a amendment of 2026-06-10 — and it was
never what the kernel does. `IdentityStorageMapping.fromClaims` throws `SecurityAuthenticationException`
(`EX-SEC-2002`) on all four of those inputs, and `AbstractSecurityProviderTck.IsolationStrategyContract`
pins the deny with explicit "downgrade is fail-OPEN" assertions.

So the public SPI documented a **weaker security contract than the kernel enforces**. An implementor
reading only the Javadoc would have written the downgrade the TCK rejects. ADR-012 §10's anti-drift rule
("if code differs from ADR text, update implementation plus TCK or amend ADR before merge") requires
closing this.

## What changed

The wording now separates the two cases the old text conflated:

- **absent/blank** → the one permissive fall-through (no isolation intent was expressed) → `SHARED`
- **declared but unhonourable** (unrecognised value, wrong-typed claim, missing/blank required sub-claim)
  → **terminal deny**, `EX-SEC-2002`

`StorageContextBridge` carried a second, unrelated staleness of the same class: it named
`SecurityProvider#authenticate` twice as the producer of non-`SHARED` contexts. Since ADR-040 (v0.10) the
producer is `IdentityStorageMapping.fromClaims` — verified: no `SecurityProvider` implementation reads
`KernelIsolationClaims` any more, and `fromClaims` has exactly one production caller
(`CommunityOidcIdentityProvider:129`).

## Verification

- `mvn install` on `exeris-kernel-spi` + `exeris-kernel-core` — GREEN
- `mvn pmd:check checkstyle:check` — **0 violations** (run explicitly; `verify` skips PMD)
- Javadoc rendering not verified — the repo pins no `maven-javadoc-plugin`, so it is not a build gate here.

## Relationship to the other PR

Found while writing the v0.11 S1 ADR-012 amendment (shared-scope tier), deliberately split out: this is a
security-contract correction that predates that work and deserves its own line in the history. The two PRs
touch disjoint files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)