### PR TITLE
docs(events): state the single-node/cross-node delivery boundary (v0.11 S13)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1728,6 +1728,10 @@ See also: v0.11 §"Runtime: `JobScheduler` SPI" (leader-election subset); ADR-01
 
 **Merge Gate:** `docs/subsystems/events.md` states the single-node-default vs Kafka-cross-node delivery boundary; the multi-node substrate inventory is recorded in one authoritative place (events.md or the operator deployment doc). No TCK / SPI change.
 
+**Status (v0.11): DELIVERED.** `events.md` §"Delivery Boundary: Single-Node Default vs Cross-Node (Kafka)" states the boundary and hosts the substrate inventory; `support-matrix.md` and `operations/reference-deployment.md` link there instead of restating it.
+
+One finding from writing it, recorded because it is sharper than the gap this entry described: **the durable-emission and cross-node-delivery paths are not composable today.** The Gap text above reads as though an operator picks the Kafka driver and keeps the Outbox. They do not — `KafkaEventEngine` runs no outbox orchestrator (its `EventQueue` slot is a `NoOpQueue`, and `KafkaEventBrokerPort` is a built adapter wired into no runtime path), while `CommunityEventEngine` constructs its local broker port directly with no seam to substitute. So the choice today is durable emission on one node *or* cross-node fan-out, not both. Documented as a current limit; tracked separately as §"Events: Durable Emission And Cross-Node Delivery Cannot Be Had Together" below, because the operator-visible cost (adopting Kafka silently drops the transactional outbox) is a gap in its own right, not a documentation shortfall.
+
 ---
 
 ### HTTP Client: Service Discovery & Logical Addressing for `KernelWebClient` — RFC Track
@@ -1858,6 +1862,39 @@ the failure this entry exists to prevent. Emit the selection as a JFR event, as 
 **Merge Gate:** binding test proving the configured provider wins with both on the classpath; a test
 proving an ambiguous configuration fails at startup rather than choosing; `docs/subsystems/storage.md`
 loses its "provider selection is an open gap" paragraph.
+
+---
+
+### Events: Durable Emission And Cross-Node Delivery Cannot Be Had Together (surfaced 2026-08-02)
+
+**Gap:** The Outbox and the Kafka driver are described throughout the docs as complementary — durable
+emission plus cross-node fan-out — but no deployment can run both. `KafkaEventEngine` starts no outbox
+orchestrator: its `EventQueue` slot is a `NoOpQueue`, and `KafkaEventBrokerPort` exists as a built,
+Wall-clean adapter that nothing wires into a runtime path. `CommunityEventEngine` constructs
+`CommunityEventBusOutboxBrokerPort` inline, so its relay target is the local bus with no seam to
+substitute. Provider selection then picks exactly one engine.
+
+The consequence is not a lost event but a lost *guarantee*, and it lands on the deployment that needs
+both most: a multi-node operator who adopts Kafka for fan-out silently gives up the transactional
+outbox — the crash-survival property that made the event atomic with the entity that caused it. Nothing
+warns them; the SPI surface is identical either way. Surfaced while writing the delivery-boundary
+section that this milestone's documentation slice required.
+
+**Owner:** Events subsystem.
+
+**Resolution:** Make the broker port a selection, not a construction detail. The two adapters already
+implement the same Core port, so the work is a seam plus config, not a new mechanism: let the engine
+take its `OutboxBrokerPort` from configuration, and let the Kafka module run the orchestrator with
+`KafkaEventBrokerPort` bound. The publish-path duplication needs settling in the same change — with a
+Kafka broker port the outbox relay and `KafkaPublishBus` are two routes to the same topic, so one of
+them has to become the only one. That the port is unwired is already on record — [ADR-050](adr/ADR-050-events-binding-agnostic-topic.md)
+§Consequences notes it, and the module's `package-info` lists it as deferred — so no ADR is contradicted
+here; this entry is where the operator-visible *cost* of the deferral is recorded, which neither of
+those does.
+
+**Merge Gate:** an integration test proving an event committed in a transaction reaches a *second*
+kernel instance after a crash of the first — the property neither engine can demonstrate today; the
+delivery-boundary section in `docs/subsystems/events.md` loses its "not composable today" paragraph.
 
 ---
 

