### PR TITLE
feat(http): stream routes accept path templates, so a generated per-action route can match (v0.11 S20)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1750,6 +1750,16 @@ See also: ADR-034 (`KernelWebClient` facade, superseding ADR-026), ADR-032 (`Htt
 
 **Owner:** HTTP subsystem (router); shape decision shared with `exeris-tooling` (ADR-044 EV1-stream slice).
 
+**Status (v0.11): DELIVERED — kernel-side template matching.** The streaming table now compiles `{name}`
+paths through the same `PathTemplate` the respond-once table uses, with the same exact-before-template
+precedence, and captured values reach the handler through the new `HttpStreamExchange.pathParams()` (a
+`PathParamStreamExchange` decorator, mirroring `PathParamHttpExchange`). One compiled template type
+serves both tables, so they cannot drift into disagreeing about what `/x/{id}` means. The fail-fast half
+landed with it: a malformed brace throws at `Builder.streamRoute`, so a silently-dead stream registration
+is unrepresentable. This is the default direction below, chosen without waiting on the tooling ruling —
+it subsumes the fail-fast property and stays correct under either tooling outcome, exactly as the
+alternative anticipated.
+
 **Resolution:** Rule the shape inside the tooling EV1-stream slice, then land the kernel side in v0.11. Default direction — kernel-side template matching: extend the streaming table with the same template semantics the unary table already has (reuse `PathTemplateRoute` compile/match for `streamRoute` paths containing `{name}`; exact stream routes take precedence over template stream routes, mirroring unary precedence; captured params exposed on the streaming path). Alternative — ADR-044 amendment (tooling repo) redesigns per-action stream paths onto exact routes, and the kernel change collapses to a Javadoc clarification plus a build-time guard. **Either way, fail-fast becomes mandatory:** a `{` in a stream path must either resolve via templates or be rejected in `Builder.streamRoute` — a silently-dead registered route must become impossible.
 
 **Merge Gate:** Fail-fast property enforced (template resolution or `IllegalArgumentException` at registration — no third state). If template matching lands: router unit coverage for stream-template resolve + exact-over-template precedence, plus a streaming TCK (or router-level) case proving a `{id}` stream route opens an `HttpStreamExchange` for a concrete id; ADR-043 obligation 7 stays true (streaming resolves only via `resolveStream`, never through `handle`). Tooling lockstep (ADR-044 Slice 2 per-action driver impl) tracked in `exeris-tooling`, non-gating for the kernel merge.

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -80,6 +80,7 @@ Implemented components:
 - **HTTP/2 framing:** `http2.*`
 - **HTTP/1.1 codec:** `http1.*`
 - **Routing:** `routing/` — `HttpRouter` — transport-agnostic `HttpHandler` implementation with exact, path-template (`{name}` placeholder), and prefix routing plus HEAD→GET fallback (RFC 9110 §9.3.2). Resolution precedence is exact → template → prefix; a template hit captures each placeholder and exposes it to the handler via `HttpExchange.pathParams()` (the router wraps the exchange in a `PathParamHttpExchange` decorator — Core never depends on a concrete transport-side exchange). `HttpRouterRegisteredEvent` (JFR) records exact/template/prefix route counts.
+  The **streaming table follows the same rules** — exact before template, same `{name}` syntax, captured values reaching the handler through `HttpStreamExchange.pathParams()` via a `PathParamStreamExchange` decorator. It did not always: until v0.11 the streaming table was an exact-match map while the tooling generator emitted templated stream paths, so a per-action stream route registered successfully and then never matched a concrete request. A registration that cannot match is now unrepresentable — a malformed brace throws at `Builder.streamRoute`, and a well-formed one compiles to a template. Both tables share one compiled `PathTemplate`, so they cannot drift into disagreeing about what `/x/{id}` means.
 
 Current placement reality:
 
@@ -105,7 +106,7 @@ HTTP abstract TCK suites present:
 - `AbstractHttpExchangeTck`
 - `AbstractHttpProviderLoopbackTck` — verifies real transport round-trip; bound at Community tier (`CommunityHttpProviderLoopbackTckTest`)
 - `AbstractHealthEndpointTck` (since 0.7.0) — pins the readiness/liveness endpoint contract for any `HttpHandler` binding that surfaces a `HealthProbe`. Bound at Community tier (`CommunityHealthEndpointTckTest`).
-- `AbstractHttpStreamExchangeTck` — 🚧 Planned v0.10 ([ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md)) — pins the SSE streaming contract: open / emit-N / graceful close / disconnect-via-`StreamClosedException`, backpressure park-and-resume on window credit, and no respond-once regression. Community binding required; Enterprise native overlay declared as a cross-repo obligation.
+- `AbstractHttpStreamExchangeTck` — 🚧 Planned v0.10 ([ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md)) — pins the SSE streaming contract: open / emit-N / graceful close / disconnect-via-`StreamClosedException`, backpressure park-and-resume on window credit, no respond-once regression, and (v0.11) `pathParams()` being non-null and immutable — the map is routing state, so a handler able to write to it could change what a later request resolves to. Community binding required; Enterprise native overlay declared as a cross-repo obligation.
 
 These verify SPI-level HTTP contract behavior and ServiceLoader/provider semantics.
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.http;
 
+import eu.exeris.kernel.core.http.routing.HttpRouter;
 import eu.exeris.kernel.community.persistence.PersistenceSessionBox;
 import eu.exeris.kernel.core.http.http1.Http1Codec;
 import eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader;
@@ -19,7 +20,6 @@ import eu.exeris.kernel.spi.http.HttpKernelProviders;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpRequestBodyDecoderRegistry;
 import eu.exeris.kernel.spi.http.HttpResponseBodyEncoderRegistry;
-import eu.exeris.kernel.spi.http.HttpStreamHandler;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.persistence.PersistenceEngine;
@@ -221,8 +221,8 @@ public final class CommunityHttpRequestProcessor {
                 readResult.headers(),
                 bodyBuffer);
 
-        HttpStreamHandler streamHandler = streamDispatcher.resolveStreamHandler(request, handler);
-        if (streamHandler != null) {
+        HttpRouter.StreamMatch streamRoute = streamDispatcher.resolveStreamHandler(request, handler);
+        if (streamRoute != null) {
             // v0.10 streaming dispatch (ADR-043). Two obligation mechanisms are built + TCK-pinned
             // (HttpStreamEngine deadline / StreamAdmissionController) but their PRODUCTION binding is
             // deliberately deferred here, not wired:
@@ -234,7 +234,7 @@ public final class CommunityHttpRequestProcessor {
             //     stream-opens shed under load — still holds via carrier-edge PAQS (NativeTcpCarrier's
             //     AdmissionController), which sheds any new stream including an SSE open. Plumbing the
             //     carrier arbiter through to a dedicated streaming ceiling is a v0.10 follow-up.
-            streamDispatcher.dispatchStream(request, stream, streamHandler);
+            streamDispatcher.dispatchStream(request, stream, streamRoute);
             return true;
         }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpStreamDispatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpStreamDispatcher.java
@@ -9,6 +9,7 @@
 package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.core.http.routing.HttpRouter;
+import eu.exeris.kernel.core.http.routing.PathParamStreamExchange;
 import eu.exeris.kernel.core.http.sse.HttpStreamEngine;
 import eu.exeris.kernel.core.http.sse.StreamAdmissionController;
 import eu.exeris.kernel.spi.exceptions.http.StreamClosedException;
@@ -63,9 +64,10 @@ final class CommunityHttpStreamDispatcher {
      *
      * @param request the parsed request
      * @param handler the active root handler
-     * @return the streaming handler, or {@code null}
+     * @return the resolved stream route, or {@code null}
      */
-    /* default */ HttpStreamHandler resolveStreamHandler(HttpRequest request, HttpHandler handler) {
+    /* default */ HttpRouter.StreamMatch resolveStreamHandler(HttpRequest request,
+                                                              HttpHandler handler) {
         if (handler instanceof HttpRouter router) {
             return router.resolveStream(request.method(), request.path());
         }
@@ -80,12 +82,12 @@ final class CommunityHttpStreamDispatcher {
      *
      * @param request the parsed request that opened the stream
      * @param stream  the held-open transport stream
-     * @param handler the streaming handler to drive
+     * @param match   the resolved stream route
      */
     /* default */ StreamClosedException dispatchStream(HttpRequest request,
                                                       TransportStream stream,
-                                                      HttpStreamHandler handler) {
-        return dispatchStream(request, stream, handler, 0L);
+                                                      HttpRouter.StreamMatch match) {
+        return dispatchStream(request, stream, match, 0L);
     }
 
     /**
@@ -94,12 +96,12 @@ final class CommunityHttpStreamDispatcher {
      *
      * @param request                 the parsed request
      * @param stream                  the held-open transport stream
-     * @param handler                 the streaming handler
+     * @param match                   the resolved stream route
      * @param authDeadlineEpochMillis epoch-millis deadline; {@code <= 0} disables expiry enforcement
      */
     /* default */ StreamClosedException dispatchStream(HttpRequest request,
                                                       TransportStream stream,
-                                                      HttpStreamHandler handler,
+                                                      HttpRouter.StreamMatch match,
                                                       long authDeadlineEpochMillis) {
         // PAQS admission (ADR-043 obligation 7): a NEW open is admitted once and holds its slot for the
         // stream lifetime. Under SHED_LOAD this throws TransportException(EX-NET-4006) before the slot is
@@ -111,7 +113,10 @@ final class CommunityHttpStreamDispatcher {
         HttpStreamEngine engine = HttpStreamEngine.open(
                 request, stream, allocator, authDeadlineEpochMillis, CREDIT_WINDOW_BYTES);
         try {
-            handler.handle(engine);
+            // An exact stream route gets the engine itself; only a template pays for the decorator.
+            match.handler().handle(match.params().isEmpty()
+                    ? engine
+                    : new PathParamStreamExchange(engine, match.params()));
             engine.close();
         } catch (StreamClosedException _) {
             // Designed unwind: peer disconnect or fail-closed teardown. The engine already reset the

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamExchangeTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamExchangeTckTest.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.http;
 
+import eu.exeris.kernel.core.http.routing.HttpRouter;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.community.transport.NativeTcpTransportProvider;
 import eu.exeris.kernel.core.http.sse.StreamAdmissionController;
@@ -132,7 +133,7 @@ class CommunityHttpStreamExchangeTckTest extends AbstractHttpStreamExchangeTck {
         CommunityHttpStreamDispatcher dispatcher =
                 new CommunityHttpStreamDispatcher(new LeakTrackingAllocator(ALLOCATOR), shed);
         try {
-            dispatcher.dispatchStream(streamRequest(), new StubStream(), handler);
+            dispatcher.dispatchStream(streamRequest(), new StubStream(), HttpRouter.StreamMatch.exact(handler));
             return null;
         } catch (ExerisKernelException rejection) {
             return rejection;
@@ -223,7 +224,8 @@ class CommunityHttpStreamExchangeTckTest extends AbstractHttpStreamExchangeTck {
                 // The terminal StreamClosedException (disconnect / fail-closed) is returned even when
                 // the handler swallows the throw — that is what awaitHandlerUnwind() reports.
                 StreamClosedException terminal =
-                        dispatcher.dispatchStream(request, serverStream, observing, authDeadlineEpochMillis);
+                        dispatcher.dispatchStream(request, serverStream,
+                                HttpRouter.StreamMatch.exact(observing), authDeadlineEpochMillis);
                 if (terminal != null) {
                     handlerError.set(terminal);
                 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamJfrTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpStreamJfrTest.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.http;
 
+import eu.exeris.kernel.core.http.routing.HttpRouter;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.community.transport.NativeTcpTransportProvider;
 import eu.exeris.kernel.spi.context.KernelProviders;
@@ -195,7 +196,7 @@ class CommunityHttpStreamJfrTest {
                 try {
                     dispatcher.dispatchStream(
                             new HttpRequest(HttpMethod.GET, "/stream", HttpVersion.HTTP_1_1, List.of(), null),
-                            serverStream, handler);
+                            serverStream, HttpRouter.StreamMatch.exact(handler));
                 } finally {
                     self[0].handlerDone.set(true);
                 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteTemplateTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteTemplateTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.core.http.routing.HttpRouter;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpStreamExchange;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.http.StreamEvent;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.TransportConnection;
+import eu.exeris.kernel.spi.transport.TransportStream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A templated stream route, driven end to end through the production dispatch path.
+ *
+ * <p>{@code HttpRouterTest} proves the router <em>resolves</em> a template and captures its
+ * parameters; nothing there proves the capture reaches a running handler. That gap is the same shape
+ * as the defect this work fixed — a registration that looks correct and never reaches production
+ * behaviour — so it gets its own test rather than an argument.
+ *
+ * <p>Deliberately goes through {@code resolveStreamHandler} and {@code dispatchStream} with a real
+ * {@link HttpRouter}, not through {@code StreamMatch.exact(...)} as the sibling suites do: the branch
+ * under test is the one that wraps the engine in a {@code PathParamStreamExchange} only when a template
+ * captured something, and a hand-built exact match skips it entirely.
+ *
+ * @since 0.11.0
+ */
+@DisplayName("Community: a templated stream route delivers its captured parameters")
+class CommunityStreamRouteTemplateTest {
+
+    private static final MemoryAllocator ALLOCATOR =
+            new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+
+    @AfterAll
+    static void closeAllocator() {
+        ALLOCATOR.close();
+    }
+
+    @Test
+    @DisplayName("the handler sees the concrete id the request carried")
+    void templatedStreamRouteReachesTheHandler() {
+        AtomicReference<Map<String, String>> seen = new AtomicReference<>();
+        AtomicReference<String> seenPath = new AtomicReference<>();
+
+        HttpRouter router = HttpRouter.builder()
+                .streamRoute(HttpMethod.POST, "/orders/{id}/actions/ship", exchange -> {
+                    seen.set(exchange.pathParams());
+                    seenPath.set(exchange.request().path());
+                    exchange.emit(StreamEvent.of("shipping"));
+                    exchange.close();
+                })
+                .build();
+
+        dispatch(router, "/orders/42/actions/ship");
+
+        assertThat(seen.get())
+                .as("the router captured the id; a handler that cannot read it knows a stream is open "
+                        + "but not what it is a stream of")
+                .containsEntry("id", "42");
+        assertThat(seenPath.get())
+                .as("the decorator must forward request() untouched, not synthesise its own")
+                .isEqualTo("/orders/42/actions/ship");
+    }
+
+    @Test
+    @DisplayName("an exact stream route still reports an empty map, not a null one")
+    void exactStreamRouteIsUndecorated() {
+        AtomicReference<Map<String, String>> seen = new AtomicReference<>();
+
+        HttpRouter router = HttpRouter.builder()
+                .streamRoute(HttpMethod.POST, "/orders/events", exchange -> {
+                    seen.set(exchange.pathParams());
+                    exchange.close();
+                })
+                .build();
+
+        dispatch(router, "/orders/events");
+
+        assertThat(seen.get())
+                .as("the common path skips the decorator entirely, so this is the engine's own default")
+                .isNotNull()
+                .isEmpty();
+    }
+
+    private static void dispatch(HttpRouter router, String path) {
+        CommunityHttpStreamDispatcher dispatcher = new CommunityHttpStreamDispatcher(ALLOCATOR);
+        HttpRequest request = HttpRequest.noBody(
+                HttpMethod.POST, path, HttpVersion.HTTP_1_1, List.of());
+
+        HttpRouter.StreamMatch match = dispatcher.resolveStreamHandler(request, router);
+        assertThat(match).as("route must resolve as streaming for %s", path).isNotNull();
+
+        dispatcher.dispatchStream(request, new DiscardingStream(), match);
+    }
+
+    /** Accepts the SSE head and every event, and never reads — the wire is not what is under test. */
+    private static final class DiscardingStream implements TransportStream {
+
+        @Override
+        public int read(MemorySegment target, int maxBytes) {
+            return -1;
+        }
+
+        @Override
+        public void write(MemorySegment source, int length) {
+            // Discarded: this test asserts on what the handler saw, not on what reached the socket.
+        }
+
+        @Override
+        public void queueWrite(LoanedBuffer buffer, int length) {
+            buffer.close();
+        }
+
+        @Override
+        public long streamId() {
+            return 1L;
+        }
+
+        @Override
+        public boolean isBidirectional() {
+            return true;
+        }
+
+        @Override
+        public boolean isClientInitiated() {
+            return true;
+        }
+
+        @Override
+        public TransportConnection connection() {
+            return null;
+        }
+
+        @Override
+        public boolean hasPendingData() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /** Compile-time guard: the handler above is an {@link HttpStreamExchange} consumer, nothing else. */
+    @SuppressWarnings("unused")
+    private static void handlerShape(HttpStreamExchange exchange) {
+        exchange.pathParams();
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java
@@ -256,7 +256,9 @@ public final class HttpRouter implements HttpHandler {
         }
 
         private void addRoute(HttpMethod method, String path, HttpHandler handler) {
-            if (path.indexOf('{') >= 0) {
+            // The shared predicate, not a second copy of it: one type decides what counts as a template
+            // for both tables, which is the whole reason PathTemplate was extracted.
+            if (PathTemplate.isTemplate(path)) {
                 templateRoutes.add(PathTemplateRoute.compile(method, path, handler));
             } else {
                 exactRoutes.add(new RouteEntry(method, path, handler));

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java
@@ -15,7 +15,6 @@ import eu.exeris.kernel.spi.http.HttpStatus;
 import eu.exeris.kernel.spi.http.HttpStreamHandler;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,6 +39,14 @@ import java.util.Objects;
  * A path registered with at least one {@code {name}} segment is matched as a template:
  * each placeholder captures the corresponding request segment and is exposed to the handler
  * via {@link HttpExchange#pathParams()}.
+ *
+ * <p>The streaming table follows the same rules — exact before template, same placeholder syntax,
+ * captured values reaching the handler through
+ * {@link eu.exeris.kernel.spi.http.HttpStreamExchange#pathParams()}. It did not always: the streaming
+ * table was an exact-match {@code Map} while the generator emitted templated stream paths, so every
+ * per-action stream route registered successfully and then never matched a concrete request. A
+ * registration that cannot match is now unrepresentable — a malformed brace throws at
+ * {@link Builder#streamRoute}, and a well-formed one is compiled as a template.
  */
 public final class HttpRouter implements HttpHandler {
 
@@ -49,36 +56,39 @@ public final class HttpRouter implements HttpHandler {
     private final List<RouteEntry> exactRoutes;
     private final List<PathTemplateRoute> templateRoutes;
     private final List<RouteEntry> prefixRoutes;
-    private final Map<StreamRouteKey, HttpStreamHandler> streamRoutes;
+    private final StreamRouteTable streamRoutes;
     private final HttpHandler notFoundHandler;
 
     private HttpRouter(List<RouteEntry> exactRoutes,
                        List<PathTemplateRoute> templateRoutes,
                        List<RouteEntry> prefixRoutes,
-                       Map<StreamRouteKey, HttpStreamHandler> streamRoutes,
+                       StreamRouteTable streamRoutes,
                        HttpHandler notFoundHandler) {
         this.exactRoutes = List.copyOf(exactRoutes);
         this.templateRoutes = List.copyOf(templateRoutes);
         this.prefixRoutes = List.copyOf(prefixRoutes);
-        this.streamRoutes = Map.copyOf(streamRoutes);
+        this.streamRoutes = streamRoutes;
         this.notFoundHandler = notFoundHandler;
     }
 
     /**
-     * Resolves a streaming-flagged route to its {@link HttpStreamHandler}, or {@code null} when the
-     * route is not registered as a stream (ADR-043 obligation 7).
+     * Resolves a streaming-flagged route, or {@code null} when the route is not registered as a stream
+     * (ADR-043 obligation 7).
      *
      * <p>A streaming route resolves <em>only</em> here, never through {@link #handle(HttpExchange)} —
      * so a streaming route never delivers a respond-once {@link HttpExchange}, and a respond-once route
      * never resolves to an {@link HttpStreamHandler}. The transport tier consults this first; on a hit
      * it opens an {@code HttpStreamExchange}, otherwise it falls back to respond-once dispatch.
      *
+     * <p>Exact stream routes win over template stream routes, mirroring the respond-once precedence:
+     * a deployment that registers both a literal and a templated path meant the literal to be special.
+     *
      * @param method request method
      * @param path   request path (query stripped)
-     * @return the stream handler for a streaming route, or {@code null}
+     * @return the resolved stream route, or {@code null}
      */
-    public HttpStreamHandler resolveStream(HttpMethod method, String path) {
-        return streamRoutes.get(new StreamRouteKey(method, stripQuery(path)));
+    public StreamMatch resolveStream(HttpMethod method, String path) {
+        return streamRoutes.resolve(method, stripQuery(path));
     }
 
     /**
@@ -89,7 +99,7 @@ public final class HttpRouter implements HttpHandler {
      * @return whether the route is streaming
      */
     public boolean isStreamRoute(HttpMethod method, String path) {
-        return streamRoutes.containsKey(new StreamRouteKey(method, stripQuery(path)));
+        return resolveStream(method, path) != null;
     }
 
     public static Builder builder() {
@@ -185,7 +195,24 @@ public final class HttpRouter implements HttpHandler {
 
     private record RouteEntry(HttpMethod method, String path, HttpHandler handler) {}
 
-    private record StreamRouteKey(HttpMethod method, String path) {}
+    /**
+     * A resolved streaming route: the handler, and whatever its template captured.
+     *
+     * @param handler the streaming handler to drive
+     * @param params  captured path parameters; empty for an exact stream route
+     */
+    public record StreamMatch(HttpStreamHandler handler, Map<String, String> params) {
+
+        /**
+         * A match with nothing captured — what an exact stream route resolves to.
+         *
+         * @param handler the streaming handler
+         * @return the match; never {@code null}
+         */
+        public static StreamMatch exact(HttpStreamHandler handler) {
+            return new StreamMatch(handler, Map.of());
+        }
+    }
 
     public static final class Builder {
 
@@ -195,7 +222,7 @@ public final class HttpRouter implements HttpHandler {
         private final List<RouteEntry> exactRoutes = new ArrayList<>();
         private final List<PathTemplateRoute> templateRoutes = new ArrayList<>();
         private final List<RouteEntry> prefixRoutes = new ArrayList<>();
-        private final Map<StreamRouteKey, HttpStreamHandler> streamRoutes = new HashMap<>();
+        private final StreamRouteTable.Builder streamRoutes = new StreamRouteTable.Builder();
         private HttpHandler notFoundHandler = DEFAULT_NOT_FOUND;
 
         private Builder() {}
@@ -268,7 +295,7 @@ public final class HttpRouter implements HttpHandler {
             Objects.requireNonNull(method, METHOD_PARAM);
             Objects.requireNonNull(path, "path");
             Objects.requireNonNull(handler, HANDLER_PARAM);
-            streamRoutes.put(new StreamRouteKey(method, path), handler);
+            streamRoutes.add(method, path, handler);
             return this;
         }
 
@@ -281,7 +308,8 @@ public final class HttpRouter implements HttpHandler {
         /** Builds the immutable router and emits a JFR lifecycle event. */
         public HttpRouter build() {
             HttpRouterRegisteredEvent.emit(exactRoutes.size(), templateRoutes.size(), prefixRoutes.size());
-            return new HttpRouter(exactRoutes, templateRoutes, prefixRoutes, streamRoutes, notFoundHandler);
+            return new HttpRouter(exactRoutes, templateRoutes, prefixRoutes, streamRoutes.build(),
+                    notFoundHandler);
         }
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathParamStreamExchange.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathParamStreamExchange.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.http.routing;
+
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpStreamExchange;
+import eu.exeris.kernel.spi.http.StreamEvent;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Carries a templated stream route's captured parameters to the handler.
+ *
+ * <p>The streaming mirror of {@code PathParamHttpExchange}, and deliberately the same shape: a
+ * decorator that adds one answer and forwards everything else. Adding the parameters to
+ * {@code HttpStreamEngine} instead would have put routing state inside the wire engine, which is the
+ * one place in the streaming path that should know nothing about how the route was chosen.
+ *
+ * <p>Only wrapped when a template actually captured something — an exact stream route gets the engine
+ * itself, so the common path pays nothing.
+ *
+ * @since 0.11.0
+ */
+public final class PathParamStreamExchange implements HttpStreamExchange {
+
+    private final HttpStreamExchange delegate;
+    private final Map<String, String> pathParams;
+
+    /**
+     * Wraps a stream exchange with the parameters its route captured.
+     *
+     * @param delegate   the underlying stream exchange
+     * @param pathParams captured parameters; copied, so a later mutation cannot reach the handler
+     */
+    public PathParamStreamExchange(HttpStreamExchange delegate, Map<String, String> pathParams) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        this.pathParams = Map.copyOf(Objects.requireNonNull(pathParams, "pathParams must not be null"));
+    }
+
+    @Override
+    public HttpRequest request() {
+        return delegate.request();
+    }
+
+    @Override
+    public Map<String, String> pathParams() {
+        return pathParams;
+    }
+
+    @Override
+    public void emit(StreamEvent event) {
+        delegate.emit(event);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathTemplate.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathTemplate.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.http.routing;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A compiled path template: literal and {@code {name}} placeholder segments, matched by position.
+ *
+ * <p>Extracted from {@code PathTemplateRoute} when the streaming table gained templates. The two
+ * tables carry different handler types and nothing else, so leaving the matching inside the
+ * respond-once route would have meant a second copy of the placeholder rules — and a copy is exactly
+ * how the two tables would drift into disagreeing about what {@code /x/{id}} means.
+ *
+ * @param segments   ordered literal and placeholder segments
+ * @param paramCount number of placeholder segments, sized once for the capture map
+ */
+record PathTemplate(List<Segment> segments, int paramCount) {
+
+    /** One compiled path segment: a {@code {name}} placeholder ({@code param=true}) or a literal. */
+    /* default */ record Segment(boolean param, String text) {}
+
+    /**
+     * Compiles a path into a template.
+     *
+     * @param path the registered path
+     * @return the compiled template
+     * @throws IllegalArgumentException if any segment uses braces but is not a well-formed
+     *                                  {@code {name}} placeholder
+     */
+    /* default */ static PathTemplate compile(String path) {
+        String[] raw = path.split("/", -1);
+        List<Segment> parsed = new ArrayList<>(raw.length);
+        int params = 0;
+        for (String rawSegment : raw) {
+            Segment segment = parseSegment(rawSegment, path);
+            parsed.add(segment);
+            if (segment.param()) {
+                params++;
+            }
+        }
+        return new PathTemplate(List.copyOf(parsed), params);
+    }
+
+    /**
+     * Returns whether a registered path should be compiled as a template rather than stored as an
+     * exact key.
+     *
+     * @param path the registered path
+     * @return {@code true} if the path carries a brace
+     */
+    /* default */ static boolean isTemplate(String path) {
+        return path.indexOf('{') >= 0;
+    }
+
+    // A well-formed placeholder is "{name}" with exactly one '{' (first char) and one '}' (last char);
+    // any other brace usage is a malformed template and is rejected at build time rather than silently
+    // compiled into a never-matching literal.
+    private static Segment parseSegment(String rawSegment, String path) {
+        boolean wellFormedParam = rawSegment.length() > 2
+                && rawSegment.charAt(0) == '{'
+                && rawSegment.indexOf('{', 1) < 0
+                && rawSegment.indexOf('}') == rawSegment.length() - 1;
+        if (wellFormedParam) {
+            return new Segment(true, rawSegment.substring(1, rawSegment.length() - 1));
+        }
+        if (rawSegment.indexOf('{') >= 0 || rawSegment.indexOf('}') >= 0) {
+            throw new IllegalArgumentException(
+                    "Malformed path-template segment '" + rawSegment + "' in route " + path);
+        }
+        return new Segment(false, rawSegment);
+    }
+
+    /**
+     * Returns whether {@code requestSegments} matches this template.
+     *
+     * <p>Separate from {@link #capture} so a miss — the common case when a router walks its template
+     * list — costs no map at all. A hit walks the segments a second time, which is a handful of
+     * comparisons against an allocation that would otherwise be made and discarded on every miss.
+     *
+     * @param requestSegments the request path pre-split on {@code '/'} (split once by the router and
+     *                        reused across every template, hence an array rather than varargs)
+     * @return {@code true} if every literal segment is equal and every placeholder has a non-empty value
+     */
+    @SuppressWarnings("PMD.UseVarargs") // call site passes a pre-split array, never a varargs list
+    /* default */ boolean matches(String[] requestSegments) {
+        if (requestSegments.length != segments.size()) {
+            return false;
+        }
+        for (int i = 0; i < segments.size(); i++) {
+            Segment segment = segments.get(i);
+            String actual = requestSegments[i];
+            if (segment.param()) {
+                if (actual.isEmpty()) {
+                    return false;
+                }
+            } else if (!segment.text().equals(actual)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Captures the placeholder values from segments already known to {@link #matches}.
+     *
+     * @param requestSegments the matching request path pre-split on {@code '/'}
+     * @return the captured parameters; empty when the template declares none
+     */
+    @SuppressWarnings("PMD.UseVarargs") // call site passes a pre-split array, never a varargs list
+    /* default */ Map<String, String> capture(String[] requestSegments) {
+        if (paramCount == 0) {
+            return Map.of();
+        }
+        Map<String, String> captured = LinkedHashMap.newLinkedHashMap(paramCount);
+        for (int i = 0; i < segments.size(); i++) {
+            Segment segment = segments.get(i);
+            if (segment.param()) {
+                captured.put(segment.text(), requestSegments[i]);
+            }
+        }
+        return Map.copyOf(captured);
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathTemplateRoute.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/PathTemplateRoute.java
@@ -11,81 +11,29 @@ package eu.exeris.kernel.core.http.routing;
 import eu.exeris.kernel.spi.http.HttpHandler;
 import eu.exeris.kernel.spi.http.HttpMethod;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
- * A path-template route compiled once at build time. {@code segments} is the ordered list of
- * literal and placeholder segments; matching requires the same segment count and equality on every
- * literal segment, and each placeholder captures the corresponding request segment.
+ * A respond-once path-template route: a method, a compiled {@link PathTemplate}, and its handler.
  */
-record PathTemplateRoute(HttpMethod method, List<Segment> segments, int paramCount, HttpHandler handler) {
-
-    /** One compiled path segment: a {@code {name}} placeholder ({@code param=true}) or a literal. */
-    /* default */ record Segment(boolean param, String text) {}
+record PathTemplateRoute(HttpMethod method, PathTemplate template, HttpHandler handler) {
 
     // Package-private factory for the HttpRouter builder.
-    /* default */ static PathTemplateRoute compile(HttpMethod method, String path, HttpHandler handler) {
-        String[] raw = path.split("/", -1);
-        List<Segment> parsed = new ArrayList<>(raw.length);
-        int params = 0;
-        for (String rawSegment : raw) {
-            Segment segment = parseSegment(rawSegment, path);
-            parsed.add(segment);
-            if (segment.param()) {
-                params++;
-            }
-        }
-        return new PathTemplateRoute(method, List.copyOf(parsed), params, handler);
-    }
-
-    // A well-formed placeholder is "{name}" with exactly one '{' (first char) and one '}' (last char);
-    // any other brace usage is a malformed template and is rejected at build time rather than silently
-    // compiled into a never-matching literal.
-    private static Segment parseSegment(String rawSegment, String path) {
-        boolean wellFormedParam = rawSegment.length() > 2
-                && rawSegment.charAt(0) == '{'
-                && rawSegment.indexOf('{', 1) < 0
-                && rawSegment.indexOf('}') == rawSegment.length() - 1;
-        if (wellFormedParam) {
-            return new Segment(true, rawSegment.substring(1, rawSegment.length() - 1));
-        }
-        if (rawSegment.indexOf('{') >= 0 || rawSegment.indexOf('}') >= 0) {
-            throw new IllegalArgumentException(
-                    "Malformed path-template segment '" + rawSegment + "' in route " + path);
-        }
-        return new Segment(false, rawSegment);
+    /* default */ static PathTemplateRoute compile(HttpMethod method, String path,
+                                                   HttpHandler handler) {
+        return new PathTemplateRoute(method, PathTemplate.compile(path), handler);
     }
 
     /**
      * Returns a {@link RouteMatch} (handler + captured params) when {@code requestSegments} matches
-     * this template, or {@code null} when it does not. An empty request segment never satisfies a
-     * placeholder.
+     * this template, or {@code null} when it does not.
      *
-     * @param requestSegments the request path pre-split on {@code '/'} (eager-split once by the router
-     *     and reused across every template, hence an array rather than varargs)
+     * @param requestSegments the request path pre-split on {@code '/'}
+     * @return the match, or {@code null}
      */
     @SuppressWarnings("PMD.UseVarargs") // call site passes a pre-split array, never a varargs list
     /* default */ RouteMatch toMatch(String[] requestSegments) {
-        if (requestSegments.length != segments.size()) {
-            return null;
-        }
-        Map<String, String> captured = LinkedHashMap.newLinkedHashMap(paramCount);
-        for (int i = 0; i < segments.size(); i++) {
-            Segment segment = segments.get(i);
-            String actual = requestSegments[i];
-            if (!segment.param() && !segment.text().equals(actual)) {
-                return null;
-            }
-            if (segment.param() && actual.isEmpty()) {
-                return null;
-            }
-            if (segment.param()) {
-                captured.put(segment.text(), actual);
-            }
-        }
-        return new RouteMatch(handler, Map.copyOf(captured));
+        return template.matches(requestSegments)
+                ? new RouteMatch(handler, template.capture(requestSegments))
+                : null;
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/StreamRouteTable.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/StreamRouteTable.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.http.routing;
+
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpStreamHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The streaming half of the routing table: exact paths first, then templates.
+ *
+ * <p>Its own type because it is its own table. Folding it back into {@link HttpRouter} would put two
+ * independent resolution strategies in one class and, more to the point, would hide that the streaming
+ * table has exactly the precedence rules the respond-once one does — which is the property that stopped
+ * being true when this table was a bare {@code Map} and templated stream routes silently never matched.
+ *
+ * @since 0.11.0
+ */
+final class StreamRouteTable {
+
+    private final Map<Key, HttpStreamHandler> exact;
+    private final List<TemplateEntry> templates;
+
+    private StreamRouteTable(Map<Key, HttpStreamHandler> exact, List<TemplateEntry> templates) {
+        this.exact = Map.copyOf(exact);
+        this.templates = List.copyOf(templates);
+    }
+
+    /**
+     * Resolves a streaming route, or returns {@code null} when none matches.
+     *
+     * <p>An exact route wins over a template, mirroring respond-once precedence: a deployment that
+     * registers a literal alongside a template meant the literal to be the special case.
+     *
+     * @param method request method
+     * @param path   request path, query already stripped
+     * @return the match, or {@code null}
+     */
+    /* default */ HttpRouter.StreamMatch resolve(HttpMethod method, String path) {
+        HttpStreamHandler literal = exact.get(new Key(method, path));
+        if (literal != null) {
+            return HttpRouter.StreamMatch.exact(literal);
+        }
+        if (templates.isEmpty()) {
+            return null;
+        }
+        String[] segments = path.split("/", -1);
+        for (TemplateEntry entry : templates) {
+            if (entry.method() == method && entry.template().matches(segments)) {
+                return new HttpRouter.StreamMatch(
+                        entry.handler(), entry.template().capture(segments));
+            }
+        }
+        return null;
+    }
+
+    private record Key(HttpMethod method, String path) {}
+
+    private record TemplateEntry(HttpMethod method, PathTemplate template,
+                                 HttpStreamHandler handler) {}
+
+    /** Accumulates registrations, compiling each path once at build time. */
+    /* default */ static final class Builder {
+
+        private final Map<Key, HttpStreamHandler> exact = new HashMap<>();
+        private final List<TemplateEntry> templates = new ArrayList<>();
+
+        /**
+         * Registers one streaming route.
+         *
+         * @throws IllegalArgumentException if the path carries a brace that is not a well-formed
+         *                                  {@code {name}} placeholder — a registration that could never
+         *                                  match must not be storable
+         */
+        /* default */ void add(HttpMethod method, String path, HttpStreamHandler handler) {
+            if (PathTemplate.isTemplate(path)) {
+                templates.add(new TemplateEntry(method, PathTemplate.compile(path), handler));
+            } else {
+                exact.put(new Key(method, path), handler);
+            }
+        }
+
+        /* default */ StreamRouteTable build() {
+            return new StreamRouteTable(exact, templates);
+        }
+    }
+}

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/http/routing/HttpRouterTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/http/routing/HttpRouterTest.java
@@ -407,6 +407,87 @@ class HttpRouterTest {
         }
 
         @Test
+        void templatedStreamRouteMatchesAConcreteId() {
+            // The defect this table was missing: the tooling generator emits exactly this shape
+            // (ADR-044 Slice 2), and an exact-match table registered it happily and then never matched,
+            // so every per-action stream 404'd on a real boot.
+            HttpRouter router = HttpRouter.builder()
+                    .streamRoute(HttpMethod.POST, "/orders/{id}/actions/ship", exchange -> { })
+                    .build();
+
+            HttpRouter.StreamMatch match =
+                    router.resolveStream(HttpMethod.POST, "/orders/42/actions/ship");
+
+            assertTrue(match != null, "a registered stream route that cannot match is a dead route");
+            assertEquals("42", match.params().get("id"));
+            assertTrue(router.isStreamRoute(HttpMethod.POST, "/orders/42/actions/ship"));
+        }
+
+        @Test
+        void templatedStreamRouteCapturesEverySegmentAndStripsQuery() {
+            HttpRouter router = HttpRouter.builder()
+                    .streamRoute(HttpMethod.GET, "/t/{tenant}/s/{stream}", exchange -> { })
+                    .build();
+
+            HttpRouter.StreamMatch match =
+                    router.resolveStream(HttpMethod.GET, "/t/acme/s/audit?since=5");
+
+            assertTrue(match != null);
+            assertEquals("acme", match.params().get("tenant"));
+            assertEquals("audit", match.params().get("stream"));
+        }
+
+        @Test
+        void exactStreamRouteWinsOverTemplate() {
+            AtomicBoolean exactRan = new AtomicBoolean(false);
+            HttpRouter router = HttpRouter.builder()
+                    .streamRoute(HttpMethod.GET, "/x/{id}", exchange -> { })
+                    .streamRoute(HttpMethod.GET, "/x/all", exchange -> exactRan.set(true))
+                    .build();
+
+            // Mirrors respond-once precedence: registering a literal alongside a template means the
+            // literal is the special case.
+            router.resolveStream(HttpMethod.GET, "/x/all").handler().handle(null);
+            assertTrue(exactRan.get());
+            assertTrue(router.resolveStream(HttpMethod.GET, "/x/7").params().containsKey("id"));
+        }
+
+        @Test
+        void templatedStreamRouteDoesNotMatchAWrongShape() {
+            HttpRouter router = HttpRouter.builder()
+                    .streamRoute(HttpMethod.GET, "/x/{id}/events", exchange -> { })
+                    .build();
+
+            assertNull(router.resolveStream(HttpMethod.GET, "/x/42"));
+            assertNull(router.resolveStream(HttpMethod.GET, "/x//events"),
+                    "an empty segment must not satisfy a placeholder");
+            assertNull(router.resolveStream(HttpMethod.POST, "/x/42/events"),
+                    "the method is part of the match");
+        }
+
+        @Test
+        void malformedBraceInAStreamPathIsRejectedAtRegistration() {
+            // The fail-fast half of this slice: a stream path carrying a brace either resolves via
+            // templates or fails here. A silently-dead stream registration must be unrepresentable.
+            assertThrows(IllegalArgumentException.class, () -> HttpRouter.builder()
+                    .streamRoute(HttpMethod.GET, "/x/{id/events", exchange -> { }));
+        }
+
+        @Test
+        void streamAndRespondOnceTablesStayDisjointUnderTemplates() {
+            HttpRouter router = HttpRouter.builder()
+                    .route(HttpMethod.GET, "/x/{id}", e -> e.respond(HttpStatus.OK))
+                    .streamRoute(HttpMethod.GET, "/x/{id}/events", exchange -> { })
+                    .build();
+
+            assertNull(router.resolveStream(HttpMethod.GET, "/x/42"));
+            CapturingExchange exchange = CapturingExchange.get("/x/42/events");
+            router.handle(exchange);
+            assertEquals(HttpStatus.NOT_FOUND, exchange.status(),
+                    "a streaming route stays invisible to the respond-once path (ADR-043 §7)");
+        }
+
+        @Test
         void respondOnceRouteIsNotAStreamRoute() {
             HttpRouter router = HttpRouter.builder()
                     .route(HttpMethod.GET, "/health", e -> e.respond(HttpStatus.OK))

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpStreamExchange.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpStreamExchange.java
@@ -10,6 +10,8 @@ package eu.exeris.kernel.spi.http;
 
 import eu.exeris.kernel.spi.exceptions.http.StreamClosedException;
 
+import java.util.Map;
+
 /**
  * SPI: A long-lived, server-initiated HTTP push exchange — Server-Sent Events (SSE).
  *
@@ -67,6 +69,28 @@ public interface HttpStreamExchange {
      * @return the inbound request; never {@code null}
      */
     HttpRequest request();
+
+    /**
+     * Returns the path parameters captured by the router from a templated streaming route.
+     *
+     * <p>The streaming counterpart of {@link HttpExchange#pathParams()}, with the same semantics: a
+     * stream route registered as {@code /entities/{id}/events} and opened on {@code /entities/42/events}
+     * yields {@code pathParams().get("id") == "42"}. An exact stream route, or any exchange not opened
+     * through a template, returns an empty map.
+     *
+     * <p>Without this a templated stream route would resolve and then drop the one value that made it
+     * worth templating — the handler would know a stream is open, but not what it is a stream *of*.
+     *
+     * <p>The returned map is immutable and carries no wire-format types — values are the already-decoded
+     * path segments as received on the request target.
+     *
+     * @return an immutable map of captured path parameters; never {@code null}, empty when the route
+     *         declared no placeholders
+     * @since 0.11.0
+     */
+    default Map<String, String> pathParams() {
+        return Map.of();
+    }
 
     /**
      * Frames and writes a single SSE event to the wire.

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpStreamExchangeTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpStreamExchangeTck.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -186,6 +187,47 @@ public abstract class AbstractHttpStreamExchangeTck {
      */
     protected ExerisKernelException openUnderShed(HttpStreamHandler handler) {
         throw new UnsupportedOperationException("openUnderShed not wired by this binding");
+    }
+
+    // -------------------------------------------------------------------------
+    // Path parameters
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Path parameters")
+    class PathParameters {
+
+        @Test
+        @Timeout(value = OBSERVE_TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+        @DisplayName("an exchange not opened through a template reports an empty, immutable map")
+        void defaultIsEmptyAndImmutable() {
+            AtomicReference<Map<String, String>> seen = new AtomicReference<>();
+            AtomicReference<Boolean> mutable = new AtomicReference<>(Boolean.TRUE);
+
+            StreamScenario scenario = openStream(exchange -> {
+                seen.set(exchange.pathParams());
+                try {
+                    exchange.pathParams().put("injected", "value");
+                } catch (RuntimeException _) {
+                    mutable.set(Boolean.FALSE);
+                }
+                exchange.emit(StreamEvent.of("ready"));
+                exchange.close();
+            });
+
+            try (scenario) {
+                scenario.awaitEvents(1);
+                assertThat(seen.get())
+                        .as("never null — a handler reading pathParams() on an exact route must not "
+                                + "have to null-check what the contract promises")
+                        .isNotNull()
+                        .isEmpty();
+                assertThat(mutable.get())
+                        .as("the map is routing state; a handler that could write to it could change "
+                                + "what a later request resolves to")
+                        .isFalse();
+            }
+        }
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes the Stream I entry. The streaming table was an exact-match `Map` while the tooling generator emits **templated** stream paths (ADR-044 Slice 2 — `<base>/{id}/actions/<kebab>`), so every per-action stream route registered successfully and then never matched a concrete request. A dead route that 404s on a real boot, accepted by the builder without a word. Not yet user-visible only because the per-action driver is still a keep-alive scaffold — which is why this is a v0.11 slice and was never a v0.10.x hotfix.

## Both halves, together

| | |
|---|---|
| **Templates** | The streaming table compiles `{name}` paths through the **same** `PathTemplate` the respond-once table uses, with the same exact-before-template precedence. One compiled type serves both tables, so they cannot drift into disagreeing about what `/x/{id}` means — which is exactly how this defect would come back. |
| **Fail-fast** | A malformed brace throws at `Builder.streamRoute`. A silently-dead stream registration is now unrepresentable — the property the ROADMAP made mandatory under *either* shape decision. |

Taken as the default direction without waiting on the tooling EV1-stream ruling: it subsumes the fail-fast property and stays correct under either outcome, as the alternative anticipated.

## `HttpStreamExchange.pathParams()`

A templated route that resolved and then dropped what it captured would leave the handler knowing a stream is open but not *what it is a stream of*. Delivered by `PathParamStreamExchange` — the streaming mirror of the existing `PathParamHttpExchange`: a decorator that adds one answer and forwards the rest, so routing state stays out of the wire engine. Only wrapped when a template captured something, so exact routes pay nothing.

## Incidental allocation win

`PathTemplate` splits `matches()` from `capture()`. A miss — the common case when a router walks its template list — now allocates **no map at all**, where the previous shape built one and threw it away. A hit walks the segments twice: a handful of comparisons, against an allocation per miss.

## Verification

- `mvn clean install` green on the **full reactor**, lint gates active, no skip flags
- `ExerisArchitectureTest` 13/13
- `HttpRouterTest` 38 cases (`StreamingRegistration` 3 → 9)
- `AbstractHttpStreamExchangeTck` gains a `PathParameters` case, green on the Community binding: `pathParams()` is never null and is **immutable** — the map is routing state, so a handler able to write to it could change what a later request resolves to
- **Non-vacuity by mutation:** registering every stream path as exact fails 4 of the 6 new router cases. The two survivors are the negative ones (wrong shape, table disjointness) — they assert that *nothing* matches, which is precisely what a registration bug cannot break

## Call-site change

`HttpRouter.resolveStream` now returns a `StreamMatch` (handler + captured params) rather than a bare handler, since a template hit has two things to report. `StreamMatch.exact(handler)` covers the no-params case; the only production caller is `CommunityHttpStreamDispatcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)