### PR TITLE
ci(sonar): run the scanner from CI so coverage is imported; suppress the @Nested S2187 noise

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -107,6 +107,20 @@ jobs:
         #
         # Skipped when the secret is absent (forked pull requests) — a missing token must not fail
         # the build gate.
+        #
+        # continue-on-error, deliberately: this job is the ROOT of the entire pipeline — all eight
+        # other jobs depend on it directly or transitively — so an unhealthy analysis step would take
+        # down every merge gate for a reason unrelated to the code under test. Static analysis is not
+        # a correctness gate here and must never be able to do that.
+        #
+        # It is load-bearing right now, not just prudent: the SonarQube Cloud organisation is
+        # currently without an administrator, so Automatic Analysis cannot be switched off — and
+        # SonarQube Cloud *rejects* a CI submission while it is enabled. Until that is resolved this
+        # step is expected to fail whenever a token is present.
+        #
+        # REMOVE once a CI-based analysis has been confirmed green; leaving it in permanently would
+        # let the analysis rot silently.
+        continue-on-error: true
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@v5
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,9 +33,18 @@ jobs:
       contents: read
       packages: write   # required for GitHub Packages publish
 
+    env:
+      # Job-level so the guard on the analysis step can read it — `secrets` is not available in a
+      # step-level `if`. Empty on forked PRs, which is exactly when the step must skip rather than fail.
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          # Sonar needs full history to attribute new code and blame; a shallow clone silently
+          # degrades the new-code period into "everything".
+          fetch-depth: 0
 
       - name: Cache JDK tarball
         id: jdk-cache
@@ -88,6 +97,18 @@ jobs:
           mvn clean verify -B -e \
             -P coverage \
             -Dexeris.tck.transport.drainTimeoutSeconds=30
+
+      - name: SonarQube Cloud Analysis
+        # Runs in this job, immediately after the build, so it consumes the compiled classes and the
+        # JaCoCo XML that `-P coverage` just produced rather than rebuilding them. That reuse is the
+        # whole point: SonarCloud Automatic Analysis never builds the project, so the
+        # `sonar.coverage.jacoco.xmlReportPaths` in sonar-project.properties could never resolve and
+        # coverage on new code read 0.0% on every pull request regardless of the tests written.
+        #
+        # Skipped when the secret is absent (forked pull requests) — a missing token must not fail
+        # the build gate.
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@v5
 
       - name: Upload TCK JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,19 @@ consumes the compiled classes and JaCoCo XML that build already produced. Config
 `sonar-project.properties` (the CLI scanner reads it; note that the `sonar:sonar` Maven goal would *not*).
 
 Two things must be true in the SonarQube Cloud project for this to work, and neither is expressible in
-this repository:
+this repository. **Do them in this order** — the second is a precondition of the first, not a companion
+to it:
 
-1. **`SONAR_TOKEN` repository secret** must exist. Without it the analysis step skips — deliberately, so
-   forked pull requests do not fail the build gate.
-2. **Automatic Analysis must stay OFF.** It is mutually exclusive with CI-based analysis: leave it on and
-   SonarQube Cloud *rejects* the CI submission, so the pipeline appears to work while the results keep
-   coming from the old path.
+1. **Automatic Analysis must be OFF.** It is mutually exclusive with CI-based analysis: leave it on and
+   SonarQube Cloud *rejects* the CI submission. Requires an organisation administrator.
+2. **`SONAR_TOKEN` repository secret.** Add it only once step 1 is done. Until then the analysis step
+   skips (no token) rather than failing — which is the state you want, because with Automatic Analysis
+   still enabled a submitted scan is rejected and the step fails.
+
+The analysis step carries `continue-on-error: true` precisely so that this cannot escalate: it runs in
+`build-and-verify`, which every other job depends on, and static analysis must never be able to block a
+merge gate. Remove that flag once a CI analysis has been confirmed green, otherwise a rotting analysis
+will go unnoticed.
 
 Automatic Analysis is also why coverage was reported as `0.0% on New Code` before this setup regardless of
 the tests written — it never builds the project, so no JaCoCo report exists for it to import. If you see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,25 @@ export DYLD_LIBRARY_PATH="$(brew --prefix openssl@3)/lib:$DYLD_LIBRARY_PATH"
 
 ---
 
+## Static Analysis (SonarQube Cloud)
+
+Analysis runs **from CI**, as a step in `build-and-verify` after `mvn clean verify -P coverage`, so it
+consumes the compiled classes and JaCoCo XML that build already produced. Configuration lives in
+`sonar-project.properties` (the CLI scanner reads it; note that the `sonar:sonar` Maven goal would *not*).
+
+Two things must be true in the SonarQube Cloud project for this to work, and neither is expressible in
+this repository:
+
+1. **`SONAR_TOKEN` repository secret** must exist. Without it the analysis step skips — deliberately, so
+   forked pull requests do not fail the build gate.
+2. **Automatic Analysis must stay OFF.** It is mutually exclusive with CI-based analysis: leave it on and
+   SonarQube Cloud *rejects* the CI submission, so the pipeline appears to work while the results keep
+   coming from the old path.
+
+Automatic Analysis is also why coverage was reported as `0.0% on New Code` before this setup regardless of
+the tests written — it never builds the project, so no JaCoCo report exists for it to import. If you see
+0.0% coverage on a pull request again, suspect the analysis path before suspecting the tests.
+
 ## Build & Test
 
 ### The Golden Command

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=exeris-systems_exeris-kernel
 sonar.projectName=Exeris Kernel
-sonar.projectVersion=0.6.0
+sonar.projectVersion=0.11.0
 
 sonar.sourceEncoding=UTF-8
 sonar.java.source=26
