### PR TITLE
fix(security): type-check the shared-scope claim during token validation (ADR-012 §4b.7)

### DIFF
--- a/docs/adr/ADR-012-security-trust-model-upgrade-for-resource-server-validation-and-fail-closed-runtime.md
+++ b/docs/adr/ADR-012-security-trust-model-upgrade-for-resource-server-validation-and-fail-closed-runtime.md
@@ -154,7 +154,10 @@ knowing whether it can be. This section rules how that is known.
   every declared scope was denied anyway. Once a deployment enforces, it is no longer tolerable: a caller
   with a malformed scope claim silently loses the visibility it asked for. Type-checking that claim during
   token validation is therefore a `TokenValidator` obligation on the same footing as
-  `ISOLATION_STRATEGY` — the mapping structurally cannot make it.
+  `ISOLATION_STRATEGY` — the mapping structurally cannot make it. **Discharged in the same milestone**
+  (deny reason `shared-scope-malformed`, pinned by `AbstractSecurityProviderTck`); the two checks stay
+  separate because a wrong-typed strategy weakens the provisioned tier while a wrong-typed scope withholds
+  visibility from it, so passing one says nothing about the other.
 
 ## 5) Fail-Closed Lifecycle Contract
 - Bootstrap readiness is denied if required trust anchors, JWKS resolution path, or validation dependencies are unavailable.
@@ -196,6 +199,12 @@ knowing whether it can be. This section rules how that is known.
   → carried onto the resolved `StorageContext`; present-but-unenforceable → terminal deny
   (`EX-SEC-2002` / `shared-scope-unsupported`). Both suites are named because §4a routes every provider
   through one mapping site — the contract must be proven from both entry surfaces.
