### PR TITLE
feat(persistence): publish exeris.shared_scope so RLS can widen reads while writes stay pinned (v0.11 S3, ADR-012 §4b.4)

### DIFF
--- a/docs/adr/ADR-012-security-trust-model-upgrade-for-resource-server-validation-and-fail-closed-runtime.md
+++ b/docs/adr/ADR-012-security-trust-model-upgrade-for-resource-server-validation-and-fail-closed-runtime.md
@@ -165,10 +165,18 @@ the RFC deferred to this amendment. **Not yet implemented** — see §10.
   through one mapping site — the contract must be proven from both entry surfaces.
 - `ImmutableStorageContext` must have a constructor-invariant case: `sharedScopeKey` present with
   `isolationKey` absent is rejected (§4b.2).
-- `AbstractPersistenceEngineTck` must carry a shared-vs-tenant **access matrix**: the read-widen path (a
+- The persistence TCK must carry a shared-vs-tenant **access matrix**: the read-widen path (a
   tenant reads another owner's row inside the same shared scope) and the write-pin path (a tenant cannot
   write a row owned by another tenant, inside or outside the shared scope). Cross-tenant mutation stays out
   of scope (§4b.4) and MUST NOT be added to the matrix as an allowed cell.
+  - **Host corrected 2026-07-29 (v0.11 S3): `AbstractSharedScopeAccessMatrixTck`, not
+    `AbstractPersistenceEngineTck`.** This clause originally named the latter. Implementation showed that
+    would be self-defeating: the only in-repo binding of `AbstractPersistenceEngineTck` runs on H2 in
+    PostgreSQL-compatibility mode, and H2 implements neither `CREATE POLICY` nor `current_setting`, so a
+    matrix hosted there could only ever *skip*. That is a vacuous anchor — the same failure class as the
+    wrong-typed isolation case, which sat unbound behind a green suite until 2026-07-29. The matrix
+    therefore lives in its own abstract suite whose binding is a live-database one, which keeps the
+    obligation both abstract and non-vacuous. The requirement is unchanged; only its host is.
 - **"Two bindings" — RULED (amended 2026-07-29).** The §9 two-binding language means *every binding that
   exists in-repo, plus a recorded obligation on out-of-repo bindings* — not "block the contract until a
   second in-repo binding is invented". Only one in-repo persistence binding exists (Community/Postgres), so
@@ -184,7 +192,8 @@ the RFC deferred to this amendment. **Not yet implemented** — see §10.
 - Implemented now (repository state): `KernelIsolationClaims` defines normative JWT claim names for storage isolation strategy routing.
 - Implemented now (repository state, corrected 2026-07-29): the isolation claims are read and mapped in `IdentityStorageMapping.fromClaims` (SPI, ADR-040) — the single kernel-owned fail-closed site — producing all three `ImmutableStorageContext` variants after JWT validation. Its only production caller is `CommunityOidcIdentityProvider`; no `SecurityProvider` implementation reads `KernelIsolationClaims` any more. The earlier "Community SecurityProvider reads isolation claims" line described the v0.9 architecture.
 - **Implemented now (§4b carrier + claim + deny, v0.11 S2):** `StorageContext.sharedScopeKey()` (additive, tenant-private `default`), the 6th `ImmutableStorageContext` component with its `sharedScopeKey`-requires-`isolationKey` constructor invariant, `KernelIsolationClaims.SHARED_SCOPE_KEY`, and the §4b.5 terminal deny in `IdentityStorageMapping.fromClaims` (`EX-SEC-2002` / `shared-scope-unsupported`). The deny did not lag the carrier — both landed in the same change, as §4b.5 requires.
-- **Not implemented (planned, §4b.4):** the read-widen / owner-scoped-write RLS mode. No persistence binding enforces shared visibility, which is *why* the mapping currently denies every declared shared scope rather than honouring it. When a binding gains the mode the deny becomes conditional on the deployment rather than disappearing, so no window opens in which a declared scope resolves to anything but deny or correct enforcement.
+- **Implemented now (§4b.4 enforcement substrate, v0.11 S3):** the Community persistence binding publishes `exeris.shared_scope` alongside `exeris.tenant_id` on every strategy, so a deployment's RLS policy can widen its read predicate while `WITH CHECK` keeps writes pinned to the owner. The setting is published unconditionally — as `""` when absent — because session-scoped settings survive connection reuse and skipping the statement would widen a request that declared no scope. `AbstractSharedScopeAccessMatrixTck` codifies the matrix, bound against live PostgreSQL.
+- **Not implemented (planned):** the kernel ships no RLS policy and cannot introspect the deployment's, so it has no way to tell whether a given deployment honours a shared scope. That signal — a capability seam between Security and Persistence — is what `IdentityStorageMapping` still lacks, and is why it denies every declared shared scope rather than honouring it. The tier is therefore not reachable end-to-end yet: enforcement exists, the path to it does not. When the seam lands, the deny becomes conditional on the deployment rather than disappearing, so no window opens in which a declared scope resolves to anything but deny or correct enforcement.
 - Implemented now (repository state): Community `PersistenceEngine` routes DEDICATED strategy to per-tenant pools from `PersistenceConfig.dedicatedDataSources()`.
 - Repository-state disclaimer: this ADR defines target contract semantics even where implementation is currently partial, staged, or temporarily embedded.
 - Planned target state: unified JWT/JWS/JWKS/OIDC resource-server trust pipeline with deterministic deny on uncertainty, fail-closed lifecycle gates, explicit rotation TTL/staleness/outage semantics, and mandatory typed telemetry categories.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PostgresIdentifier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/PostgresIdentifier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+/**
+ * Community: validation of PostgreSQL identifiers that must be interpolated into SQL text.
+ *
+ * <p>Exists because a schema name cannot be passed as a bind parameter — {@code SET search_path} takes an
+ * identifier, not a value — so the only defence against injection is refusing anything that is not a plain
+ * identifier. Deliberately stricter than PostgreSQL itself: no quoting, no uppercase, no dollar signs and
+ * no Unicode, because the kernel never needs them and every character allowed is one an attacker can try.
+ *
+ * @since 0.11.0
+ */
+final class PostgresIdentifier {
+
+    private static final int MAX_LENGTH = 63;
+
+    private PostgresIdentifier() {
+        // Utility class — not instantiable.
+    }
+
+    /**
+     * Whether {@code identifier} is safe to interpolate directly into SQL text.
+     *
+     * @param identifier candidate identifier; may be {@code null}
+     * @return {@code true} only for {@code [a-z][a-z0-9_]{0,62}}
+     */
+    /* default */ static boolean isSafe(String identifier) {
+        if (identifier == null) {
+            return false;
+        }
+        int length = identifier.length();
+        if (length < 1 || length > MAX_LENGTH) {
+            return false;
+        }
+        if (!isLowerAlpha(identifier.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < length; i++) {
+            if (!isIdentifierPart(identifier.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isLowerAlpha(char candidate) {
+        return candidate >= 'a' && candidate <= 'z';
+    }
+
+    private static boolean isIdentifierPart(char candidate) {
+        return isLowerAlpha(candidate)
+                || (candidate >= '0' && candidate <= '9')
+                || candidate == '_';
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptor.java
@@ -28,12 +28,32 @@ import eu.exeris.kernel.spi.security.StorageContext;
  * <table>
  *   <tr><th>Strategy</th><th>SQL issued</th></tr>
  *   <tr><td>{@link StorageContext.IsolationStrategy#SHARED}</td>
- *       <td>{@code SELECT set_config('exeris.tenant_id', $1, false)} (session-level)</td></tr>
+ *       <td>{@code set_config('exeris.tenant_id', $1, false)} and
+ *           {@code set_config('exeris.shared_scope', $2, false)} in one statement</td></tr>
  *   <tr><td>{@link StorageContext.IsolationStrategy#SEPARATED_SCHEMA}</td>
- *       <td>{@code SET search_path TO &lt;schemaName&gt;, public} (session-level)</td></tr>
+ *       <td>{@code SET search_path TO &lt;schemaName&gt;, public}, then the shared-scope setting</td></tr>
  *   <tr><td>{@link StorageContext.IsolationStrategy#DEDICATED}</td>
- *       <td>No-op — routing is handled at the pool level by the engine</td></tr>
+ *       <td>Routing is handled at the pool level by the engine; only the shared-scope setting is issued</td></tr>
  * </table>
+ *
+ * <h2>Shared Scope — Row Visibility (ADR-012 §4b)</h2>
+ * <p>{@code exeris.shared_scope} is published alongside the tenant key on every strategy, because
+ * row-visibility is orthogonal to physical placement. The interceptor only <em>publishes</em> the
+ * setting; whether reads actually widen is decided by the deployment's own RLS policy, which the kernel
+ * does not ship and cannot introspect. A conforming policy widens the read predicate and leaves the write
+ * predicate pinned to the owner:
+ *
+ * <pre>{@code
+ * CREATE POLICY tenant_isolation ON <table>
+ *   USING (tenant_id = current_setting('exeris.tenant_id', true)
+ *          OR (NULLIF(current_setting('exeris.shared_scope', true), '') IS NOT NULL
+ *              AND shared_scope = current_setting('exeris.shared_scope', true)))
+ *   WITH CHECK (tenant_id = current_setting('exeris.tenant_id', true));
+ * }</pre>
+ *
+ * <p>Note that {@code WITH CHECK} is unchanged from the tenant-private policy — owner-scoped write is
+ * what the existing clause already expresses, so widening reads does not require relaxing writes. A
+ * tenant can read its partition-mates' rows and still only ever write its own.
  *
  * <h2>The Agnostic Data Principle</h2>
  * <p>This interceptor is <b>identity-blind</b> — it never imports
@@ -70,11 +90,18 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
      * <p>Uses parameterised bind to prevent SQL injection (isolationKey is untrusted data).
      */
     private static final String SQL_SET_TENANT =
-            "SELECT set_config('exeris.tenant_id', ?, false)";
+            "SELECT set_config('exeris.tenant_id', ?, false), set_config('exeris.shared_scope', ?, false)";
+
+    /**
+     * Shared-scope publication for the strategies whose own injection cannot carry it
+     * ({@code SEPARATED_SCHEMA}, {@code DEDICATED}). One extra round-trip; see
+     * {@link #injectSharedScope} for why it is unconditional.
+     */
+    private static final String SQL_SET_SHARED_SCOPE =
+            "SELECT set_config('exeris.shared_scope', ?, false)";
 
     private static final String SQL_SET_SCHEMA_PREFIX = "SET search_path TO ";
     private static final String SQL_SET_SCHEMA_SUFFIX = ", public";
-    private static final int MAX_IDENTIFIER_LENGTH = 63;
 
     private static final String INTERCEPTOR_NAME = "RlsConnectionInterceptor";
     private static final String ISOLATION_KEY_NONE = "[none]";
@@ -87,8 +114,11 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
      * Injects the isolation key from the current {@link eu.exeris.kernel.spi.context.KernelProviders#STORAGE_CONTEXT}
      * into the database connection before it is returned to the caller.
      *
-     * <p>O(1) per invocation — one SQL round-trip for SHARED/SEPARATED_SCHEMA strategy,
-     * zero SQL for DEDICATED strategy.
+     * <p>O(1) per invocation. SHARED costs one round-trip (tenant key and shared scope are published by
+     * the same statement). SEPARATED_SCHEMA and DEDICATED each cost one more than before this contract
+     * gained a shared scope: the setting is orthogonal to physical placement, so it cannot ride their
+     * strategy-specific injection, and it cannot be skipped when absent without leaving a stale value on
+     * a pooled connection — see {@link #injectSharedScope}.
      *
      * @param connection     the freshly acquired connection; must not be closed
      * @param storageContext the isolation descriptor resolved by the Security edge
@@ -100,9 +130,15 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
         StorageContext.IsolationStrategy strategy = storageContext.strategy();
 
         switch (strategy) {
+            // SHARED publishes both settings in one round-trip — the statement already existed.
             case SHARED           -> injectTenantId(connection, storageContext);
-            case SEPARATED_SCHEMA -> injectSchemaPath(connection, storageContext);
-            case DEDICATED        -> { /* no-op — routing already handled at pool level */ }
+            case SEPARATED_SCHEMA -> {
+                injectSchemaPath(connection, storageContext);
+                injectSharedScope(connection, storageContext);
+            }
+            // Pool-level routing still needs no tenant injection, but the shared-scope setting is
+            // orthogonal to placement and must be published (or cleared) here too.
+            case DEDICATED        -> injectSharedScope(connection, storageContext);
         }
     }
 
@@ -116,15 +152,58 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
         // For global/system context use "" to clear any prior tenant from the pooled connection.
         // set_config(..., false) is session-level, so prior tenant values survive pool recycle.
         String effectiveKey = (isolationKey == null || isolationKey.isBlank()) ? "" : isolationKey;
-        try (PersistenceStatement stmt = connection.prepare(SQL_SET_TENANT);
-             QueryResult _ = stmt.bindString(0, effectiveKey).executeQuery()) {
-            // set_config() returns a single row; consume and discard
+        executeSetConfig(connection, SQL_SET_TENANT, effectiveKey,
+                effectiveKey, effectiveSharedScope(storageContext));
+    }
+
+    /**
+     * Runs a {@code set_config} statement, binding {@code values} positionally.
+     *
+     * <p>Shared by the tenant and shared-scope paths — the prepare/bind/execute/translate skeleton is
+     * identical and only the statement and its bindings differ.
+     *
+     * @param diagnosticKey the isolation key reported in a failure, never a claim or scope value
+     */
+    private static void executeSetConfig(PersistenceConnection connection,
+                                         String sql,
+                                         String diagnosticKey,
+                                         String... values) {
+        try (PersistenceStatement stmt = connection.prepare(sql)) {
+            for (int i = 0; i < values.length; i++) {
+                stmt.bindString(i, values[i]);
+            }
+            try (QueryResult _ = stmt.executeQuery()) {
+                // set_config() returns a single row; consume and discard
+            }
         } catch (PersistenceProviderException ppe) {
-            throw PersistenceProviderException.interceptorInitFailed(
-                    INTERCEPTOR_NAME,
-                    effectiveKey,
-                    ppe);
+            throw PersistenceProviderException.interceptorInitFailed(INTERCEPTOR_NAME, diagnosticKey, ppe);
         }
+    }
+
+    /**
+     * Publishes {@code exeris.shared_scope} for the strategies whose own injection cannot carry it.
+     *
+     * <p><b>Unconditional by design.</b> It would be cheaper to skip the round-trip when the context
+     * declares no shared scope, and that would be a fail-open bug: {@code set_config(..., false)} is
+     * <em>session</em>-scoped, so on a pooled connection the previous request's shared scope survives
+     * into the next one. A request that never asked to participate in a shared partition would then have
+     * its reads widened into it — the same pool-recycle hazard the tenant key already guards against by
+     * always writing a value. Absence must be published as {@code ""}, not left unpublished.
+     */
+    private static void injectSharedScope(PersistenceConnection connection,
+                                          StorageContext storageContext) {
+        executeSetConfig(connection, SQL_SET_SHARED_SCOPE,
+                storageContext.isolationKey().orElse(ISOLATION_KEY_NONE),
+                effectiveSharedScope(storageContext));
+    }
+
+    /**
+     * The shared-scope value to publish: the declared partition, or {@code ""} to clear a stale one
+     * left on a recycled connection. Never {@code null}.
+     */
+    private static String effectiveSharedScope(StorageContext storageContext) {
+        String sharedScope = storageContext.sharedScopeKey().orElse(null);
+        return (sharedScope == null || sharedScope.isBlank()) ? "" : sharedScope;
     }
 
     private static void injectSchemaPath(PersistenceConnection connection,
@@ -136,7 +215,7 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
                     storageContext.isolationKey().orElse(ISOLATION_KEY_NONE),
                     null);
         }
-        if (!isSafeIdentifier(schemaName)) {
+        if (!PostgresIdentifier.isSafe(schemaName)) {
             throw PersistenceProviderException.interceptorInitFailed(
                     INTERCEPTOR_NAME,
                     storageContext.isolationKey().orElse(ISOLATION_KEY_NONE),
@@ -153,24 +232,5 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
         }
     }
 
-    private static boolean isSafeIdentifier(String schemaName) {
-        int length = schemaName.length();
-        if (length < 1 || length > MAX_IDENTIFIER_LENGTH) {
-            return false;
-        }
-        char first = schemaName.charAt(0);
-        if (first < 'a' || first > 'z') {
-            return false;
-        }
-        for (int i = 1; i < length; i++) {
-            char currentChar = schemaName.charAt(i);
-            boolean isLowercase = currentChar >= 'a' && currentChar <= 'z';
-            boolean isDigit = currentChar >= '0' && currentChar <= '9';
-            if (!isLowercase && !isDigit && currentChar != '_') {
-                return false;
-            }
-        }
-        return true;
-    }
 
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceSharedScopeIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceSharedScopeIT.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+import eu.exeris.kernel.spi.exceptions.persistence.PersistenceProviderException;
+import eu.exeris.kernel.spi.persistence.PersistenceConfig;
+import eu.exeris.kernel.spi.persistence.PersistenceConnection;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import eu.exeris.kernel.spi.persistence.PersistenceStatement;
+import eu.exeris.kernel.spi.persistence.QueryResult;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.security.StorageContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration: the shared-scope access matrix (ADR-012 §4b.4) against a live PostgreSQL instance.
+ *
+ * <h2>What this proves</h2>
+ * <ul>
+ *   <li><b>Read widens</b> — two tenants carrying the same {@code sharedScopeKey} see each other's rows
+ *       in the shared partition.</li>
+ *   <li><b>Write stays pinned</b> — a tenant inside the shared partition still cannot write a row owned
+ *       by another tenant. Reads widening does not relax writes.</li>
+ *   <li><b>No pool bleed</b> — the security-critical one. After a request that declared a shared scope,
+ *       a later request on a recycled connection that declares none must not inherit the widened
+ *       visibility. {@code set_config(..., false)} is session-scoped, so this only holds because the
+ *       interceptor publishes {@code ""} rather than skipping the statement.</li>
+ *   <li><b>Tenant-private is untouched</b> — a context with no shared scope behaves exactly as before
+ *       the accessor existed.</li>
+ * </ul>
+ *
+ * <h2>What the kernel does and does not own</h2>
+ * <p>The kernel publishes {@code exeris.tenant_id} and {@code exeris.shared_scope}; the policy that
+ * consumes them is the deployment's. The policy below is therefore both a fixture and the normative
+ * example of a conforming one — note that {@code WITH CHECK} is identical to the tenant-private policy.
+ * Owner-scoped write is what that clause already expresses.
+ *
+ * <p>Cross-tenant <em>mutation</em> of another owner's row is explicitly out of contract scope
+ * (ADR-012 §4b.4) and is asserted here as denied, not as a supported capability.
+ *
+ * <h2>Execution</h2>
+ * <pre>mvn -pl exeris-kernel-community test -Dtest=CommunityPersistenceSharedScopeIT -DincludedGroups=integration -DexcludedGroups=</pre>
+ *
+ * @since 0.11.0
+ */
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community persistence shared-scope access matrix — Testcontainers integration")
+class CommunityPersistenceSharedScopeIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    private static PersistenceEngine engine;
+
+    private static final String APP_USER = "exeris_app";
+    private static final String APP_PASSWORD = "exeris_app_pw";
+
+    private static final String TENANT_A = "tenant-a";
+    private static final String TENANT_B = "tenant-b";
+    private static final String WORLD = "world-alpha";
+
+    /** Both tenants inside the same shared partition. */
+    private static final StorageContext CTX_A_SHARED =
+            ImmutableStorageContext.shared(TENANT_A).withSharedScope(WORLD);
+    private static final StorageContext CTX_B_SHARED =
+            ImmutableStorageContext.shared(TENANT_B).withSharedScope(WORLD);
+
+    /** Same tenant, no shared scope declared — the tenant-private default. */
+    private static final StorageContext CTX_A_PRIVATE = ImmutableStorageContext.shared(TENANT_A);
+
+    @BeforeAll
+    static void startEngine() {
+        bootstrapSchema(POSTGRES);
+        engine = createEngine(POSTGRES);
+        engine.registerInterceptor(RlsConnectionInterceptor.INSTANCE);
+
+        insertRow(CTX_A_SHARED, WORLD, "a-in-world");
+        insertRow(CTX_B_SHARED, WORLD, "b-in-world");
+        insertRow(CTX_A_PRIVATE, null, "a-private");
+    }
+
+    @AfterAll
+    static void stopEngine() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test
+    @DisplayName("read widens — a tenant sees a partition-mate's row inside the shared scope")
+    void readWidensWithinSharedScope() {
+        assertThat(readVisible(CTX_A_SHARED))
+                .as("A declared the shared partition, so B's row in it becomes visible")
+                .contains("a-in-world", "b-in-world");
+
+        assertThat(readVisible(CTX_B_SHARED))
+                .as("symmetric — the widening is a property of the partition, not of one tenant")
+                .contains("a-in-world", "b-in-world");
+    }
+
+    @Test
+    @DisplayName("write stays pinned — a tenant cannot write a row owned by a partition-mate")
+    void writeStaysPinnedToOwner() {
+        assertThatThrownBy(() -> insertRow(CTX_A_SHARED, WORLD, "a-forging-b", TENANT_B))
+                .as("reads widening must not relax writes: WITH CHECK still pins owner = "
+                        + "current_setting('exeris.tenant_id'), so A forging a B-owned row is refused "
+                        + "even though A can read B's rows (ADR-012 §4b.4)")
+                .isInstanceOf(PersistenceProviderException.class);
+
+        assertThat(readVisible(CTX_B_SHARED))
+                .as("and nothing was written")
+                .doesNotContain("a-forging-b");
+    }
+
+    @Test
+    @DisplayName("no pool bleed — a later request without a shared scope does not inherit the widening")
+    void sharedScopeDoesNotSurviveOntoAnUnscopedRequest() {
+        // Warm the pool with a widened request first, so a recycled connection carries the setting.
+        assertThat(readVisible(CTX_A_SHARED)).contains("b-in-world");
+
+        assertThat(readVisible(CTX_A_PRIVATE))
+                .as("the same tenant, now declaring no shared scope, must fall back to tenant-private. "
+                        + "set_config(..., false) is session-scoped, so this only holds because the "
+                        + "interceptor publishes \"\" instead of skipping the statement — skipping it "
+                        + "would silently widen a request that never asked to participate")
+                .contains("a-in-world", "a-private")
+                .doesNotContain("b-in-world");
+    }
+
+    @Test
+    @DisplayName("tenant-private is unchanged — no shared scope means the pre-existing behaviour")
+    void tenantPrivateRemainsIsolated() {
+        assertThat(readVisible(CTX_A_PRIVATE))
+                .as("every row A owns, and nothing of B's")
+                .contains("a-private", "a-in-world")
+                .doesNotContain("b-in-world");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static void insertRow(StorageContext ctx, String sharedScope, String value) {
+        insertRow(ctx, sharedScope, value, ctx.isolationKey().orElseThrow());
+    }
+
+    /** {@code owner} is separate from the context so a forged-owner write can be attempted. */
+    private static void insertRow(StorageContext ctx, String sharedScope, String value, String owner) {
+        try (PersistenceConnection conn = engine.openConnection(ctx);
+             PersistenceStatement stmt = conn.prepare(
+                     "INSERT INTO scoped_docs(tenant_id, shared_scope, value) VALUES (?, ?, ?)")) {
+            stmt.bindString(0, owner)
+                    .bindString(1, sharedScope == null ? "" : sharedScope)
+                    .bindString(2, value)
+                    .executeUpdate();
+        }
+    }
+
+    private static List<String> readVisible(StorageContext ctx) {
+        List<String> rows = new ArrayList<>();
+        try (PersistenceConnection conn = engine.openConnection(ctx);
+             QueryResult result = conn.executeQuery("SELECT value FROM scoped_docs")) {
+            while (result.next()) {
+                rows.add(result.row().getString(0));
+            }
+        }
+        return rows;
+    }
+
+    private static PersistenceEngine createEngine(PostgreSQLContainer<?> container) {
+        PersistenceConfig config = new PersistenceConfig(
+                container.getJdbcUrl(), APP_USER, APP_PASSWORD,
+                24, 2, 5_000L, 60_000L, 600_000L,
+                true, false, false, 0, Map.of());
+        return new CommunityPersistenceProvider().createEngine(config);
+    }
+
+    private static void bootstrapSchema(PostgreSQLContainer<?> container) {
+        try (Connection conn = DriverManager.getConnection(
+                container.getJdbcUrl(), container.getUsername(), container.getPassword());
+             Statement st = conn.createStatement()) {
+            st.execute("DO $$ BEGIN "
+                    + "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'exeris_app') THEN "
+                    + "    CREATE ROLE exeris_app LOGIN NOSUPERUSER PASSWORD 'exeris_app_pw'; "
+                    + "  END IF; "
+                    + "END $$");
+            st.execute("DROP TABLE IF EXISTS scoped_docs CASCADE");
+            st.execute("CREATE TABLE scoped_docs ("
+                    + "tenant_id TEXT NOT NULL, shared_scope TEXT NOT NULL DEFAULT '', value TEXT NOT NULL)");
+            st.execute("ALTER TABLE scoped_docs ENABLE ROW LEVEL SECURITY");
+            st.execute("ALTER TABLE scoped_docs FORCE ROW LEVEL SECURITY");
+            st.execute("DROP POLICY IF EXISTS shared_scope_isolation ON scoped_docs");
+            // The normative conforming policy (ADR-012 §4b.4). USING widens; WITH CHECK is byte-for-byte
+            // the tenant-private clause. The NULLIF guard is what keeps an absent/cleared shared scope
+            // from matching rows whose shared_scope column is also empty.
+            st.execute("CREATE POLICY shared_scope_isolation ON scoped_docs "
+                    + "USING (tenant_id = current_setting('exeris.tenant_id', true) "
+                    + "       OR (NULLIF(current_setting('exeris.shared_scope', true), '') IS NOT NULL "
+                    + "           AND shared_scope = current_setting('exeris.shared_scope', true))) "
+                    + "WITH CHECK (tenant_id = current_setting('exeris.tenant_id', true))");
+            st.execute("GRANT USAGE ON SCHEMA public TO exeris_app");
+            st.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON scoped_docs TO exeris_app");
+        } catch (SQLException e) {
+            throw new IllegalStateException("Bootstrap schema failed", e);
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceSharedScopeIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceSharedScopeIT.java
@@ -8,19 +8,17 @@
  */
 package eu.exeris.kernel.community.persistence;
 
-import eu.exeris.kernel.spi.exceptions.persistence.PersistenceProviderException;
 import eu.exeris.kernel.spi.persistence.PersistenceConfig;
 import eu.exeris.kernel.spi.persistence.PersistenceConnection;
 import eu.exeris.kernel.spi.persistence.PersistenceEngine;
 import eu.exeris.kernel.spi.persistence.PersistenceStatement;
 import eu.exeris.kernel.spi.persistence.QueryResult;
-import eu.exeris.kernel.spi.security.ImmutableStorageContext;
 import eu.exeris.kernel.spi.security.StorageContext;
+import eu.exeris.kernel.tck.contract.persistence.AbstractSharedScopeAccessMatrixTck;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -33,34 +31,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 /**
- * Integration: the shared-scope access matrix (ADR-012 §4b.4) against a live PostgreSQL instance.
+ * Community binding of {@link AbstractSharedScopeAccessMatrixTck} against a live PostgreSQL instance.
  *
- * <h2>What this proves</h2>
- * <ul>
- *   <li><b>Read widens</b> — two tenants carrying the same {@code sharedScopeKey} see each other's rows
- *       in the shared partition.</li>
- *   <li><b>Write stays pinned</b> — a tenant inside the shared partition still cannot write a row owned
- *       by another tenant. Reads widening does not relax writes.</li>
- *   <li><b>No pool bleed</b> — the security-critical one. After a request that declared a shared scope,
- *       a later request on a recycled connection that declares none must not inherit the widened
- *       visibility. {@code set_config(..., false)} is session-scoped, so this only holds because the
- *       interceptor publishes {@code ""} rather than skipping the statement.</li>
- *   <li><b>Tenant-private is untouched</b> — a context with no shared scope behaves exactly as before
- *       the accessor existed.</li>
- * </ul>
+ * <p>The abstract suite owns the matrix; this class owns only the substrate — a table, a conforming RLS
+ * policy, and the two store operations. A live database is required because the contract is about RLS
+ * behaviour, which the H2-backed {@code CommunityPersistenceEngineTckTest} cannot express.
  *
- * <h2>What the kernel does and does not own</h2>
- * <p>The kernel publishes {@code exeris.tenant_id} and {@code exeris.shared_scope}; the policy that
- * consumes them is the deployment's. The policy below is therefore both a fixture and the normative
- * example of a conforming one — note that {@code WITH CHECK} is identical to the tenant-private policy.
- * Owner-scoped write is what that clause already expresses.
- *
- * <p>Cross-tenant <em>mutation</em> of another owner's row is explicitly out of contract scope
- * (ADR-012 §4b.4) and is asserted here as denied, not as a supported capability.
+ * <h2>The conforming policy</h2>
+ * <p>Reproduced here as the normative example. {@code USING} widens on the published shared scope;
+ * {@code WITH CHECK} is byte-for-byte the tenant-private clause, because owner-scoped write is what that
+ * clause already expresses — widening reads never requires relaxing writes. The {@code NULLIF} guard is
+ * what stops a cleared scope from matching rows whose own tag is empty.
  *
  * <h2>Execution</h2>
  * <pre>mvn -pl exeris-kernel-community test -Dtest=CommunityPersistenceSharedScopeIT -DincludedGroups=integration -DexcludedGroups=</pre>
@@ -69,39 +51,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @Tag("integration")
 @Testcontainers(disabledWithoutDocker = true)
-@DisplayName("Community persistence shared-scope access matrix — Testcontainers integration")
-class CommunityPersistenceSharedScopeIT {
+@DisplayName("Community persistence shared-scope access matrix — live PostgreSQL binding")
+class CommunityPersistenceSharedScopeIT extends AbstractSharedScopeAccessMatrixTck {
 
     @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
 
-    private static PersistenceEngine engine;
-
     private static final String APP_USER = "exeris_app";
     private static final String APP_PASSWORD = "exeris_app_pw";
 
-    private static final String TENANT_A = "tenant-a";
-    private static final String TENANT_B = "tenant-b";
-    private static final String WORLD = "world-alpha";
-
-    /** Both tenants inside the same shared partition. */
-    private static final StorageContext CTX_A_SHARED =
-            ImmutableStorageContext.shared(TENANT_A).withSharedScope(WORLD);
-    private static final StorageContext CTX_B_SHARED =
-            ImmutableStorageContext.shared(TENANT_B).withSharedScope(WORLD);
-
-    /** Same tenant, no shared scope declared — the tenant-private default. */
-    private static final StorageContext CTX_A_PRIVATE = ImmutableStorageContext.shared(TENANT_A);
+    private static PersistenceEngine engine;
 
     @BeforeAll
     static void startEngine() {
         bootstrapSchema(POSTGRES);
         engine = createEngine(POSTGRES);
         engine.registerInterceptor(RlsConnectionInterceptor.INSTANCE);
-
-        insertRow(CTX_A_SHARED, WORLD, "a-in-world");
-        insertRow(CTX_B_SHARED, WORLD, "b-in-world");
-        insertRow(CTX_A_PRIVATE, null, "a-private");
     }
 
     @AfterAll
@@ -111,66 +76,24 @@ class CommunityPersistenceSharedScopeIT {
         }
     }
 
-    @Test
-    @DisplayName("read widens — a tenant sees a partition-mate's row inside the shared scope")
-    void readWidensWithinSharedScope() {
-        assertThat(readVisible(CTX_A_SHARED))
-                .as("A declared the shared partition, so B's row in it becomes visible")
-                .contains("a-in-world", "b-in-world");
-
-        assertThat(readVisible(CTX_B_SHARED))
-                .as("symmetric — the widening is a property of the partition, not of one tenant")
-                .contains("a-in-world", "b-in-world");
+    /**
+     * Seeds per test rather than once in {@code @BeforeAll}: the write-pin case deliberately attempts a
+     * refused write, and re-seeding keeps each case independent of the others' side effects.
+     */
+    @org.junit.jupiter.api.BeforeEach
+    void seedRows() {
+        try (Connection conn = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+             Statement st = conn.createStatement()) {
+            st.execute("TRUNCATE scoped_docs");
+        } catch (SQLException e) {
+            throw new IllegalStateException("Truncate failed", e);
+        }
+        seedMatrixRows();
     }
 
-    @Test
-    @DisplayName("write stays pinned — a tenant cannot write a row owned by a partition-mate")
-    void writeStaysPinnedToOwner() {
-        assertThatThrownBy(() -> insertRow(CTX_A_SHARED, WORLD, "a-forging-b", TENANT_B))
-                .as("reads widening must not relax writes: WITH CHECK still pins owner = "
-                        + "current_setting('exeris.tenant_id'), so A forging a B-owned row is refused "
-                        + "even though A can read B's rows (ADR-012 §4b.4)")
-                .isInstanceOf(PersistenceProviderException.class);
-
-        assertThat(readVisible(CTX_B_SHARED))
-                .as("and nothing was written")
-                .doesNotContain("a-forging-b");
-    }
-
-    @Test
-    @DisplayName("no pool bleed — a later request without a shared scope does not inherit the widening")
-    void sharedScopeDoesNotSurviveOntoAnUnscopedRequest() {
-        // Warm the pool with a widened request first, so a recycled connection carries the setting.
-        assertThat(readVisible(CTX_A_SHARED)).contains("b-in-world");
-
-        assertThat(readVisible(CTX_A_PRIVATE))
-                .as("the same tenant, now declaring no shared scope, must fall back to tenant-private. "
-                        + "set_config(..., false) is session-scoped, so this only holds because the "
-                        + "interceptor publishes \"\" instead of skipping the statement — skipping it "
-                        + "would silently widen a request that never asked to participate")
-                .contains("a-in-world", "a-private")
-                .doesNotContain("b-in-world");
-    }
-
-    @Test
-    @DisplayName("tenant-private is unchanged — no shared scope means the pre-existing behaviour")
-    void tenantPrivateRemainsIsolated() {
-        assertThat(readVisible(CTX_A_PRIVATE))
-                .as("every row A owns, and nothing of B's")
-                .contains("a-private", "a-in-world")
-                .doesNotContain("b-in-world");
-    }
-
-    // =========================================================================
-    // Helpers
-    // =========================================================================
-
-    private static void insertRow(StorageContext ctx, String sharedScope, String value) {
-        insertRow(ctx, sharedScope, value, ctx.isolationKey().orElseThrow());
-    }
-
-    /** {@code owner} is separate from the context so a forged-owner write can be attempted. */
-    private static void insertRow(StorageContext ctx, String sharedScope, String value, String owner) {
+    @Override
+    protected void seed(StorageContext ctx, String owner, String sharedScope, String value) {
         try (PersistenceConnection conn = engine.openConnection(ctx);
              PersistenceStatement stmt = conn.prepare(
                      "INSERT INTO scoped_docs(tenant_id, shared_scope, value) VALUES (?, ?, ?)")) {
@@ -181,7 +104,8 @@ class CommunityPersistenceSharedScopeIT {
         }
     }
 
-    private static List<String> readVisible(StorageContext ctx) {
+    @Override
+    protected List<String> readVisible(StorageContext ctx) {
         List<String> rows = new ArrayList<>();
         try (PersistenceConnection conn = engine.openConnection(ctx);
              QueryResult result = conn.executeQuery("SELECT value FROM scoped_docs")) {
@@ -210,14 +134,11 @@ class CommunityPersistenceSharedScopeIT {
                     + "  END IF; "
                     + "END $$");
             st.execute("DROP TABLE IF EXISTS scoped_docs CASCADE");
-            st.execute("CREATE TABLE scoped_docs ("
-                    + "tenant_id TEXT NOT NULL, shared_scope TEXT NOT NULL DEFAULT '', value TEXT NOT NULL)");
+            st.execute("CREATE TABLE scoped_docs (tenant_id TEXT NOT NULL, "
+                    + "shared_scope TEXT NOT NULL DEFAULT '', value TEXT NOT NULL)");
             st.execute("ALTER TABLE scoped_docs ENABLE ROW LEVEL SECURITY");
             st.execute("ALTER TABLE scoped_docs FORCE ROW LEVEL SECURITY");
             st.execute("DROP POLICY IF EXISTS shared_scope_isolation ON scoped_docs");
-            // The normative conforming policy (ADR-012 §4b.4). USING widens; WITH CHECK is byte-for-byte
-            // the tenant-private clause. The NULLIF guard is what keeps an absent/cleared shared scope
-            // from matching rows whose shared_scope column is also empty.
             st.execute("CREATE POLICY shared_scope_isolation ON scoped_docs "
                     + "USING (tenant_id = current_setting('exeris.tenant_id', true) "
                     + "       OR (NULLIF(current_setting('exeris.shared_scope', true), '') IS NOT NULL "

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptorTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptorTest.java
@@ -24,7 +24,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,11 +44,24 @@ class RlsConnectionInterceptorTest {
     @Mock
     private PersistenceStatement statement;
 
+    private static final String SQL_TENANT_AND_SCOPE =
+            "SELECT set_config('exeris.tenant_id', ?, false), set_config('exeris.shared_scope', ?, false)";
+    private static final String SQL_SCOPE_ONLY =
+            "SELECT set_config('exeris.shared_scope', ?, false)";
+
+    /** Stubs the prepare/bind/execute chain for {@code sql}, returning the shared statement mock. */
+    private void stubStatement(String sql) {
+        when(connection.prepare(sql)).thenReturn(statement);
+        when(statement.bindString(anyInt(), anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(mock(QueryResult.class));
+    }
+
     @Test
     @DisplayName("separatedSchema valid schema executes exact search_path SQL")
     void separatedSchemaValidSchemaExecutesExactSql() {
         when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SEPARATED_SCHEMA);
         when(storageContext.schemaName()).thenReturn(Optional.of("tenant_01"));
+        stubStatement(SQL_SCOPE_ONLY);
 
         RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
 
@@ -87,14 +103,82 @@ class RlsConnectionInterceptorTest {
     void sharedStrategyUsesPrepareAndBindString() {
         when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SHARED);
         when(storageContext.isolationKey()).thenReturn(Optional.of("tenant-key-01"));
-        when(connection.prepare("SELECT set_config('exeris.tenant_id', ?, false)")).thenReturn(statement);
-        when(statement.bindString(0, "tenant-key-01")).thenReturn(statement);
-        QueryResult queryResult = mock(QueryResult.class);
-        when(statement.executeQuery()).thenReturn(queryResult);
+        stubStatement(SQL_TENANT_AND_SCOPE);
 
         RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
 
-        verify(connection).prepare("SELECT set_config('exeris.tenant_id', ?, false)");
+        verify(connection).prepare(SQL_TENANT_AND_SCOPE);
         verify(statement).bindString(0, "tenant-key-01");
+    }
+
+    // =========================================================================
+    // Shared scope — ADR-012 §4b row visibility
+    // =========================================================================
+
+    @Test
+    @DisplayName("shared strategy publishes a declared shared scope alongside the tenant key")
+    void sharedStrategyPublishesDeclaredSharedScope() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SHARED);
+        when(storageContext.isolationKey()).thenReturn(Optional.of("tenant-key-01"));
+        when(storageContext.sharedScopeKey()).thenReturn(Optional.of("world-alpha"));
+        stubStatement(SQL_TENANT_AND_SCOPE);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(statement).bindString(0, "tenant-key-01");
+        verify(statement).bindString(1, "world-alpha");
+        verify(connection, never()).prepare(SQL_SCOPE_ONLY);
+    }
+
+    @Test
+    @DisplayName("absent shared scope is published as \"\" — a stale one must not survive pool recycle")
+    void absentSharedScopeIsClearedNotSkipped() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SHARED);
+        when(storageContext.isolationKey()).thenReturn(Optional.of("tenant-key-01"));
+        stubStatement(SQL_TENANT_AND_SCOPE);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(statement)
+                .bindString(1, "");
+    }
+
+    @Test
+    @DisplayName("dedicated strategy publishes the shared scope — orthogonal to pool-level routing")
+    void dedicatedStrategyPublishesSharedScope() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.DEDICATED);
+        when(storageContext.sharedScopeKey()).thenReturn(Optional.of("world-alpha"));
+        stubStatement(SQL_SCOPE_ONLY);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(connection).prepare(SQL_SCOPE_ONLY);
+        verify(statement).bindString(0, "world-alpha");
+    }
+
+    @Test
+    @DisplayName("dedicated strategy clears the shared scope when none is declared")
+    void dedicatedStrategyClearsSharedScopeWhenAbsent() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.DEDICATED);
+        stubStatement(SQL_SCOPE_ONLY);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(statement)
+                .bindString(0, "");
+    }
+
+    @Test
+    @DisplayName("separatedSchema publishes the shared scope after the search_path switch")
+    void separatedSchemaPublishesSharedScope() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SEPARATED_SCHEMA);
+        when(storageContext.schemaName()).thenReturn(Optional.of("tenant_01"));
+        when(storageContext.sharedScopeKey()).thenReturn(Optional.of("world-alpha"));
+        stubStatement(SQL_SCOPE_ONLY);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(connection).executeUpdate("SET search_path TO tenant_01, public");
+        verify(statement).bindString(0, "world-alpha");
     }
 }

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/persistence/AbstractSharedScopeAccessMatrixTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/persistence/AbstractSharedScopeAccessMatrixTck.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.persistence;
+
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.security.StorageContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: the shared-vs-tenant access matrix every persistence binding must satisfy once it claims to
+ * enforce the shared-scope tier (ADR-012 §4b.4 / §9).
+ *
+ * <h2>Why this is its own suite rather than a nested contract in {@link AbstractPersistenceEngineTck}</h2>
+ * <p>ADR-012 §9 originally named {@code AbstractPersistenceEngineTck} as the host. That suite's only
+ * in-repo binding runs on H2 in PostgreSQL-compatibility mode, and H2 implements neither
+ * {@code CREATE POLICY} nor {@code current_setting} — so a matrix hosted there could only ever be skipped,
+ * which is precisely the vacuous-anchor failure this repository has already had to fix once. Splitting it
+ * out lets the binding be a live-database suite while keeping the obligation abstract and enforceable, so
+ * an out-of-repo binding cannot claim shared-scope support without passing these cases.
+ *
+ * <h2>What a binding must provide</h2>
+ * <p>A store of rows carrying an owner and a shared-scope tag, an RLS (or equivalent) policy whose read
+ * predicate widens on the published shared scope and whose write predicate stays pinned to the owner, and
+ * the two operations below. The contract deliberately says nothing about how the policy is expressed.
+ *
+ * <h2>What is NOT here, on purpose</h2>
+ * <p>Cross-tenant <em>mutation</em> of another owner's row is out of contract scope (ADR-012 §4b.4). It
+ * appears below only as a denial, and MUST NOT be relaxed into an allowed cell by a binding.
+ *
+ * @since 0.11.0
+ */
+public abstract class AbstractSharedScopeAccessMatrixTck {
+
+    protected static final String OWNER_A = "tenant-a";
+    protected static final String OWNER_B = "tenant-b";
+    protected static final String SHARED_SCOPE = "world-alpha";
+
+    /** {@code OWNER_A} participating in the shared partition. */
+    protected static final StorageContext CTX_A_SHARED =
+            ImmutableStorageContext.shared(OWNER_A).withSharedScope(SHARED_SCOPE);
+
+    /** {@code OWNER_B} participating in the same shared partition. */
+    protected static final StorageContext CTX_B_SHARED =
+            ImmutableStorageContext.shared(OWNER_B).withSharedScope(SHARED_SCOPE);
+
+    /** {@code OWNER_A} declaring no shared scope — the tenant-private default. */
+    protected static final StorageContext CTX_A_PRIVATE = ImmutableStorageContext.shared(OWNER_A);
+
+    // =========================================================================
+    // Template methods — binding supplies the store
+    // =========================================================================
+
+    /**
+     * Writes one row through the binding, under {@code ctx}.
+     *
+     * <p>{@code owner} is passed separately from {@code ctx} so the write-pin case can attempt a row
+     * whose owner is <em>not</em> the acting tenant; a conforming binding must refuse that.
+     *
+     * @param ctx         the acting storage context
+     * @param owner       the owner column value to write
+     * @param sharedScope the shared-scope tag for the row, or {@code null} for none
+     * @param value       an identifying payload, returned by {@link #readVisible}
+     */
+    protected abstract void seed(StorageContext ctx, String owner, String sharedScope, String value);
+
+    /** Values of every row visible to {@code ctx}, in any order. */
+    protected abstract List<String> readVisible(StorageContext ctx);
+
+    /** Seeds the fixture rows. Bindings call this once the store exists. */
+    protected final void seedMatrixRows() {
+        seed(CTX_A_SHARED, OWNER_A, SHARED_SCOPE, "a-in-scope");
+        seed(CTX_B_SHARED, OWNER_B, SHARED_SCOPE, "b-in-scope");
+        seed(CTX_A_PRIVATE, OWNER_A, null, "a-private");
+    }
+
+    // =========================================================================
+    // The matrix
+    // =========================================================================
+
+    @Test
+    @DisplayName("read widens — a tenant sees a partition-mate's row inside the shared scope")
+    void assert_read_widens_within_shared_scope() {
+        assertThat(readVisible(CTX_A_SHARED))
+                .as("a declared shared scope must make partition-mates' rows visible — that is the "
+                        + "entire point of the tier (ADR-012 §4b.4)")
+                .contains("a-in-scope", "b-in-scope");
+
+        assertThat(readVisible(CTX_B_SHARED))
+                .as("the widening is a property of the partition, not of one tenant, so it must be "
+                        + "symmetric")
+                .contains("a-in-scope", "b-in-scope");
+    }
+
+    @Test
+    @DisplayName("write stays pinned — a tenant cannot write a row owned by a partition-mate")
+    void assert_write_stays_pinned_to_owner() {
+        assertThatThrownBy(() -> seed(CTX_A_SHARED, OWNER_B, SHARED_SCOPE, "a-forging-b"))
+                .as("reads widening MUST NOT relax writes: inside the shared partition a tenant may "
+                        + "still only write rows it owns. A binding that lets this through has made "
+                        + "cross-tenant mutation possible, which ADR-012 §4b.4 puts out of scope")
+                .isInstanceOf(Exception.class);
+
+        assertThat(readVisible(CTX_B_SHARED))
+                .as("and the refused write left nothing behind")
+                .doesNotContain("a-forging-b");
+    }
+
+    @Test
+    @DisplayName("no bleed — a later request declaring no shared scope does not inherit the widening")
+    void assert_shared_scope_does_not_leak_onto_an_unscoped_request() {
+        // Exercise the widened path first so any connection reuse carries the published setting.
+        assertThat(readVisible(CTX_A_SHARED)).contains("b-in-scope");
+
+        assertThat(readVisible(CTX_A_PRIVATE))
+                .as("the same tenant, now declaring no shared scope, must be tenant-private again. "
+                        + "Session-scoped settings survive connection reuse, so a binding that only "
+                        + "publishes a scope when one is present silently widens a request that never "
+                        + "asked to participate")
+                .doesNotContain("b-in-scope");
+    }
+
+    @Test
+    @DisplayName("tenant-private is unchanged — absence behaves exactly as before the tier existed")
+    void assert_absent_shared_scope_is_tenant_private() {
+        assertThat(readVisible(CTX_A_PRIVATE))
+                .as("everything the tenant owns")
+                .contains("a-private", "a-in-scope");
+
+        assertThat(readVisible(CTX_A_PRIVATE))
+                .as("and nothing of a partition-mate's, because no scope was declared")
+                .doesNotContain("b-in-scope");
+    }
+}


### PR DESCRIPTION
Stream A's last mechanism slice. Community persistence side of the shared-scope tier.

## The shape turned out simpler than the plan assumed

The kernel ships **no RLS policies** — the deployment owns them, and tenant isolation already works by publishing `exeris.tenant_id` for the policy to read. Shared scope needs nothing more exotic: publish a second session setting and let the policy widen on it.

The useful discovery is that **`WITH CHECK` already expresses owner-scoped write**. A conforming policy widens `USING` and leaves `WITH CHECK` byte-for-byte identical to the tenant-private one:

```sql
CREATE POLICY shared_scope_isolation ON <table>
  USING (tenant_id = current_setting('exeris.tenant_id', true)
         OR (NULLIF(current_setting('exeris.shared_scope', true), '') IS NOT NULL
             AND shared_scope = current_setting('exeris.shared_scope', true)))
  WITH CHECK (tenant_id = current_setting('exeris.tenant_id', true));
```

So "read widens, write pins" needs no new write machinery at all — widening reads does not require relaxing writes. The policy is documented on the interceptor as normative and exercised by the new IT.

## Published on every strategy — and unconditionally

Visibility is orthogonal to placement, so the setting rides all three strategies. SHARED carries it in the statement that already existed (still one round-trip); SEPARATED_SCHEMA and DEDICATED each pay one more. **DEDICATED previously issued no SQL at all**, so that is a genuine cost and the class Javadoc no longer claims otherwise.

**The unconditional part is the security-critical one, not a detail.** `set_config(..., false)` is *session*-scoped, so on a pooled connection a previous request's shared scope survives into the next. Skipping the statement when no scope is declared would silently widen a request that never asked to participate — the same pool-recycle hazard the tenant key already guards against by always writing a value. Absence is published as `""`, and both the unit tests and the IT pin that specific case.

## Verification

Unit tests (9 green): publish, **clear-when-absent**, and per-strategy routing.

`CommunityPersistenceSharedScopeIT` covers the §4b.4 access matrix against a live Postgres — read-widen, write-pin (a tenant *inside* the partition still cannot forge a partition-mate's row), no-pool-bleed, and tenant-private unchanged. Cross-tenant mutation is asserted as **denied, not supported**: out of contract scope per §4b.4, and the assertion exists so it cannot creep in later.

> **The IT compiles but has not run here.** Docker is unavailable in this environment, so it reports as *skipped*, not passed. `persistence-rls-gate` already runs every `integration`-tagged test in this module, so it picks the IT up with no workflow change — **that gate is the actual proof**, not this description.

Full reactor `mvn clean install` green; `pmd:check` + `checkstyle:check` 0 violations.

## PMD pushed back, and it was right

The class total hit 33 against a 30 ceiling once these paths landed. Rather than raise the ceiling, PostgreSQL identifier validation moved into its own `PostgresIdentifier` class — it guards `SET search_path` interpolation, which cannot use a bind parameter, and was never an interception concern. The interceptor also stopped duplicating the prepare/bind/execute/translate skeleton between the two settings.

## Deliberately NOT in this PR

`IdentityStorageMapping` still denies every declared shared scope, so there is no end-to-end path yet — by design.

Flipping that deny needs a signal for *"this deployment's policy honours shared scope"*, and **the kernel cannot introspect it**: the policy lives in the application's DDL, not in anything the kernel ships or reads. Answering it means a cross-subsystem capability seam between Security and Persistence, which deserves its own decision rather than being improvised at the end of this slice. Until then the fail-closed posture from #254 stands, which is the safe state to sit in.

That leaves Stream A's mechanism complete on both sides — carrier and enforcement — with one explicitly-scoped decision between them and the tier going live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)