### PR TITLE
docs(tck): how to prove a new negative contract case is not vacuous

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,10 @@ Before submitting a PR, verify the following:
 
 A PR that only adds unit tests is **incomplete** if it touches an SPI boundary.
 
+If the TCK expansion asserts a **deny** or any other negative behaviour, it must also be shown to fail
+against a binding that does not implement it — a negative case that would stay green regardless enforces
+nothing. See [Proving a New Contract Case Is Not Vacuous](exeris-kernel-tck/README.md#proving-a-new-contract-case-is-not-vacuous).
+
 ---
 
 ## Getting Help

--- a/exeris-kernel-tck/README.md
+++ b/exeris-kernel-tck/README.md
@@ -11,6 +11,51 @@ The TCK (Technology Compatibility Kit) ensures that any implementation of Exeris
 - **Memory Safety:** Ensures zero-copy buffers are correctly released via `LoanedBuffer` `retain()`/`release()` through the `MemoryAllocator` SPI.
 - **Context Inheritance:** Validates that `ScopedValue` propagation works across Virtual Thread forks.
 
+## Proving a New Contract Case Is Not Vacuous
+
+A TCK case that asserts a **deny**, a **failure mode**, or any other negative behaviour is worthless if it
+would stay green against a binding that does not actually implement it. The failure mode is quiet: a
+non-conforming provider passes the suite, and the contract looks enforced when nothing enforces it.
+
+**Every new negative case must be demonstrated to fail against a non-conforming binding.** Do not reason
+about it — run it. Two techniques, in order of preference.
+
+### 1. Committed meta-test (preferred — it does not decay)
+
+Drive the abstract contract method directly against two in-memory fakes: one conforming, one deliberately
+non-conforming. Assert the first passes and the second fails. This lives in the repository and runs in CI
+forever, so the proof survives refactors of the contract it guards.
+
+Reference implementation: `contract/transport/ResetDiscriminatorSelfTest` (issue #180), which proves the
+`AbstractTransportStreamTck` reset-abandon discriminator rejects a binding that drains on `reset()` while
+declaring `expectsTrueReset() = true`. Note the two structural details worth copying — it calls the
+contract method directly (no JUnit-in-JUnit) and the fake binding is a `static` nested class so it is not
+itself discovered as a runnable suite.
+
+Use this whenever the contract can be exercised against a fake. Most lifecycle, state-machine, and
+ownership contracts can.
+
+### 2. One-off guard mutation (fallback — record the evidence in the PR)
+
+Temporarily disable the production guard the case is meant to pin, re-run the suite, and confirm that
+**exactly the new case fails, and that it fails for the right reason**. The reason matters as much as the
+count: a deny case that starts erroring on a `NullPointerException` proves nothing, whereas one reporting
+*"Expecting code to raise a throwable"* proves the operation succeeded where it should have been rejected —
+which is the fail-open itself, observed. Then revert; the mutation is never committed.
+
+Reference: PR #252 (wrong-typed isolation-strategy deny). Use this when standing up a non-conforming fake
+would mean re-implementing a real provider pipeline — there, the fake costs more than the proof is worth.
+
+Because this technique leaves nothing in the tree, **the PR body is the only durable artifact**: paste the
+failing output, name the guard you disabled, and state that the diff carries no `src/main` change.
+
+### When the case is a driver obligation, say so in the factory Javadoc
+
+Some contract cases cannot be satisfied centrally by the kernel and must be implemented by each binding —
+for example a deny the kernel's own mapping structurally cannot make. Those are the cases most likely to be
+silently skipped, so the abstract factory's Javadoc must state *why* the binding owns it, not merely what
+to return. See `AbstractSecurityProviderTck.createTokenWithWrongTypedStrategy()` (ADR-012 §9).
+
 ## ⚖️ Licence
 
 This module is licensed under the **Apache License 2.0 with Commons Clause**.


### PR DESCRIPTION
Docs-only. Acts on the non-blocking observation from the #252 review.

> *"if this pattern of 'prove the new case isn't vacuous' recurs across future TCK cases, it might be worth a short note … so it isn't re-derived ad hoc each time."*

## It has already recurred — three times, two different ways

That reframes it from "might be worth a note" to "there are two techniques in the tree and no guidance on which to use when":

| Occurrence | Technique used |
|---|---|
| Issue #180 — `ResetContract` abandon-vs-drain discriminator | **committed meta-test** (`ResetDiscriminatorSelfTest`) |
| `NativeTcpCloseKeyStreamReadInterestTest` (transport) | committed negative test |
| PR #252 — wrong-typed isolation-strategy deny | **one-off guard mutation** |

The #180 approach is strictly better where it is feasible — it lives in CI and does not decay when the contract it guards is later refactored. The #252 approach was the right call *there* only because standing up a non-conforming fake would have meant re-implementing the JWT provider pipeline. Nothing recorded that distinction, so the next author would have picked whichever came to mind.

## What the section says

Added to `exeris-kernel-tck/README.md`, in preference order:

1. **Committed meta-test (preferred).** Drive the contract method against two in-memory fakes, one conforming and one deliberately not. Points at `ResetDiscriminatorSelfTest` and calls out the two structural details worth copying — call the contract method directly (no JUnit-in-JUnit), and keep the fake binding a `static` nested class so it is not itself discovered as a runnable suite.
2. **One-off guard mutation (fallback).** Records the part that is easy to get wrong: **the failure reason matters as much as the failure count.** A deny case that starts erroring on an NPE proves nothing; one reporting *"Expecting code to raise a throwable"* proves the operation succeeded where it should have been rejected — the fail-open itself, observed. And since the mutation is never committed, the PR body is the only durable artifact, so it must carry the failing output and the name of the disabled guard.

Plus a short note that a case a binding must implement *itself* — one the kernel structurally cannot enforce centrally — should say so in the abstract factory's Javadoc, because those are the ones most likely to be quietly skipped.

Cross-referenced from `CONTRIBUTING.md`'s test-triad rule, since that is where a contributor actually lands.

## Merge order

**Land after #252.** The section cites `AbstractSecurityProviderTck.createTokenWithWrongTypedStrategy()` as the driver-obligation example, and that method arrives with #252 — it is not on `development/0.11.0` yet. The other reference (`ResetDiscriminatorSelfTest`) is already on the base branch. Verified both explicitly rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)