### PR TITLE
test(transport): drive the Berkeley socket seam over real loopback (v0.11 S14)

### DIFF
--- a/.claude/skills/exeris-pr-preflight/SKILL.md
+++ b/.claude/skills/exeris-pr-preflight/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: exeris-pr-preflight
-description: Pre-PR gate for Exeris Kernel — run BEFORE opening or pushing any PR. Enforces the lint footgun (mvn verify SKIPS PMD), the architecture guard test, fresh-branch-per-task discipline, and the register-ADR-before-claiming rule. Use whenever about to commit/push a branch or open a PR in the kernel repo.
+description: Pre-PR gate for Exeris Kernel — run BEFORE opening or pushing any PR. Enforces lint-gate integrity (skip flags poison a green build's lint proof), the architecture guard test, fresh-branch-per-task discipline, and the register-ADR-before-claiming rule. Use whenever about to commit/push a branch or open a PR in the kernel repo.
 ---
 
 # Exeris PR Preflight
 
 ## Purpose
-Catch the recurring, expensive footguns that a green `mvn verify` does **not** catch, before a PR is opened. This is a workflow skill (it runs checks), not a review-lens.
+Catch the recurring, expensive footguns that a green build alone does **not** prove are absent (lint skipped via flags, ignored arch rules, tagged-test gaps), before a PR is opened. This is a workflow skill (it runs checks), not a review-lens.
 
 ## When to Use
 - About to push a branch or open a PR in `exeris-kernel`.
@@ -19,9 +19,9 @@ Catch the recurring, expensive footguns that a green `mvn verify` does **not** c
    - Confirm work is on a fresh feature branch cut off the current active development base (the `development/<active-ver>` branch on origin; check the repo `CLAUDE.md` / README for the current name as it advances per release), or the current `research/<slug>` branch — NOT an already-merged branch or directly on `main`.
    - If multiple Claude sessions may share this tree, prefer a git worktree off a clean base — a parallel branch-switch/commit can revert uncommitted edits.
 
-2. **Lint gate is NOT in `verify` — run it explicitly**
-   - `mvn verify` does **not** run `pmd:check` (it is `default-cli`). A green verify is NOT lint-clean.
-   - Run explicitly, scoped to the changed modules (spi/core/community/etc.), and **exclude `exeris-kernel-build-config`** (it ships the rulesets, is `pmd.skip`, and is not checkstyle-gated; APT processors there inherit that exemption):
+2. **Lint gate — confirm the proof was not poisoned by skip flags**
+   - The parent POM binds `checkstyle:check` to `validate` and `pmd:check` to `verify` (both fail on violation): a full `mvn clean install` with no skip flags IS lint-clean.
+   - The footgun: `-Dpmd.skip=true`/`-Dcheckstyle.skip=true` get used for fast iteration and SIGSEGV workarounds, and PMD binds at `verify`, so a `mvn test` loop never reaches it. If any build in the session used skips — or you are unsure — re-check standalone, scoped to the changed modules (spi/core/community/etc.), and **exclude `exeris-kernel-build-config`** (it ships the rulesets, is `pmd.skip`, and is not checkstyle-gated; APT processors there inherit that exemption):
      ```
      mvn -pl <changed-modules> pmd:check checkstyle:check
      ```
@@ -32,7 +32,7 @@ Catch the recurring, expensive footguns that a green `mvn verify` does **not** c
      ```
      mvn -q -pl exeris-kernel-tck -am -Dtest=ExerisArchitectureTest \
        -Dsurefire.failIfNoSpecifiedTests=false \
-       -Dpmd.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true test
+       -Dpmd.skip=true -Dcheckstyle.skip=true test
      ```
 
 4. **Contract change → TCK present**
@@ -49,7 +49,7 @@ Catch the recurring, expensive footguns that a green `mvn verify` does **not** c
 A go/no-go summary: each check → PASS / FAIL / N/A, with the exact failing command output and the minimal fix. Do not report "ready to PR" unless lint, arch guard, and (if applicable) TCK are all green or explicitly N/A with reason.
 
 ## Non-Negotiable Rules
-- Never equate green `mvn verify` with lint-clean.
+- Never equate a build that used `-Dpmd.skip`/`-Dcheckstyle.skip` with lint-clean.
 - Never include `exeris-kernel-build-config` in the `-pl` module list when running lint.
 - Never open a PR that changes a contract without TCK implications.
 - Never claim an ADR number before reserving it in the global index.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,6 +146,10 @@ See also: [Security Subsystem](./subsystems/security.md) — Responsibilities.
 
 **Merge Gate:** `TransportCarrierPinningTck` must pass with no pinning regressions; add community-scale sustained ingress load validation in CI/perf pipeline.
 
+**Status (v0.11): DISCHARGED** — by PERF-063, not by a later slice of this entry, which is why it sat open: the work landed under a different name and nobody closed the row. `NativeTcpReactor.pendingRequests` is an `MpscUnboundedArrayQueue` (`NativeTcpReactor.java:66`), so the cross-VT handoff this entry describes is lock-free today. Both merge-gate halves exist: `CommunityTransportCarrierPinningTckTest` plus its 2- and 4-reactor variants, and `NativeTcpTransportStressTest` behind the dedicated `transport-stress-gate` CI job.
+
+Two deviations from the text above, recorded so the row is not re-opened by someone diffing wording against code: the queue is **JCTools**, not Agrona (`org.jctools:jctools-core` is already a Community dependency, so no new one was taken), and it lives in `NativeTcpReactor` rather than `NativeTcpCarrier` — the reactor is where the cross-VT handoff actually is. No separate per-connection ingress queue was added and none is indicated; the Sprint-8e Hot-Path Collections Review discharged that question for the carrier as a whole.
+
 See also: [Transport Subsystem](./subsystems/transport.md) — Testing Strategy / Load Tests.
 
 ---
@@ -159,6 +163,14 @@ See also: [Transport Subsystem](./subsystems/transport.md) — Testing Strategy 
 **Resolution:** Migrate the Community carrier incrementally from primary NIO socket lifecycle management to the Core-provided FFM syscall path backed by `CoreSyscallLoader`. Preserve SPI blindness, PAQS semantics, and current TLS FD-owner binding while moving socket bootstrap and readiness operations onto the shared POSIX / Winsock layer. Java NIO remains the explicit portability / compatibility fallback when FFM socket bootstrap is unavailable, unsupported, or temporarily disabled.
 
 **Merge Gate:** Add Community integration and TCK coverage proving boot, bind, connect, ingress, and load-shed behavior through the FFM-backed socket path. Linux validation is mandatory; Windows-capable CI coverage is required for Winsock compatibility before milestone close.
+
+**Status (v0.11): PARTIAL — validation seam delivered, carrier migration deferred to v0.12 candidate.**
+
+What landed: `SyscallLoopbackRoundTripIT` drives the resolved handles through a real loopback connection — socket → bind → listen → connect → accept → send → recv with a byte-exact comparison, plus a refusal case with a positive control. Until it, the seam had only non-nullness assertions, so the build could not distinguish working socket handles from merely-present ones. That is the precondition for trusting the path enough to move a carrier onto it, and it is now in the default build (Failsafe, `**/*IT.java`).
+
+What did not land, and why it is not a slip: migrating `NativeTcpCarrier` off NIO is a live-traffic change to the one component every request crosses, and it should not be attempted while the Winsock half of the seam is unexecuted anywhere. **Named precondition, verified rather than assumed:** every job in `.github/workflows/maven.yml` is `ubuntu-latest`. There is no Windows runner, so `CoreSyscallLoader.loadWindows` and the Windows branch of the new IT have never run in CI or locally here. The migration's own merge gate demands Winsock compatibility coverage before milestone close, which no v0.11 slice could have satisfied.
+
+**v0.12 entry condition:** a Windows CI runner exists and the new IT is green on it. Absent that, the honest v0.12 scope is Linux-only migration behind a fallback, with NIO retained as the documented portability path — which the Resolution above already anticipates.
 
 See also: [Transport Subsystem](./subsystems/transport.md) — Responsibilities / Zero-Copy Ingress.
 

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -128,7 +128,7 @@ The Community carrier transfers bytes from the network socket directly into off-
    a shared long-lived STS is architecturally incompatible with the multi-carrier ingress model. These
    unstructured VTs act as roots of the Request Tree. All subsequent concurrent operations within
    the stream handler MUST use `StructuredTaskScope`.
-4. Expose cross-platform POSIX / Winsock socket symbol loading via `CoreSyscallLoader` (Panama FFM). Migration of the active Community carrier onto this shared socket path is planned; the current in-repo carrier remains NIO-backed, and NIO is retained as the explicit fallback path for portability and degraded-operation scenarios.
+4. Expose cross-platform POSIX / Winsock socket symbol loading via `CoreSyscallLoader` (Panama FFM). The POSIX half of that seam is exercised end-to-end since 0.11 (`SyscallLoopbackRoundTripIT`, below); the Winsock half has never run, because CI carries no Windows runner. Migration of the active Community carrier onto this shared socket path is planned but gated on that coverage; the current in-repo carrier remains NIO-backed, and NIO is retained as the explicit fallback path for portability and degraded-operation scenarios.
 
 ---
 
@@ -371,13 +371,16 @@ for client IP preservation behind load balancers (HAProxy, NGINX, AWS NLB, GCP L
 - **Zero-Allocation Hot-Path:** JFR baseline shows zero heap allocations during `processIngress()`.
 - **PAQS Integration:** `WatermarkManager` pressure increase correctly raises PAQS threshold and
   triggers `EX-NET-4006` for low-priority streams. 🚧 Planned — not yet implemented. `AbstractPaqsIntegrationTck` covering WatermarkManager→PAQS→EX-NET-4006 chain does not yet exist.
+- **Berkeley socket seam round-trip (since 0.11):** `SyscallLoopbackRoundTripIT` (Core) drives the handles resolved by `CoreSyscallLoader` through a real loopback connection — bind, listen, connect, accept, send, recv, byte-exact comparison — plus a refusal case that pairs a successful connect with a refused one so neither can pass alone. Runs in the default build via Failsafe; Linux and Windows only, since BSD `sockaddr_in` carries a leading `sin_len` byte that the shared 16-byte layout does not model. Integer-width entries in the C-type→`ValueLayout` table stay reviewed-not-tested: the x86-64 SysV ABI zero-extends, so a `size_t` mis-declared as `JAVA_INT` passes this gate.
 
 **Full TCK abstract class set (all have full Community bindings):** `AbstractTransportEngineTck`, `AbstractTransportProviderTck`, `AbstractTransportConnectionTck`, `AbstractTransportStreamTck`, `TransportZeroAllocTck`, `TransportCarrierPinningTck`.
 
 ### Load Tests
 
-- **Carrier Stress:** `MpscArrayQueue` (Agrona) throughput under millions of network events per second with
-  zero `CarrierPinnedEvent` emissions.
+- **Carrier Stress:** reactor-handoff queue throughput under sustained network events with zero
+  `CarrierPinnedEvent` emissions — `NativeTcpTransportStressTest`, behind the `transport-stress-gate`
+  CI job. The queue is JCTools `MpscUnboundedArrayQueue` (PERF-063); the Agrona attribution this line
+  carried was never what the code used.
 
 ---
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallLoopbackRoundTripIT.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallLoopbackRoundTripIT.java
@@ -158,6 +158,7 @@ class SyscallLoopbackRoundTripIT {
                     closeQuietly(handles, acceptedFd);
                     closeQuietly(handles, clientFd);
                     closeQuietly(handles, serverFd);
+                    releaseWinsock(handles);
                 }
             }
         }