@@ -18,3 +18,30 @@ sonar.coverage.exclusions=**/*Benchmark*.java,**/target/**
 # them is noise.
 sonar.cpd.exclusions=**/*Benchmark*.java,**/*Event.java
 sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml
+
+# Compiled output. Required by the CLI scanner for Java analysis — the Maven goal infers these, the
+# standalone scanner does not, and without them analysis degrades or fails outright. Populated by the
+# `mvn clean verify -P coverage` that runs immediately before the scan in the same CI job.
+sonar.java.binaries=**/target/classes
+sonar.java.test.binaries=**/target/test-classes
+sonar.java.libraries=**/target/*.jar
+
+# ---------------------------------------------------------------------------
+# java:S2187 "Add some tests to this class" — suppressed on test sources.
+#
+# PROVISIONAL. The rule fires on the house test shape: a class whose tests all live in JUnit 5
+# @Nested inner classes has no top-level @Test, and the analyzer served by SonarCloud Automatic
+# Analysis does not look inside. That is 103 test classes here and 77 open issues, none of them real
+# — every one of those classes runs tests.
+#
+# Trade-off, stated plainly: this also hides a genuinely empty test class. That is judged the lesser
+# cost against 77 false BLOCKERs, which train reviewers to ignore the rule entirely.
+#
+# RE-TEST AND REMOVE IF POSSIBLE. This repo is moving from Automatic Analysis to a CI-run scanner in
+# the same change, which pulls a current sonar-java. Newer analyzers understand @Nested, so this
+# suppression may already be unnecessary — verify against the first CI-based analysis and delete it
+# if S2187 no longer fires.
+# ---------------------------------------------------------------------------
+sonar.issue.ignore.multicriteria=nestedTests
+sonar.issue.ignore.multicriteria.nestedTests.ruleKey=java:S2187
+sonar.issue.ignore.multicriteria.nestedTests.resourceKey=**/src/test/java/**/*.java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,9 @@
 sonar.projectKey=exeris-systems_exeris-kernel
+# Mandatory for CI-based scans. Automatic Analysis resolved it server-side from the linked repository;
+# the CLI scanner does not and fails outright without it.
+sonar.organization=exeris-systems
 sonar.projectName=Exeris Kernel
-sonar.projectVersion=0.11.0
+sonar.projectVersion=0.11.0-SNAPSHOT
 
 sonar.sourceEncoding=UTF-8
 sonar.java.source=26


### PR DESCRIPTION
Closes both repo-level Sonar conditions surfaced while dispositioning #254. Neither was a property of that PR.

> ## ⚠️ Two manual steps, or this changes nothing
>
> 1. Add a **`SONAR_TOKEN`** repository secret. Without it the step *skips* by design (so forked PRs don't fail the gate) — analysis simply stays where it is.
> 2. **Turn Automatic Analysis OFF** in the SonarQube Cloud project. It is mutually exclusive with CI analysis: leave it on and SonarQube Cloud **rejects** the CI submission, so the pipeline looks healthy while results keep coming from the old path. This is the failure mode most likely to waste an afternoon.
>
> Both are recorded in `CONTRIBUTING.md` too, since neither is expressible in-repo.

## 1. Coverage was structurally unmeasurable, not untested

`sonar-project.properties` already set `sonar.coverage.jacoco.xmlReportPaths`, and JaCoCo really does emit that XML under `-P coverage` (with per-module ratchet minimums). But **no workflow ever ran a scanner** — analysis came from SonarCloud **Automatic Analysis**, which never builds the project. So the report did not exist when the import ran, the import silently no-opped, and *Coverage on New Code* read **0.0% on every PR regardless of the tests in it**.

The properties file reading as though coverage were tracked is worse than it plainly not being configured — it invites treating a meaningless zero as a signal.

The scan now runs inside `build-and-verify`, immediately after `mvn clean verify -P coverage`, reusing that build's classes and JaCoCo XML instead of paying for a second build. Supporting changes:

- `fetch-depth: 0` on checkout — without full history Sonar cannot attribute new code or blame, and the new-code period silently degrades to "everything"
- `sonar.java.binaries` / `test.binaries` / `libraries` — the CLI scanner does not infer these. (The Maven `sonar:sonar` goal *would*, but it also ignores `sonar-project.properties` entirely, so switching to it would mean migrating all the tuned source/exclusion/CPD config into the POM — a much larger change for no gain.)
- the step is guarded on `SONAR_TOKEN` being non-empty, read from a **job-level** `env` because `secrets` is not available in a step-level `if`

## 2. `java:S2187` — 77 false BLOCKERs, suppressed **provisionally**

The rule fires on the house test shape: tests live in JUnit 5 `@Nested` inner classes, so the outer class has no top-level `@Test` and the analyzer served by Automatic Analysis does not look inside. That is **103 test classes** here and **77 open issues**, none of them real — every one of those classes runs tests.

Suppressed on `**/src/test/java/**/*.java`, with two things written into the file rather than left implicit:

- **The trade-off.** This also hides a genuinely empty test class. Judged the lesser cost against 77 false BLOCKERs, which train reviewers to ignore the rule entirely — and a truly empty test class is something review catches.
- **It may already be unnecessary.** This same PR moves analysis onto a current `sonar-java`, and newer analyzers understand `@Nested`. **Verify against the first CI-based run and delete the suppression if S2187 no longer fires.** Marked `PROVISIONAL` in the file so it does not quietly become permanent.

## Also

`sonar.projectVersion` still read `0.6.0` against a `0.11.0-SNAPSHOT` reactor.

## Verification

YAML parsed and the resulting job structure asserted (step order, the `fetch-depth: 0` on checkout, the job-level env, the guard expression). The analysis path itself can only be verified by the first run on a branch that has the secret — stated rather than claimed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)