### PR TITLE
feat(testkit): boot a real persistence engine for downstream consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Authoritative references:
 - [docs/modules/03-community.md](docs/modules/03-community.md)
 - [docs/modules/04-enterprise.md](docs/modules/04-enterprise.md)
 - [docs/modules/05-tck.md](docs/modules/05-tck.md)
+- [docs/modules/06-testkit.md](docs/modules/06-testkit.md)
 
 ## Requirements
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1954,6 +1954,26 @@ testkit — that drives a transaction through the real engine and observes a rol
 surface documented in `docs/modules/` alongside the HTTP one. No new SPI: the fixtures compose
 existing contracts, so nothing here widens the kernel's public surface.
 
+**Status (v0.11): PARTIAL — persistence delivered, the rest open.**
+
+`EmbeddedPersistenceEngineFixture` boots the real `persistence` subsystem (transitively `memory`)
+through `KernelBootstrap` + `ServiceLoader`, with `inMemoryH2()` applying the engine's own DDL and
+`forJdbcUrl(url, runMigrations)` for a container-backed or pre-migrated database. `runInKernelScope`
+carries consumer work to the thread holding the boot, since a `ScopedValue` binding cannot be handed
+out — that is what makes the fixture usable by a host runtime's transaction manager, which resolves the
+engine from the slot rather than from a reference. Surface documented in `docs/modules/06-testkit.md`,
+which also covers the previously undocumented HTTP fixture.
+
+The merge gate is met with one stated compromise: the consumer-shaped test imports only the testkit and
+SPI — nothing from `eu.exeris.kernel.community.*` — but it *lives* in that module's test scope, because
+the testkit builds before Community in the reactor and cannot depend on a provider. A genuinely
+external consumer module would be stronger, and is worth creating if this pattern grows past one or two
+subsystems.
+
+**Still open:** events, flow, graph, scheduling, storage, telemetry. Persistence was taken first
+because transactions are the sharpest exposure; events + flow are the natural next pair, since they
+compose with the engine this slice now makes reachable.
+
 ---
 
 ## Known Gaps / Future Work planned for v0.12

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,6 +277,7 @@ To understand how these concepts map to actual code, read the subsystem definiti
 - [Community Module](modules/03-community.md) – NIO.2-backed Java 26 subsystem drivers (OSS)
 - [Enterprise Module](modules/04-enterprise.md) - High-Performance Native Drivers
 - [TCK Module](modules/05-tck.md) - Technology Compatibility Kit
+- [Testkit Module](modules/06-testkit.md) - Fixtures that boot the real kernel for consumers
 
 **Logical Subsystems:**
 - [Bootstrap](subsystems/bootstrap.md) | [Config](subsystems/config.md) | [Memory](subsystems/memory.md) | [Security](subsystems/security.md)

--- a/docs/modules/06-testkit.md
+++ b/docs/modules/06-testkit.md
@@ -85,7 +85,22 @@ of it.
 
 ### Security — `TestJwt`
 
-Signed-token construction for tests exercising `TokenValidator` / `IdentityProvider` bindings.
+Signed-token construction for tests exercising `TokenValidator` / `IdentityProvider` bindings, plus
+the attack shapes those tests are built on: `expired()`, `tamperedSignature()`, `algNone()`,
+`hmacConfusion()`, `noKid()`. Each is unit-tested against the plain, genuinely-valid token — a builder
+that quietly produced a *valid* token when asked for `algNone()` would make every negative security
+test pass while proving nothing.
+
+---
+
+## Coverage note
+
+The two `KernelBootstrap*Fixture` classes are roughly half this module's lines and **cannot be covered
+from inside it**: exercising them requires a provider on the classpath, and the module deliberately
+declares none. Their coverage lives in `exeris-kernel-community`'s test scope, which JaCoCo attributes
+to that module's bundle instead. The module clears its floor on the plumbing and `TestJwt`; expect the
+ratio to fall as each new fixture lands, since every one adds uncoverable lines here and coverable
+lines elsewhere.
 
 ---
 

--- a/docs/modules/06-testkit.md
+++ b/docs/modules/06-testkit.md
@@ -1,0 +1,116 @@
+# Module: `exeris-kernel-community-testkit`
+
+**Role:** fixtures that boot the **real** kernel for consumers outside this repository.
+**Depends on:** SPI, Core. Deliberately **not** on `exeris-kernel-community` — see *Provider discovery* below.
+
+---
+
+## Why this module exists
+
+A host runtime binding a kernel SPI has two options for testing: the real engine, or a double. Without
+fixtures it gets the double by default — and a double encodes how its author *read* the contract, not
+how the runtime *behaves*. Ordering, lifecycle, and threading are exactly the properties a double
+cannot get wrong loudly, so defects in them surface in applications rather than in test suites.
+
+That is not hypothetical. The v0.11 graceful-drain defect had the machinery present, the SPI
+documenting it, and every in-repo test green — because the TCK asserted the state machine rather than
+the semantics. Downstream reports keep arriving in the same shape.
+
+These fixtures exist so the consumer never has to write the double.
+
+---
+
+## Provider discovery
+
+No fixture imports a Community type. Each one boots through `KernelBootstrap` with a
+`BootstrapSelector`, and pulls the engine out of the `KernelProviders` slot the bootstrap bound. The
+module therefore compiles against SPI and Core alone, while booting **whatever provider the consumer's
+classpath supplies** — Community, Enterprise, or a custom one.
+
+The consequence is that the consumer supplies the provider. A fixture with no provider on the classpath
+fails at `start()` with that stated as the likely cause, rather than yielding a half-booted kernel.
+
+---
+
+## Fixtures
+
+### HTTP — `EmbeddedHttpEngineFixture`
+
+Boots the `http` subsystem on a reserved loopback port with a caller-supplied `HttpHandler`.
+
+```java
+try (EmbeddedHttpEngineFixture fixture = EmbeddedHttpEngineFixtures.kernelBootstrapFixture()) {
+    fixture.start(exchange -> exchange.respond(200, "ok"));
+    int port = fixture.boundPort();
+    // drive a real client at 127.0.0.1:port
+}
+```
+
+`close()` is a **hard stop**, not a graceful drain — it releases the boot and joins. Since v0.11 the
+underlying `TransportEngine.stop()` does drain in-flight streams (see
+[`transport.md`](../subsystems/transport.md) → *Graceful-shutdown phase order*), so a request in flight
+when the fixture closes completes rather than being severed.
+
+### Persistence — `EmbeddedPersistenceEngineFixture` (since 0.11)
+
+Boots the `persistence` subsystem — transitively pulling `memory` — against a JDBC URL.
+
+```java
+try (EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2()) {
+    fixture.start();
+    try (PersistenceConnection connection = fixture.engine().openConnection()) {
+        connection.beginTransaction();
+        connection.executeUpdate("...");
+        connection.rollback();
+    }
+}
+```
+
+- `inMemoryH2()` — a fresh in-memory H2 in PostgreSQL-compatibility mode, unique per call, **migrations
+  applied**. The engine ships its own DDL and applies it only when told to; `run.migrations` defaults
+  to `false`, which is the step most easily missed when standing the engine up by hand and the reason a
+  correctly-configured pool can still meet an empty database.
+- `forJdbcUrl(url, runMigrations)` — for a container-backed Postgres or a pre-migrated schema.
+
+**Which thread.** `engine()` is safe from the test thread: the Community engine reads no `ScopedValue`.
+Consumer code that resolves kernel slots — the usual shape of a host runtime's transaction manager —
+must go through `runInKernelScope(Runnable)`, which carries the work to the thread holding the boot.
+A `ScopedValue` binding cannot outlive the frame that opened it, so the scope cannot be handed out;
+work goes to it instead.
+
+**What the consumer supplies.** A `PersistenceProvider` on the test classpath, and a JDBC driver for
+the URL in use (`com.h2database:h2` for `inMemoryH2()`). The testkit declares neither: it references no driver
+class, and a test library has no business putting a database on the classpath of everything downstream
+of it.
+
+### Security — `TestJwt`
+
+Signed-token construction for tests exercising `TokenValidator` / `IdentityProvider` bindings.
+
+---
+
+## Shared plumbing
+
+`SystemPropertySnapshot` and `FixtureThreads` sit in the root package. Both are **testkit-internal** —
+public only because Java package access does not reach across subpackages — and neither is fixture API.
+They exist because every fixture that holds a kernel boot open on a dedicated thread has to set
+configuration properties before booting and put them back afterwards, and has to join that thread on a
+deadline rather than hanging the suite.
+
+---
+
+## Not yet covered
+
+Events, flow, graph, scheduling, storage, and telemetry have no fixtures. Consumers binding those SPIs
+are still writing doubles, with the exposure described above. Tracked in
+[`ROADMAP.md`](../ROADMAP.md) → *Testkit: No Real-Runtime Fixtures Outside HTTP*; persistence was taken
+first because transactions are the sharpest case — propagation, rollback, and connection lifecycle are
+data-integrity behaviour.
+
+---
+
+## See also
+
+- [`03-community.md`](03-community.md) — the providers these fixtures boot.
+- [`05-tck.md`](05-tck.md) — `Abstract*Tck` contract suites. Different job: the TCK verifies a
+  *provider* against the contract; the testkit lets a *consumer* run against a real provider.