+- `AbstractSecurityProviderTck.IsolationStrategyContract` must additionally cover a **wrong-typed**
+  shared-scope claim → terminal deny (`EX-SEC-2002` / `shared-scope-malformed`). Like the wrong-typed
+  strategy case this is the binding's own obligation, not inherited from the mapping, and it is kept
+  separate from that case: both stem from `claim()` reporting a wrong-typed value as absent, but one
+  weakens the provisioned tier while the other silently withholds visibility from it, so a binding
+  passing one says nothing about the other (§4b.7).
 - `ImmutableStorageContext` must have a constructor-invariant case: `sharedScopeKey` present with
   `isolationKey` absent is rejected (§4b.2).
 - The persistence TCK must carry a shared-vs-tenant **access matrix**: the read-widen path (a
@@ -227,7 +236,7 @@ knowing whether it can be. This section rules how that is known.
 - **Implemented now (§4b carrier + claim + deny, v0.11 S2):** `StorageContext.sharedScopeKey()` (additive, tenant-private `default`), the 6th `ImmutableStorageContext` component with its `sharedScopeKey`-requires-`isolationKey` constructor invariant, `KernelIsolationClaims.SHARED_SCOPE_KEY`, and the §4b.5 terminal deny in `IdentityStorageMapping.fromClaims` (`EX-SEC-2002` / `shared-scope-unsupported`). The deny did not lag the carrier — both landed in the same change, as §4b.5 requires.
 - **Implemented now (§4b.4 enforcement substrate, v0.11 S3):** the Community persistence binding publishes `exeris.shared_scope` alongside `exeris.tenant_id` on every strategy, so a deployment's RLS policy can widen its read predicate while `WITH CHECK` keeps writes pinned to the owner. The setting is published unconditionally — as `""` when absent — because session-scoped settings survive connection reuse and skipping the statement would widen a request that declared no scope. `AbstractSharedScopeAccessMatrixTck` codifies the matrix, bound against live PostgreSQL.
 - **Implemented now (§4b.7 enforceability signal, v0.11):** the kernel ships no RLS policy and cannot introspect the deployment's, so the deployment asserts enforceability itself via `exeris.security.shared-scope.enforced` (`IdentityStorageMapping.SHARED_SCOPE_ENFORCED_KEY`). `fromClaims` carries a declared shared scope onto the resolved context where the deployment has opted in, and denies it everywhere else. The tier is reachable end-to-end from that point: carrier, claim, mapping, and RLS enforcement all exist and are connected. Absent opt-in the behaviour is unchanged, so no existing deployment moves off tenant-private.
-- **Not implemented (open obligation, §4b.7):** the driver-side type check for a wrong-typed shared-scope claim. `VerifiedClaims.claim` reports it as absent, so in an *enforcing* deployment a caller with a malformed claim silently loses the visibility it asked for. This was harmless while every declared scope was denied and is not harmless now. The check belongs in each `TokenValidator`, on the same footing as `ISOLATION_STRATEGY` (§4a enforcement layers), with a TCK case to make it binding-independent.
+- **Implemented now (§4b.7 wrong-typed shared scope, v0.11):** the driver-side type check that closes §4b.7's own consequence. `VerifiedClaims.claim` reports a wrong-typed claim as absent, so a malformed shared scope would reach the mapping as "none declared" and resolve to tenant-private — harmless while every declared scope was denied, and not harmless once §4b.7 made that deny conditional, since an enforcing deployment would then silently withhold visibility the caller asked for. The check sits in the binding's token validation next to the `ISOLATION_STRATEGY` one (§4a enforcement layers), denying `shared-scope-malformed`, and is pinned for every binding by `AbstractSecurityProviderTck` rather than left to each one's diligence. Both axes are checked because the structural cause is shared but the damage is not: a wrong-typed strategy weakens the tier, a wrong-typed scope withholds from it.
 - Implemented now (repository state): Community `PersistenceEngine` routes DEDICATED strategy to per-tenant pools from `PersistenceConfig.dedicatedDataSources()`.
 - Repository-state disclaimer: this ADR defines target contract semantics even where implementation is currently partial, staged, or temporarily embedded.
 - Planned target state: unified JWT/JWS/JWKS/OIDC resource-server trust pipeline with deterministic deny on uncertainty, fail-closed lifecycle gates, explicit rotation TTL/staleness/outage semantics, and mandatory typed telemetry categories.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityOidcTokenValidator.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityOidcTokenValidator.java
@@ -122,7 +122,7 @@ final class CommunityOidcTokenValidator implements TokenValidator {
         validateIssuer(claims);
         validateAudience(claims);
         validateExpiry(claims);
-        validateIsolationStrategyWellTyped(claims);
+        validateIsolationClaimsWellTyped(claims);
 
         return new CommunityVerifiedClaims(claims);
     }
@@ -182,16 +182,27 @@ final class CommunityOidcTokenValidator implements TokenValidator {
     }
 
     /**
-     * A declared isolation-strategy claim that is present but not a string is malformed security
-     * input — terminal deny, never a silent downgrade to SHARED (S-P0-07; ADR-012 §4a amended).
-     * Verifying it here keeps {@link VerifiedClaims#claim(String)} free of deny logic; an absent or
-     * well-typed strategy is left to {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping}.
+     * An isolation claim that is present but not a string is malformed security input — terminal deny,
+     * never a silent fall-through (S-P0-07; ADR-012 §4a amended). Verifying it here keeps
+     * {@link VerifiedClaims#claim(String)} free of deny logic; absent or well-typed claims are left to
+     * {@link eu.exeris.kernel.spi.security.identity.IdentityStorageMapping}.
+     *
+     * <p>Both isolation axes need this and for the same structural reason — {@code claim()} reports a
+     * wrong-typed claim as absent — but the damage differs, which is why neither can be skipped: a
+     * wrong-typed strategy resolves to {@code SHARED}, weakening the provisioned tier, while a
+     * wrong-typed shared scope resolves to tenant-private, silently withholding visibility the caller
+     * asked for and the deployment was ready to grant (ADR-012 §4b.7).
      */
-    private static void validateIsolationStrategyWellTyped(JWTClaimsSet claims) {
+    private static void validateIsolationClaimsWellTyped(JWTClaimsSet claims) {
+        requireStringClaim(claims, KernelIsolationClaims.ISOLATION_STRATEGY, "isolation-malformed");
+        requireStringClaim(claims, KernelIsolationClaims.SHARED_SCOPE_KEY, "shared-scope-malformed");
+    }
+
+    private static void requireStringClaim(JWTClaimsSet claims, String claimName, String denyReason) {
         try {
-            claims.getStringClaim(KernelIsolationClaims.ISOLATION_STRATEGY);
+            claims.getStringClaim(claimName);
         } catch (ParseException _) {
-            throw new SecurityAuthenticationException(JWT_TYPE, "isolation-malformed");
+            throw new SecurityAuthenticationException(JWT_TYPE, denyReason);
         }
     }
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 
 @DisplayName("Community: SecurityProvider TCK")
@@ -146,6 +147,14 @@ class CommunitySecurityProviderTckTest extends AbstractSecurityProviderTck {
         // validation — the kernel mapping cannot see this case (see the TCK factory's Javadoc).
         return TestJwt.builder()
                 .claimRaw(KernelIsolationClaims.ISOLATION_STRATEGY, 42)
+                .toBuffer();
+    }
+
+    @Override
+    protected LoanedBuffer createTokenWithWrongTypedSharedScope() {
+        // A JSON array where a shared-scope string belongs — one partition name, not a list.
+        return TestJwt.builder()
+                .claimRaw(KernelIsolationClaims.SHARED_SCOPE_KEY, List.of("world-alpha"))
                 .toBuffer();
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderFixture.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderFixture.java
@@ -67,10 +67,13 @@ public final class CoreSecurityProviderFixture implements SecurityProvider {
             case 11 -> throw new SecurityAuthenticationException("JWT", "isolation-incomplete");
             case 12 -> throw new SecurityAuthenticationException("JWT", "isolation-unknown-strategy");
             case 13 -> throw new SecurityAuthenticationException("JWT", "isolation-malformed");
-            // Size 14: a declared shared scope. Denied while no binding implements read-widen /
-            // owner-scoped-write — narrowing it to tenant-private or honouring it unenforced are both
-            // forbidden (ADR-012 §4b.5). This case inverts to enforcement when a binding gains the mode.
+            // Size 14: a declared shared scope, on a provider not constructed as enforcing — narrowing
+            // it to tenant-private or honouring it unenforced are both forbidden (ADR-012 §4b.5/§4b.7).
             case 14 -> throw new SecurityAuthenticationException("JWT", "shared-scope-unsupported");
+            // Size 15: a wrong-typed shared scope. Like size 13 this deny is the provider's own — the
+            // mapping sees the claim as absent — but it guards the opposite failure: not a weakened
+            // tier, a silently withheld one (ADR-012 §4b.7).
+            case 15 -> throw new SecurityAuthenticationException("JWT", "shared-scope-malformed");
             default -> ImmutableStorageContext.GLOBAL;
         };
         return new AuthenticationResult(

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderTckTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/security/tck/CoreSecurityProviderTckTest.java
@@ -83,6 +83,11 @@ class CoreSecurityProviderTckTest extends AbstractSecurityProviderTck {
         return new StubLoanedBuffer(14L); // fixture denies: shared scope declared but unenforceable
     }
 
+    @Override
+    protected LoanedBuffer createTokenWithWrongTypedSharedScope() {
+        return new StubLoanedBuffer(15L); // fixture denies: wrong-typed shared-scope claim
+    }
+
     private static final class StubLoanedBuffer implements LoanedBuffer {
         private long size;
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/identity/IdentityStorageMapping.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/identity/IdentityStorageMapping.java
@@ -163,16 +163,15 @@ public final class IdentityStorageMapping {
      * remains wherever enforcement is absent, so no window exists in which a declared scope resolves to
      * anything but deny or correct enforcement.
      *
-     * <p><b>Wrong-typed claim — now a live driver obligation.</b>
+     * <p><b>Wrong-typed claim — discharged upstream, by obligation.</b>
      * {@link VerifiedClaims#claim(String)} reports a present-but-not-single-string claim as absent, so a
-     * wrong-typed shared-scope claim arrives here as "no shared scope declared" and yields the
-     * tenant-private default. While every declared scope was denied outright that was merely a
-     * narrowing, and therefore tolerable. It is not tolerable any more: in a deployment that asserts
-     * {@link #SHARED_SCOPE_ENFORCED_KEY}, a caller whose scope claim is malformed silently loses the
-     * shared visibility it asked for instead of being told. Type-checking this claim during token
-     * validation is consequently a {@code TokenValidator} obligation on the same footing as
-     * {@link KernelIsolationClaims#ISOLATION_STRATEGY} (ADR-012 §4a enforcement layers) — the mapping
-     * structurally cannot make it.
+     * wrong-typed shared-scope claim would arrive here as "no shared scope declared" and yield the
+     * tenant-private default. In a deployment asserting {@link #SHARED_SCOPE_ENFORCED_KEY} that means a
+     * caller with a malformed claim silently loses the visibility it asked for instead of being told.
+     * The mapping structurally cannot catch it, so type-checking the claim during token validation is a
+     * {@code TokenValidator} obligation on the same footing as
+     * {@link KernelIsolationClaims#ISOLATION_STRATEGY} (ADR-012 §4a enforcement layers), pinned for every
+     * binding by the TCK rather than left to each one's diligence.
      */
     private static String resolveSharedScope(VerifiedClaims claims, String tokenType,
                                              boolean sharedScopeEnforced) {

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractSecurityProviderTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/security/AbstractSecurityProviderTck.java
@@ -324,6 +324,32 @@ public abstract class AbstractSecurityProviderTck {
     protected abstract LoanedBuffer createTokenWithWrongTypedStrategy();
 
     /**
+     * Creates a {@link LoanedBuffer} containing a token whose
+     * {@link eu.exeris.kernel.spi.security.KernelIsolationClaims#SHARED_SCOPE_KEY} claim is
+     * <b>present but not representable as a single string</b> — the shared-scope counterpart of
+     * {@link #createTokenWithWrongTypedStrategy()}.
+     *
+     * <p>The provider MUST <b>deny</b> this token ({@link SecurityAuthenticationException},
+     * {@code EX-SEC-2002}).
+     *
+     * <h2>Why this is a second obligation and not the same one</h2>
+     * <p>The structural cause is shared — {@code claim()} reports the wrong-typed value as absent, so
+     * the mapping never sees it — but the resulting harm is not, so discharging one check does not
+     * discharge the other. A wrong-typed strategy resolves to {@code SHARED} and weakens the
+     * provisioned tier. A wrong-typed shared scope resolves to tenant-private: it grants nothing, and
+     * instead <em>withholds</em> visibility the caller asked for and an enforcing deployment was ready
+     * to grant, with no signal that anything was wrong.
+     *
+     * <p>That silent withholding is why this case did not exist before v0.11: while every declared
+     * shared scope was denied outright, the mistyped token reached the same outcome as the well-typed
+     * one, so nothing was hidden. ADR-012 §4b.7 removed that coincidence by making the deny conditional
+     * on the deployment (see §10).
+     *
+     * <p>Caller owns the buffer lifecycle.
+     */
+    protected abstract LoanedBuffer createTokenWithWrongTypedSharedScope();
+
+    /**
      * Creates a {@link LoanedBuffer} containing a token declaring
      * {@link eu.exeris.kernel.spi.security.KernelIsolationClaims#SHARED_SCOPE_KEY} — a shared-scope
      * partition the subject asks to participate in.
@@ -964,6 +990,24 @@ public abstract class AbstractSecurityProviderTck {
                                 + "and would resolve to SHARED. A binding that does not type-check "
                                 + "during validation fails OPEN here with every other gate green "
                                 + "(S-P0-07 / ADR-012 \u00a74a amended, \u00a79 enforcement layers)")
+                        .isInstanceOfSatisfying(SecurityAuthenticationException.class, ex ->
+                                assertThat(ex.errorCode()).isEqualTo(KernelErrorCodes.EX_SEC_2002));
+            }
+        }
+
+        @Test
+        @DisplayName("wrong-typed shared-scope claim \u2192 terminal deny (EX-SEC-2002)")
+        void assert_authenticate_denies_wrong_typed_shared_scope() {
+            try (LoanedBuffer token = createTokenWithWrongTypedSharedScope()) {
+                assertThatThrownBy(() -> provider.authenticate(token))
+                        .as("a present-but-not-string SHARED_SCOPE_KEY is malformed security input and "
+                                + "MUST be denied by the binding's own validation \u2014 "
+                                + "VerifiedClaims.claim() reports it as ABSENT, so it reaches "
+                                + "IdentityStorageMapping.fromClaims as \"no shared scope declared\". "
+                                + "A binding that skips the check does not fail open here; it fails "
+                                + "SILENT, resolving the request to tenant-private and withholding "
+                                + "visibility an enforcing deployment was ready to grant, with every "
+                                + "other gate green (ADR-012 \u00a74b.7, \u00a79 enforcement layers)")
                         .isInstanceOfSatisfying(SecurityAuthenticationException.class, ex ->
                                 assertThat(ex.errorCode()).isEqualTo(KernelErrorCodes.EX_SEC_2002));
             }


### PR DESCRIPTION
Closes the obligation ADR-012 §10 recorded when #257 landed — the last open item in Stream A.

## Why it became live

`VerifiedClaims.claim()` reports a present-but-wrong-typed claim as **absent**. A malformed shared scope therefore reaches `IdentityStorageMapping.fromClaims` as "none declared" and resolves to tenant-private.

While every declared scope was denied outright, the mistyped token reached the same outcome as the well-typed one — nothing was hidden, so the gap was benign. #257 made that deny **conditional on the deployment**, and the coincidence disappeared with it: in an enforcing deployment the caller silently loses the visibility it asked for, with every other gate green.

## What changed

The mapping structurally cannot catch this, so the check sits in the binding's token validation next to the `ISOLATION_STRATEGY` one, denying `shared-scope-malformed`.

**Both axes are checked separately on purpose.** Same structural cause, opposite damage — a wrong-typed strategy resolves to `SHARED` and *weakens* the provisioned tier; a wrong-typed scope resolves to tenant-private and *withholds* visibility from it. A binding passing one says nothing about the other, so they do not collapse into one check.

`AbstractSecurityProviderTck` pins it for every binding rather than leaving it to each one's diligence — that is precisely what let the strategy case sit unbound behind a green suite until #252. Two bindings implement it (Community + the Core stub fixture).

## Non-vacuity

Dropping the check fails that one case out of 48:

```
Tests run: 48, Failures: 1
assert_authenticate_denies_wrong_typed_shared_scope
  java.lang.AssertionError: Expecting code to raise a throwable.
```

Same signature as #252 — `authenticate()` **succeeding** on malformed security input, observed directly rather than argued.

## Also

- ADR-012 §4b.7 / §9 / §10 record the obligation as discharged; the SPI Javadoc no longer describes it as outstanding.
- The Core fixture comment still anchored the shared-scope deny on *"no binding implements read-widen"* — superseded by #256, corrected here.

## Verification

Full reactor `mvn clean install` green with lint gates active (no skip flags); standalone `pmd:check checkstyle:check` on spi/core/community/tck clean; `ExerisArchitectureTest` 11/11; `IsolationStrategyContract` 10/10; Core + Community security TCK bindings green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)