### PR TITLE
fix(transport): drain in-flight streams before teardown, not after

### DIFF
--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -296,6 +296,28 @@ When PAQS sheds a stream or the Kernel initiates graceful shutdown:
 > **Why `FIN` not `RST` for load shedding?** `RST` causes immediate connection teardown on the client
 > side, which may interrupt in-flight retries and force the client to reconnect. `FIN` allows the client
 > to receive the `HTTP 503` response body, which is machine-readable and enables intelligent backoff.
+
+### Graceful-shutdown phase order (since 0.11)
+
+`NativeTcpCarrier.stop()` runs three phases, and the order is load-bearing rather than incidental:
+
+1. **Close ingress** — the listening channel closes and the acceptor joins. No new connections; the
+   reactors keep serving the ones already admitted.
+2. **Drain** — `PaqsScheduler.close()` waits for the admission controller's active-stream count to
+   reach zero under its 60-second hard deadline. The reactors are deliberately still looping here, so
+   a handler that completes during the drain can still have its response flushed.
+3. **Teardown** — reactors are woken and joined, then the selector and all remaining channels close.
+
+Until 0.11 the drain ran *after* teardown, which made it inert: handlers were waited on while their
+sockets were already closed, so an in-flight request completed and its response went nowhere. The peer
+observed a connection closed with no reply, and an idempotent client retried into a listener that was
+already gone. `AbstractTransportEngineTck$GracefulDrain` now pins the contract — it holds a stream
+mid-exchange across `stop()` and asserts the response still arrives.
+
+**Telemetry.** `CommunityTransportDrainEvent` (JFR `eu.exeris.kernel.transport.CommunityTransportDrain`)
+records each drain's stream count at start, count remaining, and duration. A non-zero
+`streamsRemaining` means the deadline fired before the drain finished — the signal that in-flight work
+was severed, and the number to tune `terminationGracePeriodSeconds` against.
 > `RST` is reserved for hard timeout scenarios only.
 >
 > **`reset(long)` vs `close()`:** `close()` is a graceful end-of-stream (`FIN`, drains queued writes);

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -296,6 +296,14 @@ When PAQS sheds a stream or the Kernel initiates graceful shutdown:
 > **Why `FIN` not `RST` for load shedding?** `RST` causes immediate connection teardown on the client
 > side, which may interrupt in-flight retries and force the client to reconnect. `FIN` allows the client
 > to receive the `HTTP 503` response body, which is machine-readable and enables intelligent backoff.
+> `RST` is reserved for hard timeout scenarios only.
+>
+> **`reset(long)` vs `close()`:** `close()` is a graceful end-of-stream (`FIN`, drains queued writes);
+> `reset(long)` is the deliberate abortive primitive (`RST`, abandons queued writes) — the SPI's
+> transport-agnostic stream abort (an Enterprise QUIC binding maps it to `RESET_STREAM`). A failed
+> outbound write self-aborts via the same path. **Telemetry follow-up:** a secret-safe, single-phase
+> `StreamLifecycleEvent` for the reset transition is deferred to the security/transport
+> validation-stage JFR pass (Phase 4 N1) — the reset call sites are the intended emission points.
 
 ### Graceful-shutdown phase order (since 0.11)
 
@@ -318,14 +326,6 @@ mid-exchange across `stop()` and asserts the response still arrives.
 records each drain's stream count at start, count remaining, and duration. A non-zero
 `streamsRemaining` means the deadline fired before the drain finished — the signal that in-flight work
 was severed, and the number to tune `terminationGracePeriodSeconds` against.