--- a/docs/modules/06-testkit.md
+++ b/docs/modules/06-testkit.md
@@ -91,11 +91,33 @@ Signed-token construction for tests exercising `TokenValidator` / `IdentityProvi
 
 ## Shared plumbing
 
-`SystemPropertySnapshot` and `FixtureThreads` sit in the root package. Both are **testkit-internal** —
-public only because Java package access does not reach across subpackages — and neither is fixture API.
-They exist because every fixture that holds a kernel boot open on a dedicated thread has to set
-configuration properties before booting and put them back afterwards, and has to join that thread on a
-deadline rather than hanging the suite.
+`SystemPropertySnapshot`, `FixtureThreads` and `FixtureBootLock` sit in the root package. All three are
+**testkit-internal** — public only because Java package access does not reach across subpackages — and
+none is fixture API. They exist because every fixture that holds a kernel boot open on a dedicated
+thread has to publish configuration properties before booting and put them back afterwards, has to join
+that thread on a deadline rather than hanging the suite, and must not boot while another fixture is
+mid-boot.
+
+### Concurrent starts
+
+Kernel configuration arrives through system properties, which are JVM-global. The kernel reads them
+**uncached** (`CommunityConfigProvider.resolveRaw` calls `System.getProperty` per lookup) during
+subsystem initialisation, and `KernelBootstrap`'s `bootActive` guard is per-instance — so nothing in
+the kernel serialises two `boot()` calls. Without a lock, two fixtures started from different threads
+could each read the other's properties: for HTTP that is the wrong port, for persistence it is
+**the wrong database**.
+
+`FixtureBootLock` closes this by serialising the set-properties → boot → await-started window across
+the whole fixture family. Two guarantees follow:
+
+- **Fixtures are safe to use under parallel test execution.** They cannot boot simultaneously, but they
+  run simultaneously — the lock covers starting, not the fixture lifetime.
+- **Overlapping lifetimes are harmless.** The values are resolved once, into a configuration object the
+  engine then owns, and never re-read; so one fixture restoring its snapshot while another is still
+  running cannot affect the running one.
+
+Each fixture also refuses a second concurrent `start()` on the same instance, rather than silently
+spawning a second boot thread and leaking the first.
 
 ---
 

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>exeris-kernel-community-testkit</artifactId>
 
     <name>Exeris Kernel :: Community Testkit</name>
-    <description>Reusable community HTTP fixture utilities for tests across modules.</description>
+    <description>Reusable fixtures that boot the real kernel for tests across modules and for downstream consumers.</description>
 
     <dependencies>
         <dependency>

--- a/exeris-kernel-community-testkit/pom.xml
+++ b/exeris-kernel-community-testkit/pom.xml
@@ -29,10 +29,16 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+        <!-- Version managed by exeris-kernel-bom; the previous hard-pinned 5.10.2 diverged from the
+             reactor-wide JUnit and would have put two Jupiter versions on the test classpath. -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/FixtureBootLock.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/FixtureBootLock.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+/**
+ * Serialises the window in which a fixture publishes its configuration and the kernel reads it.
+ *
+ * <h2>The race this closes</h2>
+ * <p>Kernel configuration arrives through system properties, which are JVM-global. A fixture has to
+ * set them, boot, and only then may another fixture set its own. Nothing in the kernel enforces that:
+ * {@code CommunityConfigProvider.resolveRaw} performs an uncached {@code System.getProperty} on every
+ * call, and {@code KernelBootstrap}'s {@code bootActive} guard is a per-instance {@code AtomicBoolean},
+ * so two {@code boot()} calls from different threads are not serialised against each other. Two
+ * fixtures started concurrently could therefore each read the other's properties — for persistence
+ * that is a fixture connecting to the wrong database, not merely the wrong port.
+ *
+ * <h2>Why the boot window is the whole exposure</h2>
+ * <p>The values are resolved <em>once</em>, while the subsystem initialises, into a configuration
+ * object the engine then owns; they are never re-read. So the properties only have to be stable from
+ * the moment a fixture sets them until its boot has consumed them. Once past that point, fixtures may
+ * overlap freely — including one restoring its property snapshot while another is still running.
+ *
+ * <p>This lock therefore covers <em>starting</em>, not the fixture lifetime: concurrent tests still
+ * run concurrently, they just cannot boot at the same instant.
+ *
+ * <p>Testkit plumbing, not fixture API. Public only so the fixture subpackages can reach it.
+ *
+ * @since 0.11.0
+ */
+public final class FixtureBootLock {
+
+    private static final Object BOOT_LOCK = new Object();
+
+    private FixtureBootLock() {
+    }
+
+    /**
+     * Runs a fixture's set-properties-then-boot-then-await sequence with no other fixture booting.
+     *
+     * @param bootAndAwaitStart publishes configuration, starts the runtime thread, and returns only
+     *                          once that thread has booted or failed — returning earlier would leave
+     *                          the window open
+     */
+    public static void bootExclusively(Runnable bootAndAwaitStart) {
+        synchronized (BOOT_LOCK) {
+            bootAndAwaitStart.run();
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/FixtureThreads.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/FixtureThreads.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread handling shared by the fixtures that hold a kernel boot open on a dedicated thread.
+ *
+ * <p>Testkit plumbing, not fixture API. Public only so the fixture subpackages can reach it.
+ *
+ * @since 0.11.0
+ */
+public final class FixtureThreads {
+
+    private FixtureThreads() {
+    }
+
+    /**
+     * Waits for a fixture runtime thread to finish, then interrupts it if it has not.
+     *
+     * <p>A fixture that hangs on close must not hang the suite: the deadline turns a stuck kernel
+     * shutdown into a late-but-terminating test rather than a build that never returns.
+     *
+     * @param thread         the thread to join; {@code null} is a no-op
+     * @param timeoutSeconds how long to wait before interrupting
+     */
+    public static void joinQuietly(Thread thread, long timeoutSeconds) {
+        if (thread == null) {
+            return;
+        }
+
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (thread.isAlive() && System.nanoTime() < deadlineNanos) {
+            try {
+                thread.join(100L);
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        if (thread.isAlive()) {
+            thread.interrupt();
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/SystemPropertySnapshot.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/SystemPropertySnapshot.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Captures system properties a fixture is about to overwrite, and puts them back afterwards.
+ *
+ * <p>Kernel configuration is read from system properties at boot, so a fixture has to set them before
+ * booting. Without a restore, the first fixture in a JVM silently reconfigures every suite that runs
+ * after it — a failure that surfaces as an unrelated test failing only when run in a particular order.
+ *
+ * <p>Testkit plumbing, not fixture API. Public only so the fixture subpackages can reach it.
+ *
+ * @param keys   the property names captured
+ * @param values the values at capture time, {@code null} where the property was unset
+ * @since 0.11.0
+ */
+public record SystemPropertySnapshot(List<String> keys, List<String> values) {
+
+    /**
+     * Records the current value of each property.
+     *
+     * @param propertyKeys the property names to capture
+     * @return a snapshot that {@link #restore()} can replay
+     */
+    public static SystemPropertySnapshot capture(String... propertyKeys) {
+        List<String> capturedKeys = List.of(propertyKeys);
+        List<String> snapshotValues = new ArrayList<>(capturedKeys.size());
+        for (String key : capturedKeys) {
+            snapshotValues.add(System.getProperty(key));
+        }
+        return new SystemPropertySnapshot(capturedKeys, snapshotValues);
+    }
+
+    /** Restores every captured property, clearing the ones that were unset at capture time. */
+    public void restore() {
+        for (int index = 0; index < keys.size(); index++) {
+            String value = values.get(index);
+            if (value == null) {
+                System.clearProperty(keys.get(index));
+            } else {
+                System.setProperty(keys.get(index), value);
+            }
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.testkit.http;
 
+import eu.exeris.kernel.community.testkit.FixtureBootLock;
 import eu.exeris.kernel.community.testkit.FixtureThreads;
 import eu.exeris.kernel.community.testkit.SystemPropertySnapshot;
 import eu.exeris.kernel.core.bootstrap.KernelBootstrap;
@@ -54,58 +55,68 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
                 throw new IllegalStateException("Fixture is already started");
             }
 
-            int reservedPort = reserveLoopbackPort();
-            SystemPropertySnapshot propertySnapshot = SystemPropertySnapshot.capture(
-                    "exeris.http.mode",
-                    "exeris.http.bindHost",
-                    "exeris.http.port",
-                    "http.mode",
-                    "http.bindHost",
-                    "http.port");
-
-            CountDownLatch startedSignal = new CountDownLatch(1);
-            CountDownLatch stop = new CountDownLatch(1);
-            AtomicReference<Throwable> startupFailure = new AtomicReference<>();
-
-            Thread thread = Thread.ofPlatform()
-                    .name("kernel-bootstrap-http-fixture")
-                    .uncaughtExceptionHandler((_, throwable) -> {
-                        startupFailure.compareAndSet(null, throwable);
-                        startedSignal.countDown();
-                    })
-                    .start(() -> runFixtureRuntime(
-                            handler,
-                            reservedPort,
-                            propertySnapshot,
-                            startedSignal,
-                            stop,
-                            startupFailure));
-
-            try {
-                if (!startedSignal.await(START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                    stop.countDown();
-                    FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
-                    throw new IllegalStateException("Timed out while starting kernel HTTP fixture");
-                }
-            } catch (InterruptedException interruptedException) {
-                Thread.currentThread().interrupt();
-                stop.countDown();
-                FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
-                throw new IllegalStateException("Interrupted while starting kernel HTTP fixture",
-                        interruptedException);
-            }
-
-            Throwable failure = startupFailure.get();
-            if (failure != null) {
-                stop.countDown();
-                FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
-                throw new IllegalStateException("Kernel HTTP fixture failed to start", failure);
-            }
-
-            runtimeThread = thread;
-            stopSignal = stop;
-            started.set(true);
+            FixtureBootLock.bootExclusively(() -> bootAndAwaitStart(handler));
         }
+    }
+
+    /**
+     * Publishes configuration, starts the runtime thread, and returns once it has booted or failed.
+     *
+     * <p>Runs under {@link FixtureBootLock}: the properties are JVM-global and the kernel reads them
+     * uncached during subsystem initialisation, so no other fixture may boot while this is in flight.
+     */
+    private void bootAndAwaitStart(HttpHandler handler) {
+        int reservedPort = reserveLoopbackPort();
+        SystemPropertySnapshot propertySnapshot = SystemPropertySnapshot.capture(
+                "exeris.http.mode",
+                "exeris.http.bindHost",
+                "exeris.http.port",
+                "http.mode",
+                "http.bindHost",
+                "http.port");
+
+        CountDownLatch startedSignal = new CountDownLatch(1);
+        CountDownLatch stop = new CountDownLatch(1);
+        AtomicReference<Throwable> startupFailure = new AtomicReference<>();
+
+        Thread thread = Thread.ofPlatform()
+                .name("kernel-bootstrap-http-fixture")
+                .uncaughtExceptionHandler((_, throwable) -> {
+                    startupFailure.compareAndSet(null, throwable);
+                    startedSignal.countDown();
+                })
+                .start(() -> runFixtureRuntime(
+                        handler,
+                        reservedPort,
+                        propertySnapshot,
+                        startedSignal,
+                        stop,
+                        startupFailure));
+
+        try {
+            if (!startedSignal.await(START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                stop.countDown();
+                FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
+                throw new IllegalStateException("Timed out while starting kernel HTTP fixture");
+            }
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            stop.countDown();
+            FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
+            throw new IllegalStateException("Interrupted while starting kernel HTTP fixture",
+                    interruptedException);
+        }
+
+        Throwable failure = startupFailure.get();
+        if (failure != null) {
+            stop.countDown();
+            FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
+            throw new IllegalStateException("Kernel HTTP fixture failed to start", failure);
+        }
+
+        runtimeThread = thread;
+        stopSignal = stop;
+        started.set(true);
     }
 
     @Override

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java
@@ -8,6 +8,8 @@
  */
 package eu.exeris.kernel.community.testkit.http;
 
+import eu.exeris.kernel.community.testkit.FixtureThreads;
+import eu.exeris.kernel.community.testkit.SystemPropertySnapshot;
 import eu.exeris.kernel.core.bootstrap.KernelBootstrap;
 import eu.exeris.kernel.spi.bootstrap.BootstrapSelector;
 import eu.exeris.kernel.spi.http.HttpHandler;
@@ -16,8 +18,6 @@ import eu.exeris.kernel.spi.http.HttpServerEngine;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * KernelBootstrap-based fixture that keeps HTTP running until explicitly closed.
  */
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidUsingHardCodedIP"})
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngineFixture {
 
     private static final long START_TIMEOUT_SECONDS = 10L;
@@ -55,7 +55,7 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
             }
 
             int reservedPort = reserveLoopbackPort();
-            PropertySnapshot propertySnapshot = PropertySnapshot.capture(
+            SystemPropertySnapshot propertySnapshot = SystemPropertySnapshot.capture(
                     "exeris.http.mode",
                     "exeris.http.bindHost",
                     "exeris.http.port",
@@ -84,13 +84,13 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
             try {
                 if (!startedSignal.await(START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                     stop.countDown();
-                    joinQuietly(thread);
+                    FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
                     throw new IllegalStateException("Timed out while starting kernel HTTP fixture");
                 }
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
                 stop.countDown();
-                joinQuietly(thread);
+                FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
                 throw new IllegalStateException("Interrupted while starting kernel HTTP fixture",
                         interruptedException);
             }
@@ -98,7 +98,7 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
             Throwable failure = startupFailure.get();
             if (failure != null) {
                 stop.countDown();
-                joinQuietly(thread);
+                FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
                 throw new IllegalStateException("Kernel HTTP fixture failed to start", failure);
             }
 
@@ -148,7 +148,7 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
         if (stopToSignal != null) {
             stopToSignal.countDown();
         }
-        joinQuietly(threadToJoin);
+        FixtureThreads.joinQuietly(threadToJoin, STOP_TIMEOUT_SECONDS);
 
         synchronized (lifecycleLock) {
             started.set(false);
@@ -158,7 +158,7 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
 
     private void runFixtureRuntime(HttpHandler handler,
                                    int reservedPort,
-                                   PropertySnapshot propertySnapshot,
+                                   SystemPropertySnapshot propertySnapshot,
                                    CountDownLatch startedSignal,
                                    CountDownLatch stop,
                                    AtomicReference<Throwable> startupFailure) {
@@ -208,57 +208,6 @@ public final class KernelBootstrapHttpEngineFixture implements EmbeddedHttpEngin
             return socket.getLocalPort();
         } catch (java.io.IOException exception) {
             throw new IllegalStateException("Unable to reserve loopback HTTP port", exception);
-        }
-    }
-
-    private static void joinQuietly(Thread thread) {
-        if (thread == null) {
-            return;
-        }
-
-        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(STOP_TIMEOUT_SECONDS);
-        while (thread.isAlive() && System.nanoTime() < deadlineNanos) {
-            try {
-                thread.join(100L);
-            } catch (InterruptedException _) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-
-        if (thread.isAlive()) {
-            thread.interrupt();
-        }
-    }
-
-    private static final class PropertySnapshot {
-
-        private final List<String> keys;
-        private final List<String> values;
-
-        private PropertySnapshot(List<String> keys, List<String> values) {
-            this.keys = keys;
-            this.values = values;
-        }
-
-        private static PropertySnapshot capture(String... propertyKeys) {
-            List<String> capturedKeys = List.of(propertyKeys);
-            List<String> snapshotValues = new ArrayList<>(capturedKeys.size());
-            for (String key : capturedKeys) {
-                snapshotValues.add(System.getProperty(key));
-            }
-            return new PropertySnapshot(capturedKeys, snapshotValues);
-        }
-
-        private void restore() {
-            for (int index = 0; index < keys.size(); index++) {
-                String value = values.get(index);
-                if (value == null) {
-                    System.clearProperty(keys.get(index));
-                } else {
-                    System.setProperty(keys.get(index), value);
-                }
-            }
         }
     }
 }

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixture.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixture.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+
+/**
+ * A real kernel {@link PersistenceEngine}, booted in-process, for consumers outside this repository.
+ *
+ * <h2>Why this exists</h2>
+ * <p>Until 0.11 the testkit shipped HTTP fixtures and nothing else, so a host runtime binding the
+ * persistence SPI had no way to test against the engine it actually runs on. What it could do was write
+ * a double — and a double encodes how its author <em>read</em> the contract, not how the runtime
+ * <em>behaves</em>. Ordering, lifecycle, and threading are precisely the properties a double cannot get
+ * wrong loudly, which is why defects in them keep being found by applications rather than by tests.
+ *
+ * <p>This fixture is the real engine: real provider discovery through {@code ServiceLoader}, real
+ * bootstrap, real migrations, real pool. Nothing here is a stand-in.
+ *
+ * <h2>Lifecycle</h2>
+ * <pre>{@code
+ * try (EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2()) {
+ *     fixture.start();
+ *     try (PersistenceConnection connection = fixture.engine().openConnection()) {
+ *         connection.beginTransaction();
+ *         // …
+ *         connection.rollback();
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Which thread</h2>
+ * <p>{@link #engine()} is safe to use directly from the test thread: the Community engine reads no
+ * {@code ScopedValue}, so it does not require the kernel scope to be bound around the caller. Code
+ * that <em>does</em> read kernel slots — anything resolving {@code KernelProviders.CURRENT_CONFIG} or
+ * a provider slot, which is the usual shape of a host runtime's transaction manager — must run through
+ * {@link #runInKernelScope(Runnable)} instead, or it will fail to resolve them.
+ *
+ * @since 0.11.0
+ */
+public interface EmbeddedPersistenceEngineFixture extends AutoCloseable {
+
+    /**
+     * Boots the kernel with the persistence subsystem and blocks until the engine is bound.
+     *
+     * @throws IllegalStateException if already started, or if boot fails or times out
+     */
+    void start();
+
+    /**
+     * Returns the booted engine.
+     *
+     * @return the real {@link PersistenceEngine}; never a double
+     * @throws IllegalStateException if the fixture has not been started
+     */
+    PersistenceEngine engine();
+
+    /**
+     * Returns the JDBC URL this fixture booted against — unique per instance, so parallel tests do not
+     * share a database.
+     *
+     * @return the JDBC URL
+     * @throws IllegalStateException if the fixture has not been started
+     */
+    String jdbcUrl();
+
+    /**
+     * Runs {@code body} on the kernel thread, inside the bound kernel scope.
+     *
+     * <p>For consumer code that resolves kernel {@code ScopedValue} slots. Exceptions propagate to the
+     * caller, so an assertion failing inside {@code body} fails the test rather than disappearing onto
+     * another thread.
+     *
+     * @param body the work to run inside the kernel scope
+     * @throws IllegalStateException if the fixture has not been started
+     */
+    void runInKernelScope(Runnable body);
+
+    /**
+     * Returns whether the fixture is currently booted.
+     *
+     * @return {@code true} between a successful {@link #start()} and {@link #close()}
+     */
+    boolean isRunning();
+
+    /** Shuts the kernel down and releases the database. Idempotent. */
+    @Override
+    void close();
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixtures.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixtures.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import java.util.Objects;
+
+/**
+ * Factory for {@link EmbeddedPersistenceEngineFixture} instances.
+ *
+ * <h2>What the consumer must supply</h2>
+ * <p>Two things, neither of which the testkit can provide for you:
+ * <ul>
+ *   <li>a {@code PersistenceProvider} on the test classpath — {@code exeris-kernel-community} supplies
+ *       one via {@code ServiceLoader}; the testkit deliberately does not depend on it, so that a
+ *       consumer running an Enterprise or custom provider gets that one instead;</li>
+ *   <li>a JDBC driver for the URL in use — {@code com.h2database:h2} for {@link #inMemoryH2()}.</li>
+ * </ul>
+ * The testkit declares neither. It references no driver class, only a URL string, and a test library
+ * has no business putting a database on the classpath of everything that depends on it.
+ *
+ * @since 0.11.0
+ */
+public final class EmbeddedPersistenceEngineFixtures {
+
+    /**
+     * H2 in PostgreSQL-compatibility mode. {@code DB_CLOSE_DELAY=-1} keeps the in-memory database
+     * alive between pooled connections — without it the schema vanishes when the pool briefly drops to
+     * zero connections, and the failure looks like a migration that never ran.
+     */
+    private static final String H2_URL_TEMPLATE =
+            "jdbc:h2:mem:%s;MODE=PostgreSQL;DB_CLOSE_DELAY=-1";
+
+    private EmbeddedPersistenceEngineFixtures() {
+    }
+
+    /**
+     * A fixture on a fresh in-memory H2 database, migrations applied.
+     *
+     * <p>The database name is unique per call, so two fixtures never share state.
+     *
+     * @return an unstarted fixture
+     */
+    public static EmbeddedPersistenceEngineFixture inMemoryH2() {
+        return new KernelBootstrapPersistenceEngineFixture(
+                String.format(H2_URL_TEMPLATE, uniqueDatabaseName()), true);
+    }
+
+    /**
+     * A fixture against a JDBC URL the caller supplies — Postgres in a container, say.
+     *
+     * @param jdbcUrl       the JDBC URL to boot against
+     * @param runMigrations whether the engine should apply its own DDL. Pass {@code false} only when
+     *                      the schema is already installed; the engine defaults to <em>not</em>
+     *                      migrating, which is the step most easily missed when standing it up by hand
+     * @return an unstarted fixture
+     */
+    public static EmbeddedPersistenceEngineFixture forJdbcUrl(String jdbcUrl, boolean runMigrations) {
+        return new KernelBootstrapPersistenceEngineFixture(
+                Objects.requireNonNull(jdbcUrl, "jdbcUrl must not be null"), runMigrations);
+    }
+
+    private static String uniqueDatabaseName() {
+        return "exeris_testkit_" + Long.toUnsignedString(System.nanoTime(), 36);
+    }
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixtures.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixtures.java
@@ -42,7 +42,9 @@ public final class EmbeddedPersistenceEngineFixtures {
     /**
      * A fixture on a fresh in-memory H2 database, migrations applied.
      *
-     * <p>The database name is unique per call, so two fixtures never share state.
+     * <p>The database name is unique per call, so two fixtures never share state — including under
+     * parallel test execution, where {@code FixtureBootLock} keeps concurrent starts from reading each
+     * other's JDBC URL.
      *
      * @return an unstarted fixture
      */

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelBootstrapPersistenceEngineFixture.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelBootstrapPersistenceEngineFixture.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import eu.exeris.kernel.community.testkit.FixtureThreads;
+import eu.exeris.kernel.community.testkit.SystemPropertySnapshot;
+import eu.exeris.kernel.core.bootstrap.KernelBootstrap;
+import eu.exeris.kernel.spi.bootstrap.BootstrapSelector;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link EmbeddedPersistenceEngineFixture} backed by a real {@link KernelBootstrap} run.
+ *
+ * <p>Deliberately the same shape as {@code KernelBootstrapHttpEngineFixture}: the kernel scope is a
+ * {@code ScopedValue} binding and therefore cannot outlive the frame that opened it, so a dedicated
+ * thread holds the boot open and the fixture communicates with it by latch. That is also what makes
+ * {@link #runInKernelScope(Runnable)} possible — the scope exists on exactly one thread, and work has
+ * to be carried to it rather than the other way round (see {@link KernelScopePump}).
+ *
+ * <p>The testkit never imports a Community type. Selection goes through {@link BootstrapSelector} and
+ * the engine comes out of {@link KernelProviders}, so this class compiles against SPI and Core alone
+ * while booting whatever provider the consumer's classpath supplies.
+ */
+final class KernelBootstrapPersistenceEngineFixture implements EmbeddedPersistenceEngineFixture {
+
+    private static final String JDBC_URL_PROPERTY = "exeris.persistence.jdbcUrl";
+    private static final String RUN_MIGRATIONS_PROPERTY = "exeris.persistence.runMigrations";
+    private static final long START_TIMEOUT_SECONDS = 30L;
+    private static final long STOP_TIMEOUT_SECONDS = 15L;
+
+    private final String jdbcUrl;
+    private final boolean runMigrations;
+
+    private final AtomicReference<PersistenceEngine> engine = new AtomicReference<>();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final KernelScopePump pump = new KernelScopePump();
+
+    private Thread runtimeThread;
+
+    /* default */ KernelBootstrapPersistenceEngineFixture(String jdbcUrl, boolean runMigrations) {
+        this.jdbcUrl = Objects.requireNonNull(jdbcUrl, "jdbcUrl must not be null");
+        this.runMigrations = runMigrations;
+    }
+
+    @Override
+    public void start() {
+        if (started.get()) {
+            throw new IllegalStateException("Fixture is already started");
+        }
+
+        SystemPropertySnapshot snapshot =
+                SystemPropertySnapshot.capture(JDBC_URL_PROPERTY, RUN_MIGRATIONS_PROPERTY);
+        CountDownLatch startedSignal = new CountDownLatch(1);
+        AtomicReference<Throwable> startupFailure = new AtomicReference<>();
+
+        Thread thread = Thread.ofPlatform()
+                .name("kernel-bootstrap-persistence-fixture")
+                .uncaughtExceptionHandler((_, throwable) -> {
+                    startupFailure.compareAndSet(null, throwable);
+                    startedSignal.countDown();
+                })
+                .start(() -> runFixtureRuntime(snapshot, startedSignal, startupFailure));
+
+        awaitStart(thread, startedSignal, startupFailure);
+        runtimeThread = thread;
+        started.set(true);
+    }
+
+    @Override
+    public PersistenceEngine engine() {
+        PersistenceEngine current = engine.get();
+        if (!started.get() || current == null) {
+            throw new IllegalStateException("Fixture has not been started");
+        }
+        return current;
+    }
+
+    @Override
+    public String jdbcUrl() {
+        requireStarted();
+        return jdbcUrl;
+    }
+
+    @Override
+    public void runInKernelScope(Runnable body) {
+        Objects.requireNonNull(body, "body must not be null");
+        requireStarted();
+        pump.submitAndWait(body, START_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return started.get() && engine.get() != null;
+    }
+
+    @Override
+    public void close() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+        pump.requestStop();
+        FixtureThreads.joinQuietly(runtimeThread, STOP_TIMEOUT_SECONDS);
+        engine.set(null);
+    }
+
+    private void requireStarted() {
+        if (!started.get()) {
+            throw new IllegalStateException("Fixture has not been started");
+        }
+    }
+
+    private void runFixtureRuntime(SystemPropertySnapshot snapshot,
+                                   CountDownLatch startedSignal,
+                                   AtomicReference<Throwable> startupFailure) {
+        try {
+            System.setProperty(JDBC_URL_PROPERTY, jdbcUrl);
+            System.setProperty(RUN_MIGRATIONS_PROPERTY, Boolean.toString(runMigrations));
+
+            KernelBootstrap bootstrap = KernelBootstrap.builder()
+                    .selector(BootstrapSelector.forNames("persistence"))
+                    .build();
+
+            bootstrap.boot(() -> {
+                engine.set(KernelProviders.persistenceEngine());
+                startedSignal.countDown();
+                pump.pumpUntilStopped();
+            });
+        } catch (KernelBootstrap.BootstrapException bootstrapException) {
+            startupFailure.compareAndSet(null, bootstrapException);
+            startedSignal.countDown();
+        } finally {
+            snapshot.restore();
+        }
+    }
+
+    private void awaitStart(Thread thread,
+                            CountDownLatch startedSignal,
+                            AtomicReference<Throwable> startupFailure) {
+        try {
+            if (!startedSignal.await(START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw abandon(thread, "Timed out while starting kernel persistence fixture", null);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw abandon(thread, "Interrupted while starting kernel persistence fixture", interrupted);
+        }
+
+        Throwable failure = startupFailure.get();
+        if (failure != null) {
+            throw abandon(thread,
+                    "Kernel persistence fixture failed to start — is a PersistenceProvider and a JDBC "
+                            + "driver on the test classpath?", failure);
+        }
+    }
+
+    /** Releases a fixture thread that will never be adopted, and describes why. */
+    private IllegalStateException abandon(Thread thread, String message, Throwable cause) {
+        pump.requestStop();
+        FixtureThreads.joinQuietly(thread, STOP_TIMEOUT_SECONDS);
+        return new IllegalStateException(message, cause);
+    }
+}

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelBootstrapPersistenceEngineFixture.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelBootstrapPersistenceEngineFixture.java
@@ -8,6 +8,7 @@
  */
 package eu.exeris.kernel.community.testkit.persistence;
 
+import eu.exeris.kernel.community.testkit.FixtureBootLock;
 import eu.exeris.kernel.community.testkit.FixtureThreads;
 import eu.exeris.kernel.community.testkit.SystemPropertySnapshot;
 import eu.exeris.kernel.core.bootstrap.KernelBootstrap;
@@ -45,6 +46,8 @@ final class KernelBootstrapPersistenceEngineFixture implements EmbeddedPersisten
     private final boolean runMigrations;
 
     private final AtomicReference<PersistenceEngine> engine = new AtomicReference<>();
+    /** Claimed by the first {@link #start()}; {@code started} only flips once the boot succeeded. */
+    private final AtomicBoolean starting = new AtomicBoolean(false);
     private final AtomicBoolean started = new AtomicBoolean(false);
     private final KernelScopePump pump = new KernelScopePump();
 
@@ -57,10 +60,28 @@ final class KernelBootstrapPersistenceEngineFixture implements EmbeddedPersisten
 
     @Override
     public void start() {
-        if (started.get()) {
+        if (!starting.compareAndSet(false, true)) {
             throw new IllegalStateException("Fixture is already started");
         }
 
+        boolean booted = false;
+        try {
+            FixtureBootLock.bootExclusively(this::bootAndAwaitStart);
+            booted = true;
+        } finally {
+            // Release the claim on failure, so a fixture that could not boot is not wedged shut.
+            starting.set(booted);
+        }
+        started.set(true);
+    }
+
+    /**
+     * Publishes configuration, starts the runtime thread, and returns once it has booted or failed.
+     *
+     * <p>Runs under {@link FixtureBootLock}: the properties are JVM-global and the kernel reads them
+     * uncached during subsystem initialisation, so no other fixture may boot while this is in flight.
+     */
+    private void bootAndAwaitStart() {
         SystemPropertySnapshot snapshot =
                 SystemPropertySnapshot.capture(JDBC_URL_PROPERTY, RUN_MIGRATIONS_PROPERTY);
         CountDownLatch startedSignal = new CountDownLatch(1);
@@ -76,7 +97,6 @@ final class KernelBootstrapPersistenceEngineFixture implements EmbeddedPersisten
 
         awaitStart(thread, startedSignal, startupFailure);
         runtimeThread = thread;
-        started.set(true);
     }
 
     @Override
@@ -114,6 +134,7 @@ final class KernelBootstrapPersistenceEngineFixture implements EmbeddedPersisten
         pump.requestStop();
         FixtureThreads.joinQuietly(runtimeThread, STOP_TIMEOUT_SECONDS);
         engine.set(null);
+        starting.set(false);
     }
 
     private void requireStarted() {

--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePump.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePump.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Carries work to the thread that holds the kernel scope open.
+ *
+ * <p>A {@code ScopedValue} binding cannot outlive the frame that opened it, so a fixture cannot hand
+ * its scope to the test thread. The inversion is the only option left: one thread stays parked inside
+ * the boot running {@link #pumpUntilStopped()}, and callers post work to it.
+ *
+ * <p>The pump is single-consumer by construction — {@link #pumpUntilStopped()} is called from exactly
+ * one thread, the one inside the scope — and any number of producers may submit.
+ */
+final class KernelScopePump {
+
+    /** Identity-compared sentinel; a plain no-op {@code Runnable} would be indistinguishable. */
+    private static final Runnable STOP_SENTINEL = () -> { };
+
+    private final BlockingQueue<Runnable> tasks = new LinkedBlockingQueue<>();
+
+    /**
+     * Runs queued work on the calling thread until {@link #requestStop()} is seen.
+     *
+     * <p>Called from inside the kernel scope; returns when the fixture closes.
+     */
+    /* default */ void pumpUntilStopped() {
+        while (true) {
+            Runnable task;
+            try {
+                task = tasks.take();
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            if (task == STOP_SENTINEL) {
+                return;
+            }
+            task.run();
+        }
+    }
+
+    /**
+     * Posts work to the scope-holding thread and blocks until it has run.
+     *
+     * <p>Whatever the body threw is re-raised on the calling thread, so an assertion failure inside the
+     * scope fails the test that wrote it rather than disappearing onto the fixture thread.
+     *
+     * @param body           the work to run inside the kernel scope
+     * @param timeoutSeconds how long to wait for it to complete
+     */
+    /* default */ void submitAndWait(Runnable body, long timeoutSeconds) {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        tasks.add(() -> runCapturing(body, failure, done));
+
+        try {
+            if (!done.await(timeoutSeconds, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out running work inside the kernel scope");
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted running work inside the kernel scope", interrupted);
+        }
+
+        rethrow(failure.get());
+    }
+
+    /** Signals {@link #pumpUntilStopped()} to return, releasing the thread that holds the scope. */
+    /* default */ void requestStop() {
+        tasks.add(STOP_SENTINEL);
+    }
+
+    private static void runCapturing(Runnable body,
+                                     AtomicReference<Throwable> failure,
+                                     CountDownLatch done) {
+        try {
+            body.run();
+        } catch (Throwable t) { //NOPMD AvoidCatchingThrowable — assertion errors must reach the caller
+            failure.set(t);
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private static void rethrow(Throwable thrown) {
+        switch (thrown) {
+            case null -> { }
+            case RuntimeException runtimeException -> throw runtimeException;
+            case Error error -> throw error;
+            default -> throw new IllegalStateException("Work inside the kernel scope failed", thrown);
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/FixtureBootLockTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/FixtureBootLockTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What is testable here is <em>mutual exclusion</em>, not the race it prevents.
+ *
+ * <p>A lost race inside the kernel is not deterministically reproducible, so no test asserts that two
+ * fixtures would have swapped configuration. What can be pinned is the property the fix rests on: a
+ * second caller does not enter while the first is inside. The blocked half of that is necessarily a
+ * bounded wait; the released half is deterministic, and a broken lock fails the released half's
+ * premise as surely as the blocked one.
+ */
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+@DisplayName("FixtureBootLock")
+class FixtureBootLockTest {
+
+    private static final long BLOCKED_PROBE_MILLIS = 300L;
+
+    @Test
+    @DisplayName("runs the supplied body")
+    void runsBody() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        FixtureBootLock.bootExclusively(() -> ran.set(true));
+
+        assertThat(ran).isTrue();
+    }
+
+    @Test
+    @DisplayName("a second caller waits until the first has left the boot window")
+    void secondCallerWaitsForTheFirst() throws InterruptedException {
+        CountDownLatch firstInside = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch secondInside = new CountDownLatch(1);
+
+        Thread first = Thread.ofPlatform().start(() -> FixtureBootLock.bootExclusively(() -> {
+            firstInside.countDown();
+            awaitQuietly(releaseFirst);
+        }));
+        assertThat(firstInside.await(5L, TimeUnit.SECONDS)).isTrue();
+
+        Thread second = Thread.ofPlatform()
+                .start(() -> FixtureBootLock.bootExclusively(secondInside::countDown));
+
+        assertThat(secondInside.await(BLOCKED_PROBE_MILLIS, TimeUnit.MILLISECONDS))
+                .as("entering while the first holds the window is exactly the configuration swap "
+                        + "this lock exists to prevent")
+                .isFalse();
+
+        releaseFirst.countDown();
+
+        assertThat(secondInside.await(5L, TimeUnit.SECONDS))
+                .as("and it must then proceed — a lock that never releases would deadlock every suite")
+                .isTrue();
+        first.join(TimeUnit.SECONDS.toMillis(5L));
+        second.join(TimeUnit.SECONDS.toMillis(5L));
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException _) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/FixtureThreadsTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/FixtureThreadsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * The property worth pinning is the deadline: a fixture that hangs on close must not hang the suite.
+ */
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+@DisplayName("FixtureThreads.joinQuietly")
+class FixtureThreadsTest {
+
+    @Test
+    @DisplayName("a null thread is a no-op")
+    void nullThreadIsNoOp() {
+        assertThatCode(() -> FixtureThreads.joinQuietly(null, 1L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("joins a thread that finishes on its own")
+    void joinsFinishedThread() {
+        Thread thread = Thread.ofPlatform().start(() -> { });
+
+        FixtureThreads.joinQuietly(thread, 5L);
+
+        assertThat(thread.isAlive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("interrupts a thread that outlives the deadline instead of waiting forever")
+    void interruptsThreadThatOutlivesDeadline() throws InterruptedException {
+        CountDownLatch neverReleased = new CountDownLatch(1);
+        AtomicBoolean sawInterrupt = new AtomicBoolean(false);
+        CountDownLatch finished = new CountDownLatch(1);
+
+        Thread thread = Thread.ofPlatform().start(() -> {
+            try {
+                neverReleased.await();
+            } catch (InterruptedException _) {
+                sawInterrupt.set(true);
+                Thread.currentThread().interrupt();
+            }
+            finished.countDown();
+        });
+
+        long startNanos = System.nanoTime();
+        FixtureThreads.joinQuietly(thread, 1L);
+        long elapsedNanos = System.nanoTime() - startNanos;
+
+        assertThat(finished.await(5L, TimeUnit.SECONDS))
+                .as("without the interrupt the thread would park forever and the suite with it")
+                .isTrue();
+        assertThat(sawInterrupt).isTrue();
+        assertThat(elapsedNanos)
+                .as("it must actually wait out the deadline rather than interrupting immediately — "
+                        + "a fixture shutting down cleanly deserves the grace period")
+                .isGreaterThanOrEqualTo(TimeUnit.SECONDS.toNanos(1L));
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/SystemPropertySnapshotTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/SystemPropertySnapshotTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct coverage for the two restore paths.
+ *
+ * <p>The asymmetry is the whole point: a property that was <em>unset</em> at capture must be cleared,
+ * not set to the empty string. Restoring it to {@code ""} would leave a value the kernel's config
+ * resolver treats differently from absence, and the resulting failure surfaces in an unrelated suite
+ * that happens to run afterwards.
+ */
+@DisplayName("SystemPropertySnapshot")
+class SystemPropertySnapshotTest {
+
+    private static final String PRESET_KEY = "exeris.testkit.snapshot.preset";
+    private static final String UNSET_KEY = "exeris.testkit.snapshot.unset";
+
+    @AfterEach
+    void clearProbeProperties() {
+        System.clearProperty(PRESET_KEY);
+        System.clearProperty(UNSET_KEY);
+    }
+
+    @Nested
+    @DisplayName("restore()")
+    class Restore {
+
+        @Test
+        @DisplayName("puts back the value a property had at capture time")
+        void restoresPreviousValue() {
+            System.setProperty(PRESET_KEY, "original");
+            SystemPropertySnapshot snapshot = SystemPropertySnapshot.capture(PRESET_KEY);
+
+            System.setProperty(PRESET_KEY, "overwritten");
+            snapshot.restore();
+
+            assertThat(System.getProperty(PRESET_KEY)).isEqualTo("original");
+        }
+
+        @Test
+        @DisplayName("clears a property that was unset at capture time")
+        void clearsPropertyThatWasUnset() {
+            System.clearProperty(UNSET_KEY);
+            SystemPropertySnapshot snapshot = SystemPropertySnapshot.capture(UNSET_KEY);
+
+            System.setProperty(UNSET_KEY, "leaked");
+            snapshot.restore();
+
+            assertThat(System.getProperty(UNSET_KEY))
+                    .as("restoring to \"\" instead of clearing would leave a value the config resolver "
+                            + "reads differently from absence")
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("handles both kinds in one snapshot")
+        void handlesMixedSnapshot() {
+            System.setProperty(PRESET_KEY, "original");
+            System.clearProperty(UNSET_KEY);
+            SystemPropertySnapshot snapshot = SystemPropertySnapshot.capture(PRESET_KEY, UNSET_KEY);
+
+            System.setProperty(PRESET_KEY, "overwritten");
+            System.setProperty(UNSET_KEY, "leaked");
+            snapshot.restore();
+
+            assertThat(System.getProperty(PRESET_KEY)).isEqualTo("original");
+            assertThat(System.getProperty(UNSET_KEY)).isNull();
+        }
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixturesTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/EmbeddedPersistenceEngineFixturesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Factory-level checks only.
+ *
+ * <p>Booting is deliberately out of reach here: the testkit declares no {@code PersistenceProvider},
+ * which is the whole point of the module. That behaviour is covered by the consumer test in
+ * {@code exeris-kernel-community}'s test scope, where a provider exists.
+ */
+@DisplayName("EmbeddedPersistenceEngineFixtures")
+class EmbeddedPersistenceEngineFixturesTest {
+
+    @Test
+    @DisplayName("inMemoryH2 hands back an unstarted fixture")
+    void inMemoryH2ReturnsUnstartedFixture() {
+        EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2();
+
+        assertThat(fixture).isNotNull();
+        assertThat(fixture.isRunning()).isFalse();
+    }
+
+    @Test
+    @DisplayName("accessors refuse before start rather than handing back a half-built fixture")
+    void accessorsRefuseBeforeStart() {
+        EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2();
+
+        assertThatThrownBy(fixture::engine)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been started");
+        assertThatThrownBy(fixture::jdbcUrl)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been started");
+        assertThatThrownBy(() -> fixture.runInKernelScope(() -> { }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been started");
+    }
+
+    @Test
+    @DisplayName("closing a fixture that never started is a no-op")
+    void closeBeforeStartIsNoOp() {
+        EmbeddedPersistenceEngineFixtures.inMemoryH2().close();
+    }
+
+    @Test
+    @DisplayName("forJdbcUrl rejects a null URL at the factory rather than at boot")
+    void forJdbcUrlRejectsNull() {
+        assertThatThrownBy(() -> EmbeddedPersistenceEngineFixtures.forJdbcUrl(null, true))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("jdbcUrl");
+    }
+
+    @Test
+    @DisplayName("forJdbcUrl accepts a caller-supplied URL")
+    void forJdbcUrlAcceptsUrl() {
+        assertThat(EmbeddedPersistenceEngineFixtures.forJdbcUrl("jdbc:h2:mem:probe", false))
+                .isNotNull();
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePumpTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePumpTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.persistence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Direct coverage for the pump's failure and interrupt branches.
+ *
+ * <p>The consumer integration test only exercises the happy path. What actually matters here is the
+ * opposite: work that fails inside the kernel scope must surface on the thread that submitted it,
+ * because otherwise a failing assertion inside {@code runInKernelScope} disappears onto the fixture
+ * thread and the test passes green while proving nothing.
+ */
+@Timeout(value = 10, unit = TimeUnit.SECONDS)
+@DisplayName("KernelScopePump")
+class KernelScopePumpTest {
+
+    private static final long TIMEOUT_SECONDS = 5L;
+
+    @Nested
+    @DisplayName("Failures reach the submitting thread")
+    class FailurePropagation {
+
+        @Test
+        @DisplayName("a RuntimeException is rethrown unwrapped")
+        void runtimeExceptionRethrownUnwrapped() throws InterruptedException {
+            RuntimeException thrown = new IllegalArgumentException("boom");
+
+            assertThatThrownBy(() -> runOnPump(() -> {
+                throw thrown;
+            })).isSameAs(thrown);
+        }
+
+        @Test
+        @DisplayName("an Error is rethrown unwrapped — an AssertionError must stay an AssertionError")
+        void errorRethrownUnwrapped() throws InterruptedException {
+            AssertionError thrown = new AssertionError("assertion inside the scope");
+
+            assertThatThrownBy(() -> runOnPump(() -> {
+                throw thrown;
+            }))
+                    .as("JUnit reports a failed assertion only if it arrives as AssertionError; wrapping "
+                            + "it would downgrade a failure into an error with a misleading message")
+                    .isSameAs(thrown);
+        }
+
+        @Test
+        @DisplayName("a checked Throwable is wrapped, keeping the original as cause")
+        void checkedThrowableWrapped() throws InterruptedException {
+            Throwable thrown = new Exception("checked");
+
+            assertThatThrownBy(() -> runOnPump(() -> sneakyThrow(thrown)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Work inside the kernel scope failed")
+                    .hasCause(thrown);
+        }
+
+        @Test
+        @DisplayName("work that succeeds throws nothing and actually ran")
+        void successfulWorkRuns() throws InterruptedException {
+            AtomicBoolean ran = new AtomicBoolean(false);
+
+            runOnPump(() -> ran.set(true));
+
+            assertThat(ran)
+                    .as("without this control the three cases above would also pass against a pump that "
+                            + "never runs anything and always throws")
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Lifecycle")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("requestStop releases the pumping thread")
+        void requestStopReleasesPump() throws InterruptedException {
+            KernelScopePump pump = new KernelScopePump();
+            Thread pumpThread = startPump(pump);
+
+            pump.requestStop();
+            pumpThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+
+            assertThat(pumpThread.isAlive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("an interrupt ends the pump and leaves the interrupt flag set")
+        void interruptEndsPumpAndPreservesFlag() throws InterruptedException {
+            KernelScopePump pump = new KernelScopePump();
+            AtomicBoolean interruptFlagAtExit = new AtomicBoolean(false);
+            CountDownLatch finished = new CountDownLatch(1);
+
+            Thread pumpThread = Thread.ofPlatform().start(() -> {
+                pump.pumpUntilStopped();
+                interruptFlagAtExit.set(Thread.currentThread().isInterrupted());
+                finished.countDown();
+            });
+
+            // Give the pump time to park in take() so the interrupt lands on the blocking call.
+            Thread.onSpinWait();
+            pumpThread.interrupt();
+
+            assertThat(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            assertThat(interruptFlagAtExit)
+                    .as("swallowing the interrupt would strand a caller that relies on it to unwind")
+                    .isTrue();
+        }
+    }
+
+    private static void runOnPump(Runnable body) throws InterruptedException {
+        KernelScopePump pump = new KernelScopePump();
+        Thread pumpThread = startPump(pump);
+        try {
+            pump.submitAndWait(body, TIMEOUT_SECONDS);
+        } finally {
+            pump.requestStop();
+            pumpThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        }
+    }
+
+    private static Thread startPump(KernelScopePump pump) {
+        return Thread.ofPlatform().start(pump::pumpUntilStopped);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void sneakyThrow(Throwable thrown) throws T {
+        throw (T) thrown;
+    }
+}

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/security/TestJwtTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/security/TestJwtTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkit.security;
+
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the attack-shape builders produce the token they advertise.
+ *
+ * <p>These are the fixtures every negative security test in the reactor is built on. A builder that
+ * quietly produced a <em>valid</em> token when asked for {@code algNone()} or {@code expired()} would
+ * not fail anything — it would make each of those tests pass while proving nothing at all. So each
+ * case below is paired against the plain, genuinely-valid token: the assertion is always
+ * "this differs from a good token in exactly the advertised way".
+ */
+@DisplayName("TestJwt")
+class TestJwtTest {
+
+    @Nested
+    @DisplayName("The baseline token is actually valid")
+    class Baseline {
+
+        @Test
+        @DisplayName("verifies against the published public key and carries the expected claims")
+        void plainTokenVerifies() throws Exception {
+            SignedJWT jwt = SignedJWT.parse(TestJwt.builder().serialize());
+
+            assertThat(jwt.verify(new RSASSAVerifier(TestJwt.testPublicKey())))
+                    .as("every negative case below is only meaningful because this one is true")
+                    .isTrue();
+            assertThat(jwt.getHeader().getAlgorithm().getName()).isEqualTo("RS256");
+            assertThat(jwt.getHeader().getKeyID()).isEqualTo(TestJwt.TEST_KID);
+            assertThat(jwt.getJWTClaimsSet().getIssuer()).isEqualTo(TestJwt.EXPECTED_ISSUER);
+            assertThat(jwt.getJWTClaimsSet().getAudience()).containsExactly(TestJwt.EXPECTED_AUDIENCE);
+            assertThat(jwt.getJWTClaimsSet().getSubject()).isEqualTo(TestJwt.TEST_SUBJECT);
+            assertThat(jwt.getJWTClaimsSet().getExpirationTime().toInstant())
+                    .isAfter(Instant.now());
+        }
+
+        @Test
+        @DisplayName("custom claims reach the payload")
+        void customClaimsArePresent() throws Exception {
+            SignedJWT jwt = SignedJWT.parse(TestJwt.builder()
+                    .claim("scope", "security:read")
+                    .serialize());
+
+            assertThat(jwt.getJWTClaimsSet().getStringClaim("scope")).isEqualTo("security:read");
+        }
+    }
+
+    @Nested
+    @DisplayName("Attack shapes differ from the baseline in the advertised way")
+    class AttackShapes {
+
+        @Test
+        @DisplayName("expired() puts exp in the past and leaves the signature intact")
+        void expiredTokenIsExpiredButStillSigned() throws Exception {
+            SignedJWT jwt = SignedJWT.parse(TestJwt.builder().expired().serialize());
+
+            assertThat(jwt.getJWTClaimsSet().getExpirationTime().toInstant()).isBefore(Instant.now());
+            assertThat(jwt.verify(new RSASSAVerifier(TestJwt.testPublicKey())))
+                    .as("expiry must be the only defect — a validator that rejects on the signature "
+                            + "would pass the test for the wrong reason")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("tamperedSignature() breaks verification and nothing else")
+        void tamperedSignatureFailsVerification() throws Exception {
+            SignedJWT jwt = SignedJWT.parse(TestJwt.builder().tamperedSignature().serialize());
+
+            assertThat(jwt.verify(new RSASSAVerifier(TestJwt.testPublicKey()))).isFalse();
+            assertThat(jwt.getJWTClaimsSet().getExpirationTime().toInstant()).isAfter(Instant.now());
+        }
+
+        @Test
+        @DisplayName("algNone() emits an unsecured header with an empty signature segment")
+        void algNoneIsUnsecured() {
+            String[] segments = TestJwt.builder().algNone().serialize().split("\\.", -1);
+
+            assertThat(segments).hasSize(3);
+            assertThat(decode(segments[0])).contains("\"alg\":\"none\"");
+            assertThat(segments[2])
+                    .as("a non-empty signature segment would make this a signed token wearing an "
+                            + "unsecured header, which is not the attack being modelled")
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("hmacConfusion() declares HS256, so an RSA verifier cannot be the check")
+        void hmacConfusionDeclaresSymmetricAlg() {
+            String[] segments = TestJwt.builder().hmacConfusion().serialize().split("\\.", -1);
+
+            assertThat(decode(segments[0])).contains("\"alg\":\"HS256\"");
+            assertThat(segments[2]).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("noKid() omits kid; kid() sets the one asked for")
+        void kidIsControllable() {
+            String withoutKid = decode(TestJwt.builder().noKid().serialize().split("\\.", -1)[0]);
+            String withUnknownKid =
+                    decode(TestJwt.builder().kid(TestJwt.UNKNOWN_KID).serialize().split("\\.", -1)[0]);
+
+            assertThat(withoutKid).doesNotContain("kid");
+            assertThat(withUnknownKid).contains(TestJwt.UNKNOWN_KID);
+        }
+    }
+
+    @Nested
+    @DisplayName("Buffer handoff")
+    class Buffers {
+
+        @Test
+        @DisplayName("toBuffer() carries exactly the serialized token bytes")
+        void bufferHoldsTheToken() {
+            String compact = TestJwt.builder().serialize();
+
+            try (LoanedBuffer buffer = TestJwt.bufferOf(compact)) {
+                assertThat(buffer.size()).isEqualTo(compact.getBytes(StandardCharsets.UTF_8).length);
+                assertThat(readUtf8(buffer)).isEqualTo(compact);
+            }
+        }
+
+        @Test
+        @DisplayName("the key set publishes the test key under its kid")
+        void keySetPublishesTestKey() {
+            assertThat(TestJwt.keySet())
+                    .containsOnlyKeys(TestJwt.TEST_KID)
+                    .containsEntry(TestJwt.TEST_KID, TestJwt.testPublicKey());
+        }
+    }
+
+    private static String decode(String base64UrlSegment) {
+        return new String(Base64.getUrlDecoder().decode(base64UrlSegment), StandardCharsets.UTF_8);
+    }
+
+    private static String readUtf8(LoanedBuffer buffer) {
+        MemorySegment segment = buffer.segment();
+        byte[] bytes = new byte[(int) buffer.size()];
+        MemorySegment.copy(segment, java.lang.foreign.ValueLayout.JAVA_BYTE, 0L, bytes, 0, bytes.length);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/testkitconsumer/EmbeddedPersistenceEngineFixtureConsumerTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/testkitconsumer/EmbeddedPersistenceEngineFixtureConsumerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.testkitconsumer;
+
+import eu.exeris.kernel.community.testkit.persistence.EmbeddedPersistenceEngineFixture;
+import eu.exeris.kernel.community.testkit.persistence.EmbeddedPersistenceEngineFixtures;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.persistence.PersistenceConnection;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import eu.exeris.kernel.spi.persistence.QueryResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Drives the persistence fixture the way a downstream consumer would.
+ *
+ * <h2>Shape of this test, and its one compromise</h2>
+ * <p>It imports the testkit and the SPI and <strong>nothing from
+ * {@code eu.exeris.kernel.community.*}</strong> — deliberately, because a test that reached into
+ * Community internals would prove the fixture works for someone who does not need it. Every type below
+ * is one a host runtime outside this repository can also see.
+ *
+ * <p>The compromise is location: it lives in {@code exeris-kernel-community}'s test scope rather than a
+ * separate consumer module, because the testkit builds before Community in the reactor and cannot
+ * depend on a provider. The package name keeps the intent legible. A genuinely external consumer module
+ * would be stronger and is worth doing if this pattern grows past one subsystem.
+ *
+ * @since 0.11.0
+ */
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+@DisplayName("Testkit consumer: the persistence fixture boots a real engine")
+class EmbeddedPersistenceEngineFixtureConsumerTest {
+
+    private static final String CREATE_TABLE =
+            "CREATE TABLE IF NOT EXISTS testkit_probe (id INT PRIMARY KEY, note VARCHAR(64))";
+    private static final String INSERT_ROW = "INSERT INTO testkit_probe (id, note) VALUES (1, 'x')";
+    private static final String COUNT_ROWS = "SELECT COUNT(*) FROM testkit_probe";
+
+    @Nested
+    @DisplayName("The engine is real, not a double")
+    class RealEngine {
+
+        @Test
+        @DisplayName("rollback discards the row a committed statement would have kept")
+        void rollbackDiscardsWork() {
+            try (EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2()) {
+                fixture.start();
+                PersistenceEngine engine = fixture.engine();
+
+                execute(engine, CREATE_TABLE);
+
+                try (PersistenceConnection connection = engine.openConnection()) {
+                    connection.beginTransaction();
+                    connection.executeUpdate(INSERT_ROW);
+                    connection.rollback();
+                }
+
+                assertThat(count(engine))
+                        .as("a rolled-back insert must leave nothing behind — the property a hand-written "
+                                + "double is most likely to get right by assumption and wrong in fact")
+                        .isZero();
+
+                try (PersistenceConnection connection = engine.openConnection()) {
+                    connection.beginTransaction();
+                    connection.executeUpdate(INSERT_ROW);
+                    connection.commit();
+                }
+
+                assertThat(count(engine))
+                        .as("and the same sequence with commit must keep it — without this the assertion "
+                                + "above would also pass against an engine that silently writes nothing")
+                        .isOne();
+            }
+        }
+
+        @Test
+        @DisplayName("migrations ran, so the engine's own schema is present")
+        void migrationsApplied() {
+            try (EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2()) {
+                fixture.start();
+                // exeris_outbox ships in the engine's own DDL (V0.5.0). Its presence is what
+                // distinguishes "migrations ran" from "the pool connected to an empty database" —
+                // the failure mode a consumer hits when run.migrations is left at its false default.
+                assertThat(count(fixture.engine(), "SELECT COUNT(*) FROM exeris_outbox"))
+                        .as("the engine must have applied its own DDL")
+                        .isZero();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Kernel scope is reachable for consumer code that needs it")
+    class KernelScope {
+
+        @Test
+        @DisplayName("runInKernelScope resolves the provider slot the test thread cannot")
+        void kernelScopeResolvesProviderSlot() {
+            try (EmbeddedPersistenceEngineFixture fixture = EmbeddedPersistenceEngineFixtures.inMemoryH2()) {
+                fixture.start();
+
+                AtomicReference<PersistenceEngine> fromScope = new AtomicReference<>();
+                fixture.runInKernelScope(() -> fromScope.set(KernelProviders.persistenceEngine()));
+
+                assertThat(fromScope.get())
+                        .as("a host runtime's transaction manager resolves the engine from the slot, not "
+                                + "from a reference handed to it; if the fixture could not offer that, "
+                                + "every such consumer would still be reduced to a double")
+                        .isSameAs(fixture.engine());
+            }
+        }
+    }
+
+    private static void execute(PersistenceEngine engine, String sql) {
+        try (PersistenceConnection connection = engine.openConnection()) {
+            connection.beginTransaction();
+            connection.executeUpdate(sql);
+            connection.commit();
+        }
+    }
+
+    private static long count(PersistenceEngine engine) {
+        return count(engine, COUNT_ROWS);
+    }
+
+    private static long count(PersistenceEngine engine, String sql) {
+        try (PersistenceConnection connection = engine.openConnection();
+             QueryResult result = connection.executeQuery(sql)) {
+            return result.next() ? result.row().getLong(0) : -1L;
+        }
+    }
+}


### PR DESCRIPTION
## Why

A host runtime binding a kernel SPI has two options for testing: the real engine, or a double. Without fixtures it gets the double — and a double encodes how its author *read* the contract, not how the runtime *behaves*. Ordering, lifecycle and threading are exactly the properties a double cannot get wrong loudly, so defects in them surface in applications rather than in test suites.

That is not hypothetical. The v0.11 graceful-drain defect (#272) had the machinery present, the SPI documenting it, and every in-repo test green — the TCK asserted the state machine rather than the semantics. Downstream reports keep arriving in that shape.

Persistence is taken first because transactions are the sharpest exposure: propagation, rollback and connection lifecycle are data-integrity behaviour.

Closes the first slice of the `Testkit: No Real-Runtime Fixtures Outside HTTP` gap (#274).

## What

**`EmbeddedPersistenceEngineFixture`** boots the real `persistence` subsystem (transitively `memory`) through `KernelBootstrap` + `ServiceLoader`:

- `inMemoryH2()` — fresh in-memory H2 in PostgreSQL-compatibility mode, unique per call, **migrations applied**. `run.migrations` defaults to `false`, which is the step most easily missed when standing the engine up by hand and the reason a correctly-configured pool can still meet an empty database.
- `forJdbcUrl(url, runMigrations)` — container-backed Postgres, or a pre-migrated schema.
- `runInKernelScope(Runnable)` — carries consumer work to the thread holding the boot. A `ScopedValue` binding cannot outlive the frame that opened it, so the scope cannot be handed out; `KernelScopePump` inverts the direction instead. This is what a host runtime's transaction manager needs, since it resolves the engine from the **provider slot**, not from a reference passed to it.

**No fixture imports a Community type.** Selection goes through `BootstrapSelector`, the engine comes out of `KernelProviders` — so the module compiles against SPI and Core alone while booting whatever provider the consumer's classpath supplies (Community, Enterprise, or custom). The consumer supplies the provider and a JDBC driver; the testkit declares neither.

**Deduplication.** `SystemPropertySnapshot` and `FixtureThreads` move to the root testkit package — both fixtures had their own copy. Mechanical move, no behaviour change, and it drops the HTTP fixture below the complexity threshold, **retiring its `PMD.CyclomaticComplexity` suppression** rather than adding a second one.

## Verification

| Gate | Result |
|---|---|
| `mvn clean install` (full reactor, **no skip flags** → lint-gated) | green |
| `mvn -pl exeris-kernel-community-testkit,exeris-kernel-community pmd:check checkstyle:check` | 0 violations |
| `ExerisArchitectureTest` | 13/13 |
| Consumer test | 3/3 — rollback+commit control, migrations present, `runInKernelScope` resolves the slot |

The consumer test asserts **both** halves of rollback: without the committed control, `count == 0` would also pass against an engine that silently writes nothing.

One build in the middle failed on `AbstractSagaRecoveryTck$RestartUnderLoad.parkedFleetSurvivesForceCloseAndResumes`. Surefire has no `forkCount`/`reuseForks` override, so the new test shares a JVM with it — worth ruling out rather than assuming. Five further full Community runs (1432 tests each) were green; one failure in six, with no flow/persistence runtime code in the diff, is the pre-existing flake.

## Stated compromise

The consumer test imports only the testkit and SPI — nothing from `eu.exeris.kernel.community.*` — but it *lives* in that module's test scope, because the testkit builds before Community in the reactor and cannot depend on a provider. A genuinely external consumer module would be stronger and is worth creating if this pattern grows past one or two subsystems.

## Scope

Test-fixture module + Community test scope + docs. No SPI surface, no runtime hot path, no ADR: the fixtures compose existing contracts.

Events, flow, graph, scheduling, storage and telemetry remain uncovered — the ROADMAP entry goes to **PARTIAL**, not closed. Events + flow are the natural next pair, since they compose with the engine this slice makes reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)