@@ -219,6 +220,7 @@ class SyscallLoopbackRoundTripIT {
                     closeQuietly(handles, acceptedClientFd);
                     closeQuietly(handles, parkedFd);
                     closeQuietly(handles, listenerFd);
+                    releaseWinsock(handles);
                 }
             }
         }
@@ -305,6 +307,25 @@ class SyscallLoopbackRoundTripIT {
     private static void closeQuietly(SyscallHandles handles, long descriptor) throws Throwable {
         if (descriptor >= 0) {
             call(handles.close(), fd(handles.close(), descriptor));
+        }
+    }
+
+    /**
+     * Pairs the {@code WSAStartup} that {@link CoreSyscallLoader#load} performs on Windows.
+     *
+     * <p>{@link SyscallHandles#wsaCleanup()} documents that it must run before the owning arena closes.
+     * These tests load into a fresh {@link Arena#ofConfined()} per method, so without this each method
+     * would close its arena on an unbalanced Winsock refcount — the sibling
+     * {@code CoreSyscallLoaderTest} does not have the problem because it loads once into
+     * {@link Arena#global()}, which never closes.
+     *
+     * <p>No-op on POSIX, where the handle is null by the loader's own convention. Unverified in this
+     * repository's CI, which has no Windows runner — it satisfies the documented contract rather than a
+     * green run.
+     */
+    private static void releaseWinsock(SyscallHandles handles) throws Throwable {
+        if (handles.hasWsaCleanup()) {
+            call(handles.wsaCleanup());
         }
     }
 }

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallLoopbackRoundTripIT.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallLoopbackRoundTripIT.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.transport.syscall;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration Test: the resolved Berkeley socket handles actually carry bytes over loopback.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>{@code CoreSyscallLoaderTest} and {@code SyscallHandlesTest} prove that every symbol
+ * <em>resolves</em> and that no handle is null on its platform. Nothing invoked one. Until this test
+ * the build could not tell a working socket seam from a set of handles that merely exists — a real
+ * connection, a real payload, and a byte-exact comparison on the far side is the difference.
+ *
+ * <h2>What mutation showed it catches — and does not</h2>
+ * <p>Measured, not assumed. Binding {@code recv} to the {@code send} symbol is caught, and caught
+ * only by the content assertion: both counts still read 15, and the buffer came back all zeros. A
+ * descriptor error that reaches the wrong function, or any regression that stops bytes moving, fails
+ * here.
+ *
+ * <p>What it does <em>not</em> catch is worth stating so nobody trusts it further than it goes:
+ * declaring {@code send}'s {@code size_t} as {@code JAVA_INT} instead of {@code JAVA_LONG} passes.
+ * The x86-64 SysV ABI zero-extends the argument register, so a small length is indistinguishable
+ * either way, and no payload this test could reasonably carry would separate them. Integer-width
+ * entries in the C-type→{@code ValueLayout} table documented on {@link CoreSyscallLoader} therefore
+ * remain reviewed-not-tested on this platform.
+ *
+ * <h2>Not tagged</h2>
+ * <p>Deliberately carries no {@code @Tag("integration")}. The class name ends in {@code IT}, and
+ * {@code exeris-kernel-core/pom.xml} binds Failsafe over {@code **&#47;*IT.java} at
+ * {@code integration-test}/{@code verify}, so the standard build runs it. Adding the tag would drop it
+ * from Surefire-only opt-out paths ({@code -DexcludedGroups=integration}) while Failsafe ran it
+ * anyway — the exact mismatch removed from {@code OffHeapTlsEngineLoopbackIT} in v0.8 Sprint 6.
+ *
+ * <h2>Platform</h2>
+ * <p>Linux and Windows. macOS is excluded on a concrete layout difference, not caution: BSD
+ * {@code sockaddr_in} opens with a one-byte {@code sin_len} before {@code sin_family}, so the
+ * 16-byte address this test builds would be read with the family in the wrong place. Writing a
+ * second, unexecuted layout would be guessing; the exclusion is honest and reversible.
+ *
+ * @since 0.11.0
+ */
+@EnabledOnOs({OS.LINUX, OS.WINDOWS})
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@DisplayName("IT: Berkeley socket handles — loopback round-trip over the resolved FFM seam")
+class SyscallLoopbackRoundTripIT {
+
+    private static final boolean IS_WINDOWS =
+            System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+
+    private static final int AF_INET = 2;
+    private static final int SOCK_STREAM = 1;
+    private static final int BACKLOG = 1;
+
+    /** {@code sizeof(struct sockaddr_in)} on Linux and Win32 alike. */
+    private static final int SOCKADDR_IN_BYTES = 16;
+
+    private static final byte[] PAYLOAD = "EXERIS-LOOPBACK".getBytes(StandardCharsets.US_ASCII);
+
+    @Nested
+    @DisplayName("A byte written through send() arrives through recv()")
+    class RoundTrip {
+
+        @Test
+        @DisplayName("connect → accept → send → recv returns the same bytes, and the same count")
+        void loopbackRoundTrip() throws Throwable {
+            try (Arena arena = Arena.ofConfined()) {
+                SyscallHandles handles = CoreSyscallLoader.load(arena);
+                assertThat(handles.supportsPlainSocketIo())
+                        .as("the seam under test must be fully resolved before anything is asserted "
+                                + "about it")
+                        .isTrue();
+
+                long serverFd = -1;
+                long clientFd = -1;
+                long acceptedFd = -1;
+                try {
+                    serverFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(serverFd).as("socket() for the listener").isNotNegative();
+
+                    MemorySegment bindAddress = sockaddrIn(arena, 0);
+                    assertThat(call(handles.bind(), fd(handles.bind(), serverFd), bindAddress,
+                            SOCKADDR_IN_BYTES))
+                            .as("bind() to 127.0.0.1:0").isZero();
+                    assertThat(call(handles.listen(), fd(handles.listen(), serverFd), BACKLOG))
+                            .as("listen()").isZero();
+
+                    int port = boundPort(arena, serverFd);
+                    assertThat(port)
+                            .as("the kernel must have assigned an ephemeral port; a zero here means "
+                                    + "getsockname wrote nothing and every later assertion is vacuous")
+                            .isPositive();
+
+                    clientFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(clientFd).as("socket() for the client").isNotNegative();
+
+                    MemorySegment target = sockaddrIn(arena, port);
+                    assertThat(call(handles.connect(), fd(handles.connect(), clientFd), target,
+                            SOCKADDR_IN_BYTES))
+                            .as("connect() completes off the listen backlog without a concurrent "
+                                    + "accept(), which is what keeps this test single-threaded")
+                            .isZero();
+
+                    acceptedFd = call(handles.accept(), fd(handles.accept(), serverFd),
+                            MemorySegment.NULL, MemorySegment.NULL);
+                    assertThat(acceptedFd).as("accept()").isNotNegative();
+
+                    MemorySegment outbound = arena.allocate(PAYLOAD.length);
+                    MemorySegment.copy(MemorySegment.ofArray(PAYLOAD), 0L, outbound, 0L,
+                            PAYLOAD.length);
+
+                    long sent = call(handles.send(), fd(handles.send(), clientFd), outbound,
+                            length(handles.send(), PAYLOAD.length), 0);
+                    assertThat(sent)
+                            .as("send() must report the exact byte count — a size_t/ssize_t mapped to "
+                                    + "the wrong width shows up here and nowhere earlier")
+                            .isEqualTo(PAYLOAD.length);
+
+                    MemorySegment inbound = arena.allocate(PAYLOAD.length);
+                    long received = call(handles.recv(), fd(handles.recv(), acceptedFd), inbound,
+                            length(handles.recv(), PAYLOAD.length), 0);
+                    assertThat(received).as("recv() byte count").isEqualTo(PAYLOAD.length);
+
+                    assertThat(inbound.toArray(JAVA_BYTE))
+                            .as("the bytes themselves, not just the counts — a correct length over "
+                                    + "wrong content is still a broken seam")
+                            .containsExactly(PAYLOAD);
+                } finally {
+                    closeQuietly(handles, acceptedFd);
+                    closeQuietly(handles, clientFd);
+                    closeQuietly(handles, serverFd);
+                }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("A refused connection is reported, not swallowed")
+    class Refusal {
+
+        /**
+         * Asserts both outcomes through one handle, and the pairing is the point.
+         *
+         * <p>An earlier version asserted only the {@code -1}. Mutation testing found it vacuous: bind
+         * {@code connect} to any symbol that fails on these arguments and the case still passed, because
+         * "correctly refused" and "broken beyond use" both return {@code -1}. Only the successful
+         * connection immediately before it makes the refusal mean anything.
+         */
+        @Test
+        @DisplayName("the same handle returns 0 to a listener and -1 to a bound-but-unlistening port")
+        void connectDistinguishesRefusalFromSuccess() throws Throwable {
+            try (Arena arena = Arena.ofConfined()) {
+                SyscallHandles handles = CoreSyscallLoader.load(arena);
+
+                long listenerFd = -1;
+                long parkedFd = -1;
+                long acceptedClientFd = -1;
+                long refusedClientFd = -1;
+                try {
+                    listenerFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(call(handles.bind(), fd(handles.bind(), listenerFd),
+                            sockaddrIn(arena, 0), SOCKADDR_IN_BYTES)).isZero();
+                    assertThat(call(handles.listen(), fd(handles.listen(), listenerFd), BACKLOG))
+                            .isZero();
+                    int listeningPort = boundPort(arena, listenerFd);
+
+                    // Hold a port without listening on it. Picking a port and closing it would race
+                    // another process into the gap; owning it makes the refusal deterministic.
+                    parkedFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(call(handles.bind(), fd(handles.bind(), parkedFd),
+                            sockaddrIn(arena, 0), SOCKADDR_IN_BYTES)).isZero();
+                    int parkedPort = boundPort(arena, parkedFd);
+                    assertThat(parkedPort).isNotEqualTo(listeningPort);
+
+                    acceptedClientFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(call(handles.connect(), fd(handles.connect(), acceptedClientFd),
+                            sockaddrIn(arena, listeningPort), SOCKADDR_IN_BYTES))
+                            .as("positive control — without it, the refusal below cannot tell a working "
+                                    + "connect() from one that fails on everything")
+                            .isZero();
+
+                    refusedClientFd = call(handles.socket(), AF_INET, SOCK_STREAM, 0);
+                    assertThat(call(handles.connect(), fd(handles.connect(), refusedClientFd),
+                            sockaddrIn(arena, parkedPort), SOCKADDR_IN_BYTES))
+                            .as("nothing is listening on a bound-but-unlistened port, so the kernel "
+                                    + "refuses and the handle must surface that as -1")
+                            .isEqualTo(-1L);
+                } finally {
+                    closeQuietly(handles, refusedClientFd);
+                    closeQuietly(handles, acceptedClientFd);
+                    closeQuietly(handles, parkedFd);
+                    closeQuietly(handles, listenerFd);
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Scaffolding
+    // =========================================================================
+
+    /**
+     * Invokes a resolved handle and normalises the result to {@code long}.
+     *
+     * <p>{@code invokeWithArguments} rather than {@code invokeExact} on purpose: POSIX types a
+     * descriptor around {@code int} file descriptors while Winsock uses a 64-bit {@code SOCKET}, so an
+     * exact call site would have to exist twice. Test scaffolding, never a hot path — the cost is a
+     * boxed argument per syscall in a test that makes a handful.
+     */
+    private static long call(MethodHandle handle, Object... args) throws Throwable {
+        return ((Number) handle.invokeWithArguments(args)).longValue();
+    }
+
+    /** Boxes a descriptor as the width this platform's resolved signature declares for it. */
+    private static Object fd(MethodHandle handle, long descriptor) {
+        return handle.type().parameterType(0) == long.class
+                ? (Object) descriptor
+                : (Object) (int) descriptor;
+    }
+
+    /** Same idea for the send/recv length: {@code size_t} on POSIX, {@code int} on Winsock. */
+    private static Object length(MethodHandle handle, int bytes) {
+        return handle.type().parameterType(2) == long.class
+                ? (Object) (long) bytes
+                : (Object) bytes;
+    }
+
+    /**
+     * Reads back the port the kernel assigned to a socket bound to port 0.
+     *
+     * <p>{@code getsockname} is resolved here rather than added to {@link SyscallHandles}: the runtime
+     * never needs it, and widening a production seam to serve a test is how seams grow.
+     */
+    private static int boundPort(Arena arena, long socketFd) throws Throwable {
+        Linker linker = Linker.nativeLinker();
+        SymbolLookup lookup = IS_WINDOWS
+                ? SymbolLookup.libraryLookup("Ws2_32.dll", arena)
+                : linker.defaultLookup();
+        MethodHandle getsockname = linker.downcallHandle(
+                lookup.find("getsockname").orElseThrow(
+                        () -> new IllegalStateException("getsockname not found")),
+                FunctionDescriptor.of(JAVA_INT, IS_WINDOWS ? JAVA_LONG : JAVA_INT, ADDRESS, ADDRESS));
+
+        MemorySegment address = arena.allocate(SOCKADDR_IN_BYTES, 8);
+        MemorySegment addressLength = arena.allocate(JAVA_INT);
+        addressLength.set(JAVA_INT, 0L, SOCKADDR_IN_BYTES);
+
+        long result = call(getsockname, fd(getsockname, socketFd), address, addressLength);
+        assertThat(result).as("getsockname()").isZero();
+
+        // sin_port is network byte order regardless of host endianness.
+        int high = address.get(JAVA_BYTE, 2L) & 0xFF;
+        int low = address.get(JAVA_BYTE, 3L) & 0xFF;
+        return (high << 8) | low;
+    }
+
+    /**
+     * Builds {@code sockaddr_in} for {@code 127.0.0.1:port}.
+     *
+     * <p>Port and address are written byte-wise because both are network byte order while
+     * {@code sin_family} is host order — mixing the two through a single multi-byte layout is the
+     * classic way to bind to a port nobody asked for.
+     */
+    private static MemorySegment sockaddrIn(Arena arena, int port) {
+        MemorySegment address = arena.allocate(SOCKADDR_IN_BYTES, 8);
+        address.set(JAVA_SHORT, 0L, (short) AF_INET);
+        address.set(JAVA_BYTE, 2L, (byte) (port >>> 8));
+        address.set(JAVA_BYTE, 3L, (byte) port);
+        address.set(JAVA_BYTE, 4L, (byte) 127);
+        address.set(JAVA_BYTE, 5L, (byte) 0);
+        address.set(JAVA_BYTE, 6L, (byte) 0);
+        address.set(JAVA_BYTE, 7L, (byte) 1);
+        return address;
+    }
+
+    private static void closeQuietly(SyscallHandles handles, long descriptor) throws Throwable {
+        if (descriptor >= 0) {
+            call(handles.close(), fd(handles.close(), descriptor));
+        }
+    }
+}


### PR DESCRIPTION
Stream F housekeeping. Writes the round-trip gate the plan listed as a loss risk — the file was untracked and is gone from the tree and from git history, so this is from scratch, not a recovery — and closes the two v0.6 transport entries that had no disposition.

## The gap

`CoreSyscallLoaderTest` and `SyscallHandlesTest` prove every symbol resolves and no handle is null on its platform. Nothing invoked one. The build could not distinguish a working socket seam from handles that merely exist, and the C-type→`ValueLayout` table `CoreSyscallLoader` documents had no executable check at all.

`SyscallLoopbackRoundTripIT`: socket → bind → listen → connect → accept → send → recv over 127.0.0.1, byte-exact comparison on the far side, plus a refusal case.

## Mutation results — including the one that survived

| Mutation | Result |
|---|---|
| `recv` bound to the `send` symbol | **Caught** — and only by the content assertion. Both counts still read 15; the buffer came back all zeros. The byte comparison is load-bearing, not decorative. |
| `send`'s `size_t` as `JAVA_INT` instead of `JAVA_LONG` | **Survived.** x86-64 SysV zero-extends the argument register, so a small length is indistinguishable either way. Integer-width entries in that table stay *reviewed-not-tested* on this platform — the Javadoc states this rather than implying coverage the test does not have. |
| `connect` bound to the `bind` symbol | **Exposed the refusal case as vacuous.** "Correctly refused" and "broken beyond use" both return `-1`, so it passed while the round-trip failed. |

That third result is why the refusal case looks the way it does now: it asserts **both** outcomes through one handle — a successful connect to a live listener immediately before the refused one. Re-running the same mutation now fails both cases, the refusal on its positive control. Without the positive control the assertion could not tell a working `connect()` from one that fails on everything.

All three reverted; the loader is byte-identical to HEAD.

## Two deliberate departures from the plan text

**No `@Tag("integration")`.** Core's pom binds Failsafe over `**/*IT.java` at `integration-test`/`verify`, so the name alone puts the test in the default build — confirmed by watching it execute inside `mvn clean install`, not inferred from the pom. Tagging it would drop it from Surefire opt-out paths (`-DexcludedGroups=integration`) while Failsafe ran it anyway: the exact mismatch removed from `OffHeapTlsEngineLoopbackIT` in v0.8 Sprint 6.

**macOS excluded**, on a concrete layout difference rather than caution: BSD `sockaddr_in` opens with a one-byte `sin_len` before `sin_family`, so the shared 16-byte address would be read with the family in the wrong place. Writing a second, unexecuted layout would be guessing.

## ROADMAP dispositions

**MpscArrayQueue ingress handoff → DISCHARGED.** Done by PERF-063 under a different name, which is why nobody closed the row: JCTools `MpscUnboundedArrayQueue` in `NativeTcpReactor`, not Agrona in `NativeTcpCarrier`. Both merge-gate halves exist (pinning TCK + its 2/4-reactor variants, and `NativeTcpTransportStressTest` behind `transport-stress-gate`). Recorded with the deviations so the row is not re-opened by someone diffing wording against code. `transport.md`'s stale Agrona attribution corrected to match.

**FFM socket migration → PARTIAL.** The validation seam is what landed. Migrating `NativeTcpCarrier` off NIO is a live-traffic change to the component every request crosses, and it should not begin while the Winsock half of the seam is unexecuted. **Precondition named and verified, not assumed:** every job in `.github/workflows/maven.yml` is `ubuntu-latest`, so no Windows runner exists and `loadWindows` has never run — here or in CI. That entry's own merge gate demands Winsock coverage before milestone close, which no v0.11 slice could satisfy.

## One repo-hygiene fix

This branch's own `exeris-pr-preflight` skill still claimed *"`mvn verify` does not run `pmd:check` (it is `default-cli`). A green verify is NOT lint-clean."* The parent POM binds `pmd:check` to `verify` (`verify-complexity`) and `checkstyle:check` to `validate` (`validate-architecture`). PR #238 corrected this on `main` and it was never forward-ported, so the development line has been telling every session a false thing about its own lint gate — including the gate run for this PR. Corrected text ported.

**Related finding, deliberately not folded in:** #238 also expanded `CLAUDE.md` from 92 to 185 lines (build/verify definition-of-done, operating standards, scoped bans). That is on `main` only too. Porting a guardrail document of that size inside a test slice would be scope inflation, so it is flagged here rather than done silently.

## Verification

- `mvn clean install` — BUILD SUCCESS, `MAVEN_EXIT=0`, full reactor, no skip flags; the new IT ran inside it (2/2).
- `ExerisArchitectureTest` — 13/13.
- Mutations reverted, loader confirmed clean against HEAD.
- Relative links in changed docs resolve.

Test-only plus docs: no SPI surface, no observable behaviour change, no ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)