-> `RST` is reserved for hard timeout scenarios only.
->
-> **`reset(long)` vs `close()`:** `close()` is a graceful end-of-stream (`FIN`, drains queued writes);
-> `reset(long)` is the deliberate abortive primitive (`RST`, abandons queued writes) — the SPI's
-> transport-agnostic stream abort (an Enterprise QUIC binding maps it to `RESET_STREAM`). A failed
-> outbound write self-aborts via the same path. **Telemetry follow-up:** a secret-safe, single-phase
-> `StreamLifecycleEvent` for the reset transition is deferred to the security/transport
-> validation-stage JFR pass (Phase 4 N1) — the reset call sites are the intended emission points.
 
 ---
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.transport;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * JFR event recording the outcome of the graceful-stop drain.
+ *
+ * <h2>JFR-First Contract</h2>
+ * <p>Emitted once per {@code stop()}, on the stopping thread, after the drain has either completed or
+ * hit its deadline. It exists because the two outcomes are operationally different and otherwise
+ * indistinguishable: a drain that completes means every admitted request got its response, while a
+ * drain that times out means the kernel severed live exchanges. Today only a log line marks the
+ * second case, and the first leaves no trace at all — so an operator tuning
+ * {@code terminationGracePeriodSeconds} has nothing to tune against.
+ *
+ * <p>{@code streamsRemaining > 0} is the signal that matters: the deadline fired first. Pair it with
+ * {@code durationNanos} to tell "handlers are genuinely slow" from "one handler is stuck".
+ *
+ * <p>Counts only — no peer identity, no request content. Single-phase {@code commit()} on the platform
+ * thread driving shutdown; never on a virtual thread, so the carrier-pinning hazard that afflicts
+ * begin/commit straddles does not arise.
+ *
+ * @since 0.11.0
+ */
+@Name("eu.exeris.kernel.transport.CommunityTransportDrain")
+@Label("Community Transport Drain")
+@Description("Outcome of the graceful-stop in-flight stream drain: completed, or cut short by deadline")
+@Category({"Exeris Kernel", "Transport"})
+@StackTrace(false)
+final class CommunityTransportDrainEvent extends Event {
+
+    @Label("Engine Name")
+    /* default */ String engineName;
+
+    @Label("Streams In Flight At Drain Start")
+    /* default */ int streamsAtStart;
+
+    @Label("Streams Remaining After Drain")
+    /* default */ int streamsRemaining;
+
+    @Label("Drain Duration (ns)")
+    /* default */ long durationNanos;
+
+    /* default */ static void emit(String engineName,
+                                   int streamsAtStart,
+                                   int streamsRemaining,
+                                   long durationNanos) {
+        if (!FlightRecorder.isInitialized()) {
+            return;
+        }
+        CommunityTransportDrainEvent event = new CommunityTransportDrainEvent();
+        if (event.isEnabled()) {
+            event.engineName = engineName;
+            event.streamsAtStart = streamsAtStart;
+            event.streamsRemaining = streamsRemaining;
+            event.durationNanos = durationNanos;
+            event.commit();
+        }
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -87,6 +87,7 @@ public final class NativeTcpCarrier implements TransportEngine {
     private final NativeTcpSocketBackend backend;
 
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean draining = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final AtomicLong streamSeq = new AtomicLong(1);
@@ -180,12 +181,30 @@ public final class NativeTcpCarrier implements TransportEngine {
         }
     }
 
+    /**
+     * Graceful stop per the {@code TransportEngine.stop()} contract: stop accepting, drain in-flight
+     * streams for a bounded period, then force-close whatever is left.
+     *
+     * <p>The drain machinery is {@link PaqsScheduler#close()} — it waits for the admission
+     * controller's active-stream count to reach zero under a 60-second hard deadline. It was already
+     * here, but it ran <em>last</em>, after {@code closeSelectorAndChannels()} had closed the sockets
+     * and the reactors had exited. Handlers were therefore drained against dead file descriptors:
+     * a request that had reached its handler completed, and its response went nowhere. The peer saw a
+     * connection closed with no reply, and an idempotent client retried into a listener that was
+     * already gone.
+     *
+     * <p>So the order below is the fix, not the mechanism. Ingress closes first, the reactors stay up
+     * to carry responses out, the drain runs while they can still flush, and only then does anything
+     * get torn down.
+     */
     @Override
     public void stop() {
         if (!running.compareAndSet(true, false)) {
             return;
         }
+        draining.set(true);
 
+        // Phase 1 — close ingress. No new connections; the reactors keep serving admitted ones.
         closeQuietly(serverChannel);
 
         Thread acceptor = acceptorThread;
@@ -197,6 +216,22 @@ public final class NativeTcpCarrier implements TransportEngine {
             }
         }
 
+        // Phase 2 — drain in-flight streams while the write path is still alive.
+        long drainStartNanos = System.nanoTime();
+        int inFlightAtStart = paqsActiveStreams();
+        PaqsScheduler localPaqs = paqs;
+        if (localPaqs != null) {
+            localPaqs.close();
+        }
+        int inFlightRemaining = paqsActiveStreams();
+        CommunityTransportDrainEvent.emit(
+                engineName(),
+                inFlightAtStart,
+                inFlightRemaining,
+                System.nanoTime() - drainStartNanos);
+
+        // Phase 3 — the drain is over by completion or by deadline; take the loops down.
+        draining.set(false);
         for (NativeTcpReactor reactor : reactors) {
             reactor.wakeup();
         }
@@ -205,11 +240,11 @@ public final class NativeTcpCarrier implements TransportEngine {
         }
 
         closeSelectorAndChannels();
+    }
 
+    private int paqsActiveStreams() {
         PaqsScheduler localPaqs = paqs;
-        if (localPaqs != null) {
-            localPaqs.close();
-        }
+        return localPaqs == null ? 0 : localPaqs.admissionController().activeStreamCount();
     }
 
     @Override
@@ -321,6 +356,19 @@ public final class NativeTcpCarrier implements TransportEngine {
 
     /* default */ boolean isRunning() {
         return running.get();
+    }
+
+    /**
+     * Whether the reactor loops should keep selecting.
+     *
+     * <p>Distinct from {@link #isRunning()} because a graceful stop has two phases, and collapsing
+     * them is what broke the drain: {@code running} goes false the instant {@link #stop()} decides to
+     * stop <em>accepting</em>, while the reactors must keep flushing responses for streams already
+     * admitted. A reactor that exits on {@code running} alone takes the write path down with it, so
+     * the drain that follows has nothing left to drain through.
+     */
+    /* default */ boolean isReactorActive() {
+        return running.get() || draining.get();
     }
 
     /* default */ String requestedSocketBackend() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -199,10 +199,21 @@ public final class NativeTcpCarrier implements TransportEngine {
      */
     @Override
     public void stop() {
-        if (!running.compareAndSet(true, false)) {
+        // Claim the stop before clearing `running`, and in this order. The reactors' liveness
+        // predicate is `running || draining`, so raising `draining` second would leave a window where
+        // both read false and a reactor could exit before the drain has even begun — the very failure
+        // this method exists to prevent, reintroduced at instruction scale. Entering through the
+        // `draining` CAS also makes the guard atomic: a concurrent second stop() loses the race here
+        // and returns, instead of both threads passing a separate check.
+        if (!draining.compareAndSet(false, true)) {
             return;
         }
-        draining.set(true);
+        if (!running.compareAndSet(true, false)) {
+            // Not running — nothing to drain, and `draining` must not stay raised or the reactors of a
+            // subsequent start() would never be allowed to exit.
+            draining.set(false);
+            return;
+        }
 
         // Phase 1 — close ingress. No new connections; the reactors keep serving admitted ones.
         closeQuietly(serverChannel);
@@ -366,6 +377,12 @@ public final class NativeTcpCarrier implements TransportEngine {
      * stop <em>accepting</em>, while the reactors must keep flushing responses for streams already
      * admitted. A reactor that exits on {@code running} alone takes the write path down with it, so
      * the drain that follows has nothing left to drain through.
+     *
+     * <p>These are two independent reads, not one atomic state, so {@link #stop()} owes them an
+     * ordering invariant: at least one of the two flags reads true from the moment a stop is claimed
+     * until the drain has finished. {@code stop()} raises {@code draining} <em>before</em> clearing
+     * {@code running} for exactly that reason — the reverse order leaves a window, however narrow, in
+     * which both read false and a reactor exits ahead of the drain.
      */
     /* default */ boolean isReactorActive() {
         return running.get() || draining.get();

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpReactor.java
@@ -131,10 +131,10 @@ final class NativeTcpReactor {
     @SuppressWarnings("PMD.CognitiveComplexity") // selector loop drains MPSC + polls keys; per-key
     // dispatch extracted to dispatchSelectedKey (PERF-073) so cyclomatic complexity no longer trips.
     private void runLoop() {
-        while (host.isRunning()) {
+        while (host.isReactorActive()) {
             try {
                 boolean drainedRequests = drainPendingRequests();
-                if (!host.isRunning()) {
+                if (!host.isReactorActive()) {
                     return;
                 }
 
@@ -165,7 +165,7 @@ final class NativeTcpReactor {
                     }
                 }
             } catch (IOException e) {
-                if (host.isRunning()) {
+                if (host.isReactorActive()) {
                     host.handleAsyncFailure("reactor/" + index, e);
                 }
                 return;

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpCarrierTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpCarrierTckTest.java
@@ -12,6 +12,7 @@ import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.transport.StreamHandler;
 import eu.exeris.kernel.spi.transport.TransportConfig;
 import eu.exeris.kernel.spi.transport.TransportEngine;
 import eu.exeris.kernel.spi.transport.TransportMode;
@@ -45,6 +46,17 @@ class CommunityNativeTcpCarrierTckTest extends AbstractTransportEngineTck {
         // Accepted connections are parked, never served: closing them here would free slots
         // underneath the ceiling and the refusal path would never be reached.
         holder[0].setStreamHandler(stream -> { });
+        return holder[0];
+    }
+
+    @Override
+    protected TransportEngine createEngineWithHandler(int port, StreamHandler handler) {
+        TransportConfig config = new TransportConfig(
+                TransportMode.SERVER, "127.0.0.1", port, 1, null, null, 16, 30_000);
+        TransportEngine[] holder = new TransportEngine[1];
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
+                .run(() -> holder[0] = new NativeTcpTransportProvider().createEngine(config));
+        holder[0].setStreamHandler(handler);
         return holder[0];
     }
 

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportEngineTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/transport/AbstractTransportEngineTck.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.tck.contract.transport;
 
+import eu.exeris.kernel.spi.transport.StreamHandler;
 import eu.exeris.kernel.spi.transport.TransportEngine;
 import eu.exeris.kernel.spi.transport.TransportMode;
 import eu.exeris.kernel.spi.transport.TransportStats;
@@ -20,11 +21,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -50,6 +53,8 @@ public abstract class AbstractTransportEngineTck {
     private static final int OVER_CEILING = 2;
     private static final int CONNECT_TIMEOUT_MS = 2_000;
     private static final long REJECTION_TIMEOUT_SECONDS = 5L;
+    private static final long DRAIN_TIMEOUT_SECONDS = 10L;
+    private static final byte[] DRAIN_PAYLOAD = {'D', 'R', 'A', 'I', 'N', 'E', 'D', '!'};
 
     /**
      * Creates a fully initialised (but not yet started) {@link TransportEngine} in SERVER mode.
@@ -72,6 +77,19 @@ public abstract class AbstractTransportEngineTck {
      *                       engine without needing a binding-specific way to read the bound address
      */
     protected abstract TransportEngine createEngineWithConnectionCeiling(int maxConnections, int port);
+
+    /**
+     * Creates an unstarted SERVER-mode engine bound to {@code port} whose stream handler is the one
+     * supplied, rather than one the binding chooses.
+     *
+     * <p>The drain contract cannot be asserted from outside the handler: proving that {@code stop()}
+     * lets an in-flight exchange finish requires holding one open across the call, which only the
+     * suite's own handler can do.
+     *
+     * @param port    the port to bind
+     * @param handler the handler the engine must invoke for each admitted stream
+     */
+    protected abstract TransportEngine createEngineWithHandler(int port, StreamHandler handler);
 
     /**
      * Returns the expected {@link TransportMode} of the engine created by {@link #createEngine()}.
@@ -220,6 +238,62 @@ public abstract class AbstractTransportEngineTck {
         assertThat(bounded.stats().totalRejected())
                 .as("a refusal the engine does not count is a refusal an operator cannot see")
                 .isPositive();
+    }
+
+    @Nested
+    @DisplayName("stop() drains in-flight streams before tearing the transport down")
+    class GracefulDrain {
+
+        @Test
+        @DisplayName("a stream mid-exchange when stop() is called still delivers its response")
+        void inFlightStreamSurvivesStop() throws Exception {
+            CountDownLatch handlerEntered = new CountDownLatch(1);
+            CountDownLatch releaseHandler = new CountDownLatch(1);
+            int port = freePort();
+
+            TransportEngine draining = createEngineWithHandler(port, stream -> {
+                handlerEntered.countDown();
+                try {
+                    // Hold the exchange open so stop() is guaranteed to land mid-flight. Without this
+                    // the handler could finish first and the test would pass on timing, not contract.
+                    if (!releaseHandler.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        return;
+                    }
+                    MemorySegment response = MemorySegment.ofArray(DRAIN_PAYLOAD);
+                    stream.write(response, DRAIN_PAYLOAD.length);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stream.close();
+                }
+            });
+            draining.start();
+
+            Socket client = connectQuietly(port);
+            try {
+                client.setSoTimeout((int) TimeUnit.SECONDS.toMillis(DRAIN_TIMEOUT_SECONDS));
+                assertThat(handlerEntered.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .as("the handler must be running before stop() is called, or this asserts nothing")
+                        .isTrue();
+
+                Thread stopper = Thread.ofPlatform().start(draining::stop);
+                releaseHandler.countDown();
+
+                byte[] received = client.getInputStream().readNBytes(DRAIN_PAYLOAD.length);
+                stopper.join(TimeUnit.SECONDS.toMillis(DRAIN_TIMEOUT_SECONDS));
+
+                assertThat(received)
+                        .as("stop() promises in-flight streams are drained before being forcefully "
+                                + "closed. Severing the socket first and draining afterwards leaves the "
+                                + "handler running against a dead descriptor: it completes, the peer "
+                                + "gets nothing, and an idempotent client retries into a closed listener")
+                        .containsExactly(DRAIN_PAYLOAD);
+            } finally {
+                releaseHandler.countDown();
+                closeQuietly(client);
+                draining.close();
+            }
+        }
     }
 
     private static int freePort() {


### PR DESCRIPTION
Surfaced from a downstream flaky test whose failing assertion turned out to be the correct one. `TransportEngine.stop()` has promised graceful drain since 0.5.0; the Community carrier ran every step of it, in an order that made the drain inert.

## The defect

`TransportEngine.stop()` (SPI, not just prose):

> Initiates a graceful stop — no new connections accepted, **in-flight streams are drained for a bounded period** before being forcefully closed.

`NativeTcpCarrier.stop()` did this:

```java
running.compareAndSet(true, false);   // reactors poll this → they exit
closeQuietly(serverChannel);          // ingress closed ✓
acceptor.join(2_000L);
for (r : reactors) r.wakeup();
for (r : reactors) r.join(2_000L);
closeSelectorAndChannels();           // every live channel closed
paqs.close();                         // ← the drain, against dead descriptors
```

`PaqsScheduler.close()` **is** the drain — it waits for the admission controller's active-stream count to reach zero under a 60-second hard deadline, exactly as `bootstrap.md` and the `transport.md` draining table describe. It just ran last. By the time it waited, the sockets those streams were answering on were gone, and so were the reactors: they poll `host.isRunning()`, and `stop()` clears that in its first line, so a single flag meant both *stop accepting* and *stop processing*.

Net effect: a request that reached its handler completed correctly and its response went nowhere. The peer saw a connection closed with no reply; an idempotent client retried and got a refusal, because ingress had closed several steps earlier.

## The fix

Ordering, plus the state distinction that was missing:

- New `draining` flag. Reactors poll `isReactorActive() == running || draining`, so they keep flushing responses for already-admitted streams while accepting none.
- `stop()` runs three phases: **close ingress** → **drain while the write path is alive** → **tear down**.

The 60-second deadline, the spin-then-yield backoff, the admission counting — all pre-existing and unchanged. Only *when* the drain runs is different.

## TCK — why this survived

The contract dates to 0.5.0. `AbstractTransportEngineTck` asserted only the state machine: `start()` → `stop()` → `close()`, idempotent restart, mode reporting. Nothing held a stream open across `stop()`, so a violation this visible passed every gate.

New `GracefulDrain` case does exactly that, plus a `createEngineWithHandler(port, handler)` factory so the suite can own the handler (the contract can't be asserted from outside it). Abstract rather than defaulted-to-skip, for the same reason the connection-ceiling factory is — a binding that silently didn't implement it would pass by not running.

**Non-vacuity by construction, no mutation required.** Against the unfixed carrier the case fails with `but was: []` — the client receives zero bytes. After the fix, 10/10.

**Cross-repo obligation:** any other binding of this TCK must implement the new factory.

## Telemetry

`CommunityTransportDrainEvent` — streams at start, streams remaining, duration. A non-zero remaining count means the deadline fired before the drain finished: the signal that in-flight work was severed, and the number to size `terminationGracePeriodSeconds` against. Until now a completed drain left no trace at all and a timed-out one left only a log line.

## Docs

`bootstrap.md` and the `transport.md` draining policy table were already correct — the code now matches them, so neither changed. Added a phase-order subsection and the JFR event to `transport.md`, including what the old order actually did.

## Verification

| Gate | Status |
|---|---|
| `mvn clean install`, full reactor, lint gates, no skip flags | `MAVEN_EXIT=0`, BUILD SUCCESS |
| `ExerisArchitectureTest` | 13/13 |
| Transport stress gate (`-DincludedGroups=stress -DexcludedGroups=`) | RUN+GREEN — 4 tests incl. multi-reactor pinning, which the reactor-predicate change directly affects |
| Community integration gate (`-DincludedGroups=integration -DexcludedGroups=`) | RUN+GREEN — 9 run, 3 skipped; all skips in the OpenSSL-conditional TLS loopback IT, untouched here. `NativeTcpCarrierIngressIntegrationTest` 5/5 |
| New TCK case, pre-fix | FAILS (`but was: []`) — the intended result |

🤖 Generated with [Claude Code](https://claude.com/claude-code)