--- a/docs/operations/reference-deployment.md
+++ b/docs/operations/reference-deployment.md
@@ -65,7 +65,9 @@ Validated by the v0.9 operational-continuity suite (the `recovery-continuity-gat
 ## Known operational limits (Community)
 
 - **Single-node, NIO carrier** — no `io_uring`, no slab pools (Enterprise overlay). Best-effort performance contract.
-- **No server-initiated push yet** — HTTP is request/response; a live view polls until the SSE streaming SPI lands (target v0.10/v0.11; RFC in review). See the [Support Matrix](../support-matrix.md) → *Deferred*.
+- **Server push is SSE-only** — one-directional `HttpStreamExchange` since 0.10 ([ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md)); no WebSocket, so full-duplex clients still poll. The SSE body is HTTP/1.1 close-delimited today, which matters for reverse proxies that buffer length-unknown responses — see [`subsystems/http.md`](../subsystems/http.md).
+- **Events do not cross the node boundary on the default driver** — the in-heap bus is single-node and the Outbox is durable *emission*, not cross-node delivery; fanning out to peers means running the Kafka driver. See [`subsystems/events.md`](../subsystems/events.md) → *Delivery Boundary*.
+- **No cross-node coordination seam** — distributed lock / leader election / singleton execution are the host application's concern today.
 - **Caffeine** in-process cache only; no distributed cache provider.
 
 ## See also

--- a/docs/stability-matrix.md
+++ b/docs/stability-matrix.md
@@ -60,8 +60,9 @@ this is informational and **not** a dependency of the open-core surface.
 | `…spi.events` | **preview** | 0.5.0 | — | `AbstractEventBusTck`, `…EventLoopTck`, `…KafkaEventEngineTck`, +5 | — |
 | `…spi.graph` | **preview** | 0.5.0 | — | `AbstractGraphProviderTck`, `…GraphEngineTck`, `…GraphDialectTck`, +3 | — |
 | `…spi.security` | **preview** | 0.5.0 | ADR-014 (RBAC) | `AbstractSecurityProviderTck`, `…RequiresRoleTck`, `…CitadelGuardTck`, +6 | — |
+| `…spi.security.identity` | **preview** | 0.10.0 | ADR-040 | `AbstractIdentityProviderTck` | — |
 | `…spi.crypto` | **preview** | 0.5.0 | ADR-008 (TLS engine) | `AbstractCryptoEngineTck` | yes (FFM crypto) |
-| `…spi.http` | **mixed** | 0.5.0 | ADR-009 / ADR-032 / ADR-034 | see per-surface rows below | yes (HTTP/3 path) |
+| `…spi.http` | **mixed** | 0.5.0 | ADR-009 / ADR-032 / ADR-034 / ADR-043 | see per-surface rows below | yes (HTTP/3 path) |
 | `…spi.util` | _internal_ | 0.5.0 | — | — | — |
 
 ¹ `config`: `ConfigProvider` / `KernelProfile` / `Dynamic` are mature 0.5.0 contracts and treated
@@ -76,10 +77,18 @@ as `stable`. The `@Immutable` annotation + watcher-refusal semantics (since 0.9.
 | `HttpClientEngine`, `HttpServerEngine`, `HttpProvider`, `HttpExchange`, `HttpHandler` | **stable** | 0.5.0 | ADR-009 | `AbstractHttpClientEngineTck`, `…HttpServerEngineTck`, `…HttpProviderTck`, `…HttpExchangeTck`, `…HttpHandlerTck` |
 | `HttpClientRequestEnricher` | **stable** | 0.8.0 | ADR-032 | `AbstractHttpClientRequestEnricherTck` |
 | `HttpRequestBodyEncoder` / `HttpRequestBodyDecoder` / `HttpResponseBodyDecoder` | **preview** | 0.8.0 | ADR-034 | `AbstractHttpRequestBodyEncoderTck`, `…RequestBodyDecoderTck`, `…ResponseBodyDecoderTck` |
+| `HttpStreamExchange` / `HttpStreamHandler` / `StreamEvent` (SSE server-push) | **preview** | 0.10.0 | ADR-043 | `AbstractHttpStreamExchangeTck` |
 
 > The body-codec quadrant has an **accepted ADR (ADR-034)** and executable TCKs, so it is past
 > `experimental` — but the server-side generator that consumes the request decoder lands in a
 > later cycle, so the contract is held at `preview` until that loop closes.
+
+> The streaming surface is wired end-to-end and TCK-pinned, but changes are still in flight rather
+> than merely possible: the wire framing is HTTP/1.1 close-delimited today (per-event chunked framing
+> and an HTTP/2 `DATA` path are follow-ups), the JWT-expiry deadline is built and TCK-pinned but not
+> yet passed by production dispatch, and 0.11 added `pathParams()` to the interface. `preview` is the
+> honest label until those close — see [`subsystems/http.md`](./subsystems/http.md) for the per-item
+> delivery status.
 
 `util` is excluded from the consumer matrix: `eu.exeris.kernel.spi.util` currently contains only
 `SpiDiagnostics`, an internal helper — not a consumer-facing SPI surface.

--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -164,6 +164,57 @@ in the `EventDescriptor` primitive layout.
 
 ---
 
+## Delivery Boundary: Single-Node Default vs Cross-Node (Kafka)
+
+The default Community Events driver is **single-node**. Nothing in the SPI says so — it is
+implementation-blind by design — and "Transactional Outbox" reads as cross-node delivery to anyone who
+has met the pattern elsewhere. Stating the boundary is therefore the documentation's job, not the
+contract's.
+
+**The in-heap bus never crosses the node boundary.** `CommunityEventEngine` composes an in-JVM
+`InMemoryEventBus`; a subscriber is an `EventHandler` registered in the same process. A second kernel
+instance running the same application does not observe the first instance's publications.
+
+**The Outbox is durable *emission*, not cross-node *delivery*.** A row is written to `exeris_outbox`
+through `EventStore.append` inside the caller's own transaction, so the event commits atomically with
+the entity that caused it and survives a crash between commit and dispatch. That is the guarantee it
+buys. Where it dispatches *to* is the part that surprises: the default `OutboxBrokerPort` is
+`CommunityEventBusOutboxBrokerPort`, which republishes onto **that same node's bus**. The durability is
+real; the fan-out is local. Two conditions are worth knowing because neither announces itself — the
+orchestrator is constructed only when `outboxEnabled` (default `true` in
+`EventEngineConfig.communityDefaults()`) *and* a `PersistenceEngine` is bound, so on a kernel with no
+persistence the outbox is silently inert; and the relay is a poll loop over committed rows, so it is
+asynchronous with respect to the transaction that produced them.
+
+**Cross-node delivery requires `exeris-kernel-community-kafka`.** `KafkaEventProvider` registers at
+priority 50 and outranks the in-memory Community provider (priority 0), so adding the jar to the
+classpath swaps the engine — intra-Community precedence, still below the Enterprise tier slot (100).
+Publication then goes producer → broker, and local subscribers see the event only after the roundtrip
+— deliberately, so a local subscriber has the same semantics as a remote one. The consume-side caveats documented for that driver hold: the poll loop runs with
+`enable.auto.commit=true` (at-most-once on consume) and hands each decoded record to an internal
+in-memory bus for local fan-out.
+
+**The two are not composable today.** `KafkaEventEngine` runs no outbox orchestrator at all — its
+`EventQueue` slot is a `NoOpQueue`, and `KafkaEventBrokerPort` ships as a built adapter that is not
+wired into any runtime path. `CommunityEventEngine`, for its part, constructs the local broker port
+directly with no seam to substitute. So a deployment gets durable emission on one node *or* cross-node
+fan-out, not both from one engine. This is a current limit, not a contract: the outbox-orchestrator-driven
+Kafka delivery path is listed as deferred in that module's `package-info`.
+
+### Multi-node substrate inventory
+
+What a "5 instances of the same app" deployment gets from the kernel today. This table is the
+authoritative home for the answer; other docs link here rather than restating it.
+
+| Concern | Substrate today | Where |
+|:--------|:----------------|:------|
+| Per-request state | Stateless — `PrincipalContext` / `StorageContext` propagate through `ScopedValue` per request, so any instance can serve any request | `spi.context`, no shared store needed |
+| Durable shared state | PostgreSQL — saga snapshots with optimistic concurrency on the shared row | [ADR-013](../adr/ADR-013-distributed-saga-state-distribution-model.md); the snapshot store binds through the [ADR-022](../adr/ADR-022-persistence-spi-extension-instant-binders.md) persistence-SPI extension |
+| Cross-node event fan-out | Kafka / Redpanda driver — see the boundary above | `exeris-kernel-community-kafka` |
+| Cross-node coordination (distributed lock, leader election, singleton execution) | **No kernel seam.** Hand-rolled over Postgres advisory locks or Kafka consumer groups, with the fencing-token and lease-expiry burden on application code | ROADMAP → *Runtime: Cross-Node Coordination (Leader Election / Distributed Lock) — RFC Track* |
+
+---
+
 ## Responsibilities
 
 **What Events SPI DOES:**
@@ -439,9 +490,13 @@ operational differences relevant when targeting Kafka vs. Redpanda:
 The Events subsystem is the nervous system of the Exeris Kernel. The `EventDescriptor` / `EventPayload`
 separation is the architectural core: primitive routing metadata enables O(1) dispatch and Valhalla
 scalarization, while RAII `EventPayload` ref-counting guarantees that off-heap memory is reclaimed
-deterministically — regardless of how many subscribers fan out or how deep the retry chain goes. Together
-with the Transactional Outbox, it scales from a single-node application to a
-globally distributed event-driven mesh without changing a single line of domain logic.
+deterministically — regardless of how many subscribers fan out or how deep the retry chain goes.
+
+Going from a single-node application to a distributed event-driven mesh costs no change to domain
+logic — the SPI is implementation-blind, so publishers and subscribers are written once. It does cost
+a **deployment** change: the default driver is single-node, and cross-node delivery means running on
+the Kafka driver. See *Delivery Boundary: Single-Node Default vs Cross-Node (Kafka)* above for what
+each driver actually carries.
 
 ---
 

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -41,7 +41,7 @@ Typed Response Encoding contracts:
 - `HttpResponseEncodingContext` — encoding parameter carrier
 - `HttpEncodedBody` — encoded output carrier
 
-Streaming (server-push) contracts — 🚧 Planned v0.10, ratified by [ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md) (ACCEPTED):
+Streaming (server-push) contracts — ✅ shipped v0.10, ratified by [ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md) (ACCEPTED); per-item delivery status below:
 
 - `HttpStreamExchange` — sibling of `HttpExchange` for SSE server-push; `emit(StreamEvent)` may be called repeatedly until the stream closes. The respond-once `HttpExchange` invariant is left **untouched** — streaming is a separate, opt-in surface selected by route metadata.
 - `StreamEvent` — Valhalla-ready record (`event` / `data` / `id` / `retryMillis`) mapping directly to the SSE wire format; event-shaped and implementation-blind (never a raw byte buffer).
@@ -106,7 +106,7 @@ HTTP abstract TCK suites present:
 - `AbstractHttpExchangeTck`
 - `AbstractHttpProviderLoopbackTck` — verifies real transport round-trip; bound at Community tier (`CommunityHttpProviderLoopbackTckTest`)
 - `AbstractHealthEndpointTck` (since 0.7.0) — pins the readiness/liveness endpoint contract for any `HttpHandler` binding that surfaces a `HealthProbe`. Bound at Community tier (`CommunityHealthEndpointTckTest`).
-- `AbstractHttpStreamExchangeTck` — 🚧 Planned v0.10 ([ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md)) — pins the SSE streaming contract: open / emit-N / graceful close / disconnect-via-`StreamClosedException`, backpressure park-and-resume on window credit, no respond-once regression, and (v0.11) `pathParams()` being non-null and immutable — the map is routing state, so a handler able to write to it could change what a later request resolves to. Community binding required; Enterprise native overlay declared as a cross-repo obligation.
+- `AbstractHttpStreamExchangeTck` (since 0.10.0, [ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md)) — pins the SSE streaming contract: open / emit-N / graceful close / disconnect-via-`StreamClosedException`, backpressure park-and-resume on window credit, no respond-once regression, and (v0.11) `pathParams()` being non-null and immutable — the map is routing state, so a handler able to write to it could change what a later request resolves to. Community binding required; Enterprise native overlay declared as a cross-repo obligation.
 
 These verify SPI-level HTTP contract behavior and ServiceLoader/provider semantics.
 

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -313,12 +313,14 @@ When PAQS sheds a stream or the Kernel initiates graceful shutdown:
 
 | Protocol     | Status      | Rationale                                                                                              |
 |:-------------|:------------|:-------------------------------------------------------------------------------------------------------|
-| **SSE**       | 🚧 Planned v0.10 — ratified by [ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md) (ACCEPTED) | One-directional server push via HTTP/1.1 chunked transfer (a thin `data:…\n\n` framing layer over the existing `Http1ChunkedEncoder`) or HTTP/2. Surfaced as the sibling `HttpStreamExchange` SPI (respond-once `HttpExchange` untouched). **SSE-first** — the minimal server-push primitive; see [http.md](http.md) for the SPI surface. |
+| **SSE**       | ✅ Shipped v0.10 — ratified by [ADR-043](../adr/ADR-043-kernel-http-streaming-spi.md) (ACCEPTED) | One-directional server push, surfaced as the sibling `HttpStreamExchange` SPI (respond-once `HttpExchange` untouched). **SSE-first** — the minimal server-push primitive. The delivered wire framing is a close-delimited HTTP/1.1 response, not chunked transfer as sketched here before it landed; per-event chunked framing and an HTTP/2 `DATA` path are follow-ups. See [http.md](http.md) for the SPI surface and the per-item delivery status. |
 | **WebSocket** | Deferred — separately-justified follow-up (not milestone-pinned) | Full duplex; requires an HTTP Upgrade (H1) / Extended CONNECT (H2 RFC 8441) handshake + frame protocol. Decided separately once a bidirectional/low-latency client-streaming use case is proven; may precede 1.0 but is not pinned to a release milestone (see ADR-043 §What is NOT in scope). |
 | **gRPC streaming** | 🚧 Planned TRL-5 | Modelled as HTTP/2 streams — follows transport carrier maturity. |
 
-Before SSE lands, real-time push uses the **Events subsystem (L3)** with a Kafka/Redpanda
-backend and a polling client. The PAQS scheduler handles priority-based delivery.
+Full-duplex traffic still has no kernel primitive: until WebSocket is decided, a bidirectional
+use case pairs SSE downstream with ordinary requests upstream, or falls back to the **Events
+subsystem (L3)** with a Kafka/Redpanda backend and a polling client. The PAQS scheduler handles
+priority-based delivery.
 
 ---
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -14,8 +14,8 @@
 | **Database**     | PostgreSQL 16                              | Persistence + Flow snapshot store + outbox; validated via Testcontainers `postgres:16`. |
 | **Event broker** | Kafka 3.6 wire (validated on CP 7.6.x)     | Optional — only when the Events subsystem uses the Kafka driver (`exeris-kernel-community-kafka`). |
 | **TLS**          | OpenSSL 3.0 – 4.x (multi-version)          | Community fd-owner TLS engine; 3.x floor retained for FIPS provider compatibility (ADR-008, OpenSSL-4 migration). |
-| **HTTP**         | HTTP/1.1, HTTP/2 (h2 + h2c)                | TLS 1.2 / 1.3 via OpenSSL; request/response only (server-push: see *Deferred* below). |
-| **Topology**     | Single-node Community                      | Multi-node + Enterprise overlay are a separate (Enterprise) concern — see [reference deployment](./operations/reference-deployment.md). |
+| **HTTP**         | HTTP/1.1, HTTP/2 (h2 + h2c)                | TLS 1.2 / 1.3 via OpenSSL; request/response plus SSE server-push since 0.10 (ADR-043). WebSocket is still out — see *Deferred* below. |
+| **Topology**     | Single-node Community                      | The validated baseline is one node — see [reference deployment](./operations/reference-deployment.md). Scaling out is not Enterprise-gated but it is not turnkey either: what the kernel does and does not carry for N instances is inventoried in [`subsystems/events.md`](./subsystems/events.md) → *Multi-node substrate inventory*. |
 
 ## SPI surface status
 
@@ -28,6 +28,8 @@ Mirrors [`stability-matrix.md`](./stability-matrix.md) — that document is the 
 | `diagnostics` | **stable** | 0.9.0 (ADR-033) |
 | `http` — `HttpServerEngine`/`HttpClientEngine`/`HttpExchange`/`HttpHandler`/`HttpProvider`, `HttpClientRequestEnricher` | **stable** | 0.5.0 / 0.8.0 |
 | `http` — `HttpRequestBodyEncoder`/`Decoder`, `HttpResponseBodyDecoder` (ADR-034) | **preview** | 0.8.0 |
+| `http` — `HttpStreamExchange`/`HttpStreamHandler`/`StreamEvent`, SSE server-push (ADR-043) | **preview** | 0.10.0 |
+| `security.identity` — `IdentityProvider`/`TokenValidator`/`VerifiedClaims` (ADR-040) | **preview** | 0.10.0 |
 | `events`, `graph`, `security`, `crypto` | **preview** | 0.5.0 |
 | `util` | _internal_ | — |
 
@@ -41,7 +43,8 @@ transport in Enterprise):
 - **Single-node only** — no built-in clustering/discovery; horizontal scale is the host application's concern.
 - **NIO transport carrier** — `java.nio` selector reactors, not `io_uring`; OpenSSL fd-owner TLS.
 - **Caffeine** is the only in-process cache; no pluggable `CacheProvider` yet.
-- **No server-initiated push yet** — HTTP is request/response; a live view polls. (Server push is the next SPI to land — see *Deferred*.)
+- **Server push is SSE-only** — one-directional `HttpStreamExchange` since 0.10 (ADR-043); no WebSocket, so a full-duplex client still polls or opens a second request.
+- **Events are single-node by default** — the in-heap bus does not cross the node boundary and the Outbox is durable *emission*, not cross-node delivery; that needs the Kafka driver. See [`subsystems/events.md`](./subsystems/events.md) → *Delivery Boundary*.
 - Best-effort performance contract (No Waste Compute on hot paths, but not the Enterprise zero-copy native tier).
 
 ## Enterprise-only (out of open-core scope)
@@ -57,9 +60,7 @@ These are deliberately **not** in the Community kernel and live behind the Enter
 
 | Capability | Target | Driver |
 |:-----------|:-------|:-------|
-| **HTTP server-push / streaming SPI (SSE-first)** | **v0.10 / v0.11** *(brought earlier than the originally-planned v0.12)* | RFC in review → ADR-043 (reserved) |
-| WebSocket (full duplex) | after SSE | follows the SSE primitive; separately justified |
-| `IdentityProvider` SPI + first driver | v0.10 | RFC-2026-06-08 (ACCEPTED) → ADR-040 (reserved) |
+| WebSocket (full duplex) | after SSE | follows the SSE primitive (shipped 0.10); separately justified, not milestone-pinned |
 | `BlobStorageProvider`, `JobScheduler` SPI | v0.11 | new-SPI roadmap |
 | `CacheProvider` SPI | RFC-stage | new-SPI roadmap |
 | OTLP metrics export + distributed tracing | ~v0.12 | ADR-031 (kernel-gated) — no tracing logic in the kernel today |

--- a/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/package-info.java
+++ b/exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/package-info.java
@@ -31,8 +31,9 @@
  * {@link KafkaEventBrokerPort} (Core {@code OutboxBrokerPort} adapter — built but not
  * yet wired into a runtime path; reserved for the outbox-driven delivery follow-up),
  * {@link KafkaEventEngine} ({@code KafkaPublishBus} + virtual-thread {@code ConsumerLoop}
- * + {@code NoOpQueue}), and {@link KafkaEventProvider} (ServiceLoader, priority 100 —
- * outranks the in-memory Community provider). Coverage:
+ * + {@code NoOpQueue}), and {@link KafkaEventProvider} (ServiceLoader, priority 50 —
+ * outranks the in-memory Community provider at 0, stays below the Enterprise tier slot at 100;
+ * see {@link KafkaEventProvider#PRIORITY}, which this text contradicted until 0.11). Coverage:
  * {@link eu.exeris.kernel.tck.contract.events.AbstractKafkaEventEngineTck}
  * (publish/consume roundtrip + idempotent close, Testcontainers Kafka 3.x).
  *


### PR DESCRIPTION
Closes the ROADMAP v0.11 entry *Events: Multi-Node Delivery Boundary — Default Driver Is Single-Node*. Documentation slice, plus one Javadoc correction where the code and the docs disagreed.

## Why

The default Community Events driver is single-node and nothing stated it. The SPI cannot — it is implementation-blind by design — and "Transactional Outbox" reads as cross-node delivery to anyone who has met the pattern elsewhere. An operator planning five instances had no authoritative answer to what the kernel carries for them and what it does not.

## The new section

`events.md` §*Delivery Boundary: Single-Node Default vs Cross-Node (Kafka)*, written against the code rather than against intent:

- The in-heap bus never leaves the JVM — a second instance does not observe the first's publications.
- The Outbox is durable **emission**: a row committed with the entity that caused it, surviving a crash between commit and dispatch. Its default `OutboxBrokerPort` is `CommunityEventBusOutboxBrokerPort`, which republishes onto **that same node's bus**. The durability is real; the fan-out is local.
- Two conditions that never announce themselves: the orchestrator is built only when `outboxEnabled` *and* a `PersistenceEngine` is bound (no persistence → silently inert), and the relay is a poll loop, so it is asynchronous with respect to the producing transaction.
- Cross-node delivery requires `exeris-kernel-community-kafka`; the consume-side caveats (`enable.auto.commit=true` → at-most-once) hold.

It also hosts the **multi-node substrate inventory** as the single authoritative home — per-request state, durable shared state, cross-node fan-out, and coordination (no kernel seam) — so `support-matrix.md` and `reference-deployment.md` link there rather than each keeping a copy free to drift.

## One finding, sharper than the gap it closed

**The two paths are not composable.** `KafkaEventEngine` runs no outbox orchestrator at all — its `EventQueue` slot is a `NoOpQueue` and `KafkaEventBrokerPort` is a built adapter wired into no runtime path — while `CommunityEventEngine` constructs its broker port inline with no seam to substitute. Provider selection then picks one engine.

The consequence is a lost *guarantee*, not a lost event, and it lands on the deployment that needs both most: adopt Kafka for fan-out and the transactional outbox goes with it, silently, with an identical SPI surface either way. ADR-050 §Consequences already records that the port is unwired, so no decision is contradicted — but neither it nor the module Javadoc records what the deferral costs an operator. Given its own ROADMAP entry with a merge gate that would actually prove the property (an event committed in a transaction reaching a *second* instance after the first crashes — which neither engine can demonstrate today).

## Drift hygiene — the class, not the three named instances

The plan named three stale spots. The same class had more:

| Where | Was | Now |
|---|---|---|
| `support-matrix.md` ×4 | SSE + IdentityProvider still under *Deferred*; HTTP row "request/response only"; Topology row read as if multi-node were Enterprise-gated | shipped-in-0.10 rows; WebSocket is what remains deferred |
| `transport.md` | SSE "🚧 Planned v0.10", plus "Before SSE lands…" prose | ✅ Shipped v0.10, with the delivered framing corrected (close-delimited HTTP/1.1, not the chunked transfer sketched pre-landing) |
| `http.md` ×2 | "🚧 Planned v0.10" — contradicting that same file's v0.10 delivery-status paragraph | shipped, per-item status below |
| `reference-deployment.md` | "No server-initiated push yet" | SSE-only, plus the events boundary and the missing coordination seam as known limits |
| `stability-matrix.md` | **no rows at all** for the streaming SPI or `spi.security.identity` — in the document that declares itself the single authority on SPI maturity | both added at `preview`, streaming with its reason stated (H1-only framing, unbound JWT-expiry deadline, `pathParams()` added in 0.11) |

## Code

`exeris-kernel-community-kafka/package-info.java` claimed provider priority 100. `KafkaEventProvider.PRIORITY` is 50 — intra-Community precedence, below the Enterprise tier slot — and `events.md:63` already said so. Comment-only.

## Verification

- `mvn clean install` — BUILD SUCCESS, `MAVEN_EXIT=0`, full reactor, **no skip flags**; `checkstyle:check` and `pmd:check` executions confirmed in the log for the changed module rather than assumed.
- `ExerisArchitectureTest` — 13/13.
- Every relative link in the changed docs resolves (scripted check).
- Doc triage: no ADR authored, so no number reserved; no contract or observable behaviour changed, so no TCK implications.

Each claim in the new section is anchored to a named type or config default; nothing describes target state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)