### PR TITLE
test(tck): bind the wrong-typed isolation-strategy deny across all SecurityProvider bindings

### DIFF
--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityIsolationStrategyResolutionTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityIsolationStrategyResolutionTest.java
@@ -46,6 +46,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   <tr><td>8</td><td>wrong-typed</td><td>—</td><td>DENY (EX-SEC-2002)</td></tr>
  * </table>
  *
+ * <p>Every row here is also driven across all bindings by
+ * {@code AbstractSecurityProviderTck.IsolationStrategyContract}; this class is the Community-local
+ * companion, not the authoritative coverage. Case 8 in particular used to be the <i>only</i> coverage
+ * of the wrong-typed deny anywhere in the repository — the abstract suite had no such case, so no
+ * other binding was ever asked for that token. It now does (ADR-012 §9, enforcement layers).
+ *
  * @since 0.5.0
  */
 @DisplayName("Community: isolation strategy resolution — fail-closed (ADR-012 §4a amended)")

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
@@ -141,6 +141,15 @@ class CommunitySecurityProviderTckTest extends AbstractSecurityProviderTck {
     }
 
     @Override
+    protected LoanedBuffer createTokenWithWrongTypedStrategy() {
+        // A JSON number where a strategy string belongs. Discharged by the driver's own token
+        // validation — the kernel mapping cannot see this case (see the TCK factory's Javadoc).
+        return TestJwt.builder()
+                .claimRaw(KernelIsolationClaims.ISOLATION_STRATEGY, 42)
+                .toBuffer();
+    }
+
+    @Override
     protected RotationHarness createRotationHarness() {
         return new CommunityRotationHarness();
     }

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderFixture.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderFixture.java
@@ -57,12 +57,16 @@ public final class CoreSecurityProviderFixture implements SecurityProvider {
             case 2  -> ImmutableStorageContext.separatedSchema(TENANT_KEY, SEPARATED_SCHEMA_NAME);
             case 3  -> ImmutableStorageContext.dedicated(TENANT_KEY, DEDICATED_DS_KEY);
             // ADR-012 §4a (amended) / S-P0-07: a declared-but-unhonourable isolation strategy is a
-            // terminal deny, NOT a downgrade to SHARED. Sizes 10/11/12 model the three deny shapes
+            // terminal deny, NOT a downgrade to SHARED. Sizes 10/11/12/13 model the four deny shapes
             // the inverted IsolationStrategyContract drives (missing schema / missing datasource /
-            // unrecognized strategy). Secret-safe reason codes only.
+            // unrecognized strategy / wrong-typed strategy). Secret-safe reason codes only.
+            // Size 13 models what a conforming provider does during *its own* token validation:
+            // per §9 the wrong-typed deny is not inherited from IdentityStorageMapping, because
+            // VerifiedClaims.claim() reports such a claim as absent.
             case 10 -> throw new SecurityAuthenticationException("JWT", "isolation-incomplete");
             case 11 -> throw new SecurityAuthenticationException("JWT", "isolation-incomplete");
             case 12 -> throw new SecurityAuthenticationException("JWT", "isolation-unknown-strategy");
+            case 13 -> throw new SecurityAuthenticationException("JWT", "isolation-malformed");
             default -> ImmutableStorageContext.GLOBAL;
         };
         return new AuthenticationResult(

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderTckTest.java
@@ -73,6 +73,11 @@ class CoreSecurityProviderTckTest extends AbstractSecurityProviderTck {
         return new StubLoanedBuffer(12L); // fixture denies: unrecognized strategy value
     }
 
+    @Override
+    protected LoanedBuffer createTokenWithWrongTypedStrategy() {
+        return new StubLoanedBuffer(13L); // fixture denies: wrong-typed strategy claim
+    }
+
     private static final class StubLoanedBuffer implements LoanedBuffer {
         private long size;
 

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractSecurityProviderTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractSecurityProviderTck.java
@@ -295,6 +295,34 @@ public abstract class AbstractSecurityProviderTck {
      */
     protected abstract LoanedBuffer createTokenWithUnrecognizedStrategy();
 
+    /**
+     * Creates a {@link LoanedBuffer} containing a token whose isolation strategy claim is
+     * <b>present but not representable as a single string</b> — e.g. a JSON number, boolean, array,
+     * or object as the value of
+     * {@link eu.exeris.kernel.spi.security.KernelIsolationClaims#ISOLATION_STRATEGY}. An unrecognised
+     * <i>string</i> value is a different case, covered by {@link #createTokenWithUnrecognizedStrategy()}.
+     *
+     * <p>The provider MUST <b>deny</b> this token ({@link SecurityAuthenticationException},
+     * {@code EX-SEC-2002}).
+     *
+     * <h2>Why this case is the binding's own obligation</h2>
+     * <p>Every other isolation deny in this contract is enforced centrally: bindings route through
+     * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping#fromClaims} and inherit
+     * them for free. This one they do not inherit.
+     * {@link eu.exeris.kernel.spi.security.identity.VerifiedClaims#claim(String)} deliberately carries
+     * no deny logic and reports a present-but-not-single-string claim as <b>absent</b>, so a
+     * wrong-typed strategy arrives at the mapping as the permissive "no isolation intent" case and
+     * resolves to {@link StorageContext.IsolationStrategy#SHARED}. The deny must therefore happen
+     * earlier, in the binding's own token validation.
+     *
+     * <p>A binding that omits that check silently downgrades malformed security input to the weakest
+     * isolation tier — fail-OPEN — while passing every other case in this suite. That is why the case
+     * exists here rather than only in a binding-local unit test.
+     *
+     * <p>Caller owns the buffer lifecycle.
+     */
+    protected abstract LoanedBuffer createTokenWithWrongTypedStrategy();
+
     // =========================================================================
     // Optional rotation harness — default-skip for non-rotating subclasses
     // =========================================================================
@@ -897,6 +925,24 @@ public abstract class AbstractSecurityProviderTck {
                         .as("a declared-but-unrecognised strategy value cannot be honoured and MUST "
                                 + "be denied \u2014 downgrading to SHARED grants a session on an injection "
                                 + "probe instead of rejecting it (S-P0-07 / ADR-012 \u00a74a amended)")
+                        .isInstanceOfSatisfying(SecurityAuthenticationException.class, ex ->
+                                assertThat(ex.errorCode()).isEqualTo(KernelErrorCodes.EX_SEC_2002));
+            }
+        }
+
+        @Test
+        @DisplayName("wrong-typed strategy claim \u2192 terminal deny (EX-SEC-2002)")
+        void assert_authenticate_denies_on_wrong_typed_strategy() {
+            try (LoanedBuffer token = createTokenWithWrongTypedStrategy()) {
+                assertThatThrownBy(() -> provider.authenticate(token))
+                        .as("a present-but-not-string ISOLATION_STRATEGY is malformed security input "
+                                + "and MUST be denied. This is the one isolation deny the kernel cannot "
+                                + "make on a binding's behalf: VerifiedClaims.claim() reports a "
+                                + "wrong-typed claim as ABSENT, so it reaches "
+                                + "IdentityStorageMapping.fromClaims as the permissive no-intent case "
+                                + "and would resolve to SHARED. A binding that does not type-check "
+                                + "during validation fails OPEN here with every other gate green "
+                                + "(S-P0-07 / ADR-012 \u00a74a amended, \u00a79 enforcement layers)")
                         .isInstanceOfSatisfying(SecurityAuthenticationException.class, ex ->
                                 assertThat(ex.errorCode()).isEqualTo(KernelErrorCodes.EX_SEC_2002));
             }


### PR DESCRIPTION
Closes the gap recorded in ADR-012 §9 by #251. Test-only — **no production code changed** (`git diff --name-only` over `src/main` is empty).

## The gap

`AbstractSecurityProviderTck.IsolationStrategyContract` had six cases and **no wrong-typed one**. There was no `createTokenWithWrongTypedStrategy()` factory, so no binding was ever handed such a token. The only coverage anywhere in the repository was `CommunityIsolationStrategyResolutionTest` Case 8 — a Community-module-local unit test that no other binding runs.

The coverage was the wrong way round:

| Deny case | Enforced by | TCK-pinned before this PR |
|---|---|---|
| unrecognised strategy value | `IdentityStorageMapping.fromClaims` (kernel, central) | yes |
| missing/blank required sub-claim | `IdentityStorageMapping.fromClaims` (kernel, central) | yes |
| **wrong-typed strategy claim** | **the binding's own `TokenValidator`** | **no** |

The two the kernel makes on every binding's behalf were both gated. The one each binding must implement itself was not — and it is structurally impossible for `fromClaims` to cover it: `VerifiedClaims.claim()` reports a present-but-not-single-string claim as **absent**, so a wrong-typed `ISOLATION_STRATEGY` arrives as the permissive no-intent case and resolves to `SHARED`. A binding that omits the type-check fails open on the isolation boundary with every other case green.

## The change

- `IsolationStrategyContract`: new abstract factory + deny case → **7 cases**. The factory Javadoc explains why this one is the binding's own obligation, so an implementor cannot read it as ceremonial.
- **Community binding**: mints a real JWT with a numeric `ISOLATION_STRATEGY` via `TestJwt.Builder.claimRaw` — the fixture was written for exactly this purpose and had a single caller.
- **Core binding**: fixture gains size-13 beside the existing 10/11/12 deny shapes.

## Proven non-vacuous by mutation, not by inspection

A new deny-assertion is worth nothing if it passes for an unrelated reason, so I disabled `CommunityOidcTokenValidator.validateIsolationStrategyWellTyped` and re-ran:

```
Tests run: 7, Failures: 1 — IsolationStrategyContract
  assert_authenticate_denies_on_wrong_typed_strategy
  Expecting code to raise a throwable.
```

**Exactly one** test failed — the new one — and it failed because `authenticate()` **succeeded**. That is the fail-open itself, observed rather than argued: the malformed token was accepted and resolved to `SHARED`. The other six isolation cases stayed green, which independently confirms none of them covered this path. Guard restored afterwards; the diff carries no `src/main` change.

## Note on the Community-local test

ADR-012 §9's obligation says to "demote the Community-local test to its binding implementation". Implemented as: the **binding** now mints the token for the abstract suite, so Case 8 stops being the sole coverage. All eight rows stay in `CommunityIsolationStrategyResolutionTest` — every one of them is duplicated by the abstract suite, so deleting only Case 8 would be both inconsistent and a net loss of assertions. Its Javadoc now records that the abstract suite is the authoritative cross-binding coverage.

## Verification

- Full reactor `mvn clean install` — GREEN, nothing skipped
- `mvn pmd:check checkstyle:check` — **0 violations** (run explicitly; `verify` skips PMD)
- `IsolationStrategyContract` 7/7 on **both** bindings (Core + Community)

🤖 Generated with [Claude Code](https://claude.com/claude-code)