### PR TITLE
feat(security): route-authorization contract and decision (ADR-061, part 1)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2019,6 +2019,12 @@ application written directly against the kernel, with no annotation processing a
 gets edge authorization. `@RequiresRole` remains the method-level layer above it.
 
 **Merge Gate:** `AbstractHttpRoutePolicyTck` + a Community binding, with the deny paths and the
+unmatched-route path as mandatory cases — a suite that only proves admission would pass against an
+implementation that admits everything. `ExerisArchitectureTest` green. `security.md`, `http.md` and
+`bootstrap.md` updated in the implementing slice — not before it, since they describe what the kernel
+does. (The stale `security.md:6` note is a separate matter: it stated something false about the past,
+so it was corrected with ADR-061 itself.) Release notes record the default-boot behaviour change:
+`/secure/*` stops answering `401` unconditionally once a provider is bound.
 
 **Status (v0.11): PARTIAL — contract and decision landed, wiring pending.**
 
@@ -2038,12 +2044,6 @@ not an undeclared route, and now denies outright.
 `KernelProviders.SECURITY_PROVIDER`, the dispatcher reading the slot instead of `SECURE_PATH_PREFIX`,
 removal of the unreachable `isPublicPath` allowlist, and the `security.md` / `http.md` /
 `bootstrap.md` updates that describe the wired behaviour.
-unmatched-route path as mandatory cases — a suite that only proves admission would pass against an
-implementation that admits everything. `ExerisArchitectureTest` green. `security.md`, `http.md` and
-`bootstrap.md` updated in the implementing slice — not before it, since they describe what the kernel
-does. (The stale `security.md:6` note is a separate matter: it stated something false about the past,
-so it was corrected with ADR-061 itself.) Release notes record the default-boot behaviour change:
-`/secure/*` stops answering `401` unconditionally once a provider is bound.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2019,6 +2019,25 @@ application written directly against the kernel, with no annotation processing a
 gets edge authorization. `@RequiresRole` remains the method-level layer above it.
 
 **Merge Gate:** `AbstractHttpRoutePolicyTck` + a Community binding, with the deny paths and the
+
+**Status (v0.11): PARTIAL — contract and decision landed, wiring pending.**
+
+`HttpRoutePolicy` + `RouteRequirement` in `eu.exeris.kernel.spi.http` behind
+`HttpKernelProviders.HTTP_ROUTE_POLICY`, and `RouteAuthorizationEnforcer` in
+`eu.exeris.kernel.core.security` beside `RoleCheckEnforcer`, with
+`AbstractHttpRoutePolicyTck` + the Community binding green. No behaviour change yet: nothing reads
+the slot, so the dispatcher still gates on `/secure`.
+
+The TCK earned its place before the wiring did. Its `nullAnswerDenies` case caught a fail-open in the
+first implementation of the enforcer, which substituted `HttpRoutePolicy.unmatched()` — that is
+`authenticated()` — when a policy returned `null`. A broken policy would therefore have admitted any
+logged-in caller to a route that may have demanded an admin scope. A `null` answer is a policy defect,
+not an undeclared route, and now denies outright.
+
+**Still open:** obligations 4 and 5 — the Community security `Subsystem` binding
+`KernelProviders.SECURITY_PROVIDER`, the dispatcher reading the slot instead of `SECURE_PATH_PREFIX`,
+removal of the unreachable `isPublicPath` allowlist, and the `security.md` / `http.md` /
+`bootstrap.md` updates that describe the wired behaviour.
 unmatched-route path as mandatory cases — a suite that only proves admission would pass against an
 implementation that admits everything. `ExerisArchitectureTest` green. `security.md`, `http.md` and
 `bootstrap.md` updated in the implementing slice — not before it, since they describe what the kernel

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/KernelTierDirectionArchitectureTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/KernelTierDirectionArchitectureTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the direction of the tier dependency: SPI ← Core ← Community.
+ *
+ * <h2>Why this did not exist</h2>
+ * <p>The Wall is the repository's most load-bearing structural invariant, and until this class its
+ * <em>direction</em> was enforced by nothing. {@code ExerisArchitectureTest} carries thirteen rules,
+ * every one of them about what the SPI may reference — none about Core reaching down into a driver.
+ * That is not an oversight in the rules so much as a consequence of where they live:
+ * {@code exeris-kernel-tck} depends only on the SPI, so no Core or Community class is ever on its
+ * analysis classpath, and a rule written there naming {@code eu.exeris.kernel.core..} would match
+ * zero classes and pass on the empty set forever.
+ *
+ * <p>This module is the first point in the reactor where SPI, Core and Community are all visible at
+ * once, so it is the only place the direction can actually be checked. Same reasoning, and same
+ * placement, as {@code CommunitySchedulingArchitectureTest}.
+ *
+ * <h2>What "direction" means here</h2>
+ * <p>Community depending on Core is intended, not tolerated — the drivers are built on the
+ * driver-agnostic engine, and {@code exeris-kernel-community/pom.xml} declares that edge. What must
+ * never happen is the reverse: Core reaching into a concrete driver would make the engine
+ * driver-specific, which is the whole thing the SPI exists to prevent.
+ */
+@AnalyzeClasses(packages = "eu.exeris.kernel")
+class KernelTierDirectionArchitectureTest {
+
+    @ArchTest
+    static void allThreeTiersAreOnTheAnalysisClasspath(JavaClasses classes) {
+        // Both rules below are "no classes ... should ...", which pass trivially when the subject
+        // package is absent. Without this check a classpath change could silence them and every
+        // build would stay green — the exact failure mode that kept the direction unguarded.
+        assertThat(countIn(classes, "eu.exeris.kernel.spi"))
+                .as("SPI classes must be analysable").isGreaterThan(0);
+        assertThat(countIn(classes, "eu.exeris.kernel.core"))
+                .as("Core classes must be analysable — otherwise coreDoesNotDependOnCommunity is vacuous")
+                .isGreaterThan(0);
+        assertThat(countIn(classes, "eu.exeris.kernel.community"))
+                .as("Community classes must be analysable — otherwise there is nothing to depend upon")
+                .isGreaterThan(0);
+    }
+
+    @ArchTest
+    static final ArchRule coreDoesNotDependOnCommunity = noClasses()
+            .that().resideInAPackage("eu.exeris.kernel.core..")
+            .should().dependOnClassesThat().resideInAPackage("eu.exeris.kernel.community..")
+            .because("The Wall: Core is the driver-agnostic engine. A single edge into a concrete "
+                    + "driver makes it driver-specific, and every provider after that one inherits "
+                    + "an assumption nobody declared.");
+
+    @ArchTest
+    static final ArchRule spiDependsOnNeitherCoreNorCommunity = noClasses()
+            .that().resideInAPackage("eu.exeris.kernel.spi..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                    "eu.exeris.kernel.core..", "eu.exeris.kernel.community..")
+            .because("The Wall: the SPI is the constitution both tiers are written against, so it "
+                    + "cannot know either of them.");
+
+    private static long countIn(JavaClasses classes, String packagePrefix) {
+        return classes.stream()
+                .filter(c -> c.getPackageName().startsWith(packagePrefix))
+                .count();
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRoutePolicyTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpRoutePolicyTckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.security.RouteAuthorizationEnforcer;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
+import eu.exeris.kernel.spi.http.RouteRequirement;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.tck.contract.http.AbstractHttpRoutePolicyTck;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Community binding for {@link AbstractHttpRoutePolicyTck} (ADR-061).
+ *
+ * <p>The decision under test is the Core helper the Community dispatcher calls, so this suite pins the
+ * behaviour the HTTP edge actually exhibits rather than a parallel implementation of it.
+ */
+@DisplayName("Community: HTTP route-authorization policy TCK")
+class CommunityHttpRoutePolicyTckTest extends AbstractHttpRoutePolicyTck {
+
+    @Override
+    protected Decision decide(RouteRequirement requirement, PrincipalContext principal) {
+        return map(RouteAuthorizationEnforcer.decide(requirement, principal));
+    }
+
+    @Override
+    protected Decision decide(HttpRoutePolicy policy,
+                              HttpMethod method,
+                              String path,
+                              PrincipalContext principal) {
+        return map(RouteAuthorizationEnforcer.decide(policy, method, path, principal));
+    }
+
+    private static Decision map(RouteAuthorizationEnforcer.RouteDecision decision) {
+        return switch (decision) {
+            case ADMIT -> Decision.ADMIT;
+            case UNAUTHENTICATED -> Decision.UNAUTHENTICATED;
+            case FORBIDDEN -> Decision.FORBIDDEN;
+        };
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RouteAuthorizationEnforcer.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RouteAuthorizationEnforcer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.security;
+
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
+import eu.exeris.kernel.spi.http.RouteRequirement;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+
+/**
+ * Core: the per-request route-authorization decision (ADR-061).
+ *
+ * <h2>Why Core and not the driver</h2>
+ * <p>This is the sibling of {@link RoleCheckEnforcer}, and it sits here for the same reason: ADR-014 §4
+ * places runtime admission integration in Core, so every transport inherits one decision layer rather
+ * than each driver growing its own. It is also what lets a host-runtime binding translate its own rule
+ * DSL onto this decision instead of building a second authorization mechanism beside it.
+ *
+ * <h2>Three outcomes, not two</h2>
+ * <p>{@link RouteDecision} separates "no identity" from "identity without the required scope", because
+ * the caller must map them to different HTTP statuses — {@code 401} and {@code 403} respectively, as
+ * fixed by ADR-012 and documented in {@code security.md}. Collapsing them would tell an authenticated
+ * caller to authenticate again.
+ *
+ * <h2>Allocation</h2>
+ * <p>No allocation on any path: the scope walk uses {@link RouteRequirement#scopeCount()} /
+ * {@link RouteRequirement#scopeAt(int)} rather than an iterator, and the outcome is an enum constant.
+ *
+ * @since 0.11.0
+ */
+public final class RouteAuthorizationEnforcer {
+
+    private RouteAuthorizationEnforcer() {
+        // Static decision helper — never instantiated, mirroring RoleCheckEnforcer.
+    }
+
+    /** Outcome of a route-authorization decision. */
+    public enum RouteDecision {
+        /** The request may proceed to its handler. */
+        ADMIT,
+        /** No verified identity is present; the caller must authenticate ({@code 401}). */
+        UNAUTHENTICATED,
+        /** A verified identity is present but lacks the declared scopes ({@code 403}). */
+        FORBIDDEN
+    }
+
+    /**
+     * Decides whether a request satisfies the requirement its route declares.
+     *
+     * @param requirement what the route demands; must not be {@code null}
+     * @param principal   the verified identity, or {@code null} when none was established
+     * @return the decision
+     */
+    public static RouteDecision decide(RouteRequirement requirement, PrincipalContext principal) {
+        if (requirement.kind() == RouteRequirement.Kind.PERMIT_ALL) {
+            return RouteDecision.ADMIT;
+        }
+        if (principal == null) {
+            return RouteDecision.UNAUTHENTICATED;
+        }
+        return switch (requirement.kind()) {
+            case AUTHENTICATED -> RouteDecision.ADMIT;
+            case ANY_SCOPE -> hasAny(requirement, principal)
+                    ? RouteDecision.ADMIT : RouteDecision.FORBIDDEN;
+            case ALL_SCOPES -> hasAll(requirement, principal)
+                    ? RouteDecision.ADMIT : RouteDecision.FORBIDDEN;
+            // PERMIT_ALL returned above; listed so a new Kind fails the compile rather than
+            // falling through to ADMIT, which would open every route carrying it.
+            case PERMIT_ALL -> RouteDecision.ADMIT;
+        };
+    }
+
+    /**
+     * Resolves the route's requirement through the policy and decides in one step.
+     *
+     * @param policy    the application's route policy; must not be {@code null}
+     * @param method    the request method
+     * @param path      the request path, without query string
+     * @param principal the verified identity, or {@code null} when none was established
+     * @return the decision
+     */
+    public static RouteDecision decide(HttpRoutePolicy policy,
+                                       HttpMethod method,
+                                       String path,
+                                       PrincipalContext principal) {
+        RouteRequirement requirement = policy.requirementFor(method, path);
+        if (requirement == null) {
+            // A policy that breaks the never-null contract is broken, and a broken policy must not
+            // grant. Substituting unmatched() here would admit any authenticated caller — so a policy
+            // bug would hand an ordinary user a route that may have demanded an admin scope. Deny
+            // outright instead, and deny in the shape the caller can act on: no identity is still a
+            // 401, an identity we cannot authorize is a 403.
+            return principal == null ? RouteDecision.UNAUTHENTICATED : RouteDecision.FORBIDDEN;
+        }
+        return decide(requirement, principal);
+    }
+
+    private static boolean hasAny(RouteRequirement requirement, PrincipalContext principal) {
+        for (int i = 0; i < requirement.scopeCount(); i++) {
+            if (principal.hasScope(requirement.scopeAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAll(RouteRequirement requirement, PrincipalContext principal) {
+        for (int i = 0; i < requirement.scopeCount(); i++) {
+            if (!principal.hasScope(requirement.scopeAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpKernelProviders.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpKernelProviders.java
@@ -134,6 +134,19 @@ public final class HttpKernelProviders {
     public static final ScopedValue<HttpRequestBodyDecoderRegistry> HTTP_REQUEST_BODY_DECODER_REGISTRY =
             ScopedValue.newInstance();
 
+    /**
+     * Optional per-route authorization policy ({@link HttpRoutePolicy}), supplied by the application.
+     *
+     * <p>Bound during HTTP bootstrap when the application declares one (ADR-061). The transport
+     * admission path reads this slot to decide whether a request may reach its handler. When unbound,
+     * no per-route requirement is applied — the kernel behaves as it did before 0.11, which is why an
+     * application that declares nothing sees no change. Use {@link #httpRoutePolicy()} to read
+     * defensively.
+     *
+     * @since 0.11.0
+     */
+    public static final ScopedValue<HttpRoutePolicy> HTTP_ROUTE_POLICY = ScopedValue.newInstance();
+
     private HttpKernelProviders() {
         // Static ScopedValue slots only — never instantiated.
     }
@@ -216,6 +229,18 @@ public final class HttpKernelProviders {
     public static Optional<HttpRequestBodyDecoderRegistry> httpRequestBodyDecoderRegistry() {
         return HTTP_REQUEST_BODY_DECODER_REGISTRY.isBound()
                 ? Optional.of(HTTP_REQUEST_BODY_DECODER_REGISTRY.get())
+                : Optional.empty();
+    }
+
+    /**
+     * Returns the optional per-route authorization policy, if the application bound one.
+     *
+     * @return an {@link Optional} containing the policy when bound, or empty otherwise
+     * @since 0.11.0
+     */
+    public static Optional<HttpRoutePolicy> httpRoutePolicy() {
+        return HTTP_ROUTE_POLICY.isBound()
+                ? Optional.of(HTTP_ROUTE_POLICY.get())
                 : Optional.empty();
     }
 }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRoutePolicy.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRoutePolicy.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.http;
+
+import java.util.Set;
+
+/**
+ * SPI: the application's statement of what each of its HTTP routes requires (ADR-061).
+ *
+ * <h2>Why this exists</h2>
+ * <p>Before 0.11 the kernel's admission gate was steered by constants compiled into the Community
+ * driver — a {@code /secure} path prefix and two literal scope names. The gate worked, but no
+ * application could address it: a route policy is a property of the application's own URL space, and
+ * there was no way to state one. Everything outside the prefix reached its handler with no identity
+ * bound at all.
+ *
+ * <h2>Contract</h2>
+ * <p>{@link #requirementFor(HttpMethod, String)} is called once per request, before the handler runs.
+ * It must be:
+ * <ul>
+ *   <li><b>Total.</b> Every {@code (method, path)} pair gets an answer, and never {@code null} —
+ *       see {@link #unmatched()} for how to say "nothing declared for this route", which is a
+ *       decision, not an absence. A {@code null} answer is treated as a policy defect and denies
+ *       the request outright; it is <em>not</em> read as {@link #unmatched()}, because that would
+ *       let a broken policy admit any authenticated caller to a route it never described.</li>
+ *   <li><b>Pure and thread-safe.</b> It runs on the admission path of every request, concurrently.</li>
+ *   <li><b>Allocation-free.</b> Return pre-built {@link RouteRequirement} instances. Building one per
+ *       request puts allocation on the admission path, which the performance contract does not allow
+ *       for the neighbouring RBAC decision either (ADR-014 §5).</li>
+ * </ul>
+ *
+ * <h2>The unmatched route is the dangerous case</h2>
+ * <p>A policy that declares rules for {@code /api/orders/**} says nothing about {@code /api/internal}
+ * — and what happens to that request is the whole security posture. This contract does not choose for
+ * you, but it does force you to choose: {@link #unmatched()} names the two options, and a policy must
+ * return one of them rather than leaving the question implicit. Returning
+ * {@link RouteRequirement#permitAll()} for unmatched routes is fail-open and must be a decision the
+ * application makes knowingly.
+ *
+ * <h2>Binding</h2>
+ * <p>Supplied by the application and bound into {@link HttpKernelProviders#HTTP_ROUTE_POLICY}. When
+ * the slot is unbound, the kernel applies no per-route requirement — behaviour matches a kernel with
+ * no policy at all. Read defensively via {@link HttpKernelProviders#httpRoutePolicy()}.
+ *
+ * @since 0.11.0
+ */
+@FunctionalInterface
+public interface HttpRoutePolicy {
+
+    /**
+     * Returns what the given route requires of the caller.
+     *
+     * @param method the request method; never {@code null}
+     * @param path   the request path, without query string; never {@code null}
+     * @return the requirement; never {@code null}
+     */
+    RouteRequirement requirementFor(HttpMethod method, String path);
+
+    /**
+     * Documents the two answers available for a route the policy does not describe.
+     *
+     * <p>This is not a factory to call at request time — it is here so the choice has a name and a
+     * place in the contract. {@link RouteRequirement#authenticated()} is fail-closed: an undeclared
+     * route still demands identity. {@link RouteRequirement#permitAll()} is fail-open: an undeclared
+     * route is public, which is how a forgotten endpoint becomes an unauthenticated one.
+     *
+     * @return the fail-closed answer, which is the one to prefer when unsure
+     */
+    static RouteRequirement unmatched() {
+        return RouteRequirement.authenticated();
+    }
+
+    /**
+     * A policy that requires nothing of any route.
+     *
+     * <p>Equivalent to leaving the slot unbound, and useful as an explicit "this deployment declares
+     * no route policy" rather than an omission a reader has to infer.
+     *
+     * @return a policy answering {@link RouteRequirement#permitAll()} everywhere
+     */
+    static HttpRoutePolicy permitAll() {
+        return (method, path) -> RouteRequirement.permitAll();
+    }
+
+    /**
+     * A policy requiring a verified identity on every route.
+     *
+     * @return a policy answering {@link RouteRequirement#authenticated()} everywhere
+     */
+    static HttpRoutePolicy authenticated() {
+        return (method, path) -> RouteRequirement.authenticated();
+    }
+
+    /**
+     * A policy requiring a verified identity holding at least one of the given scopes on every route.
+     *
+     * <p>The blunt instrument: useful for a service whose entire surface is one permission, and as a
+     * starting point to narrow from.
+     *
+     * @param scopes the accepted scopes; must be non-null and non-empty
+     * @return a policy answering the same scope requirement everywhere
+     */
+    static HttpRoutePolicy requiringAnyScope(Set<String> scopes) {
+        RouteRequirement requirement = RouteRequirement.requiringAnyScope(scopes);
+        return (method, path) -> requirement;
+    }
+}

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/RouteRequirement.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/RouteRequirement.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.spi.http;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * SPI: what a route demands of the caller before a handler may run (ADR-061).
+ *
+ * <h2>Three shapes, deliberately</h2>
+ * <ul>
+ *   <li>{@link #permitAll()} — no identity required. The handler runs without a
+ *       {@code PrincipalContext} bound.</li>
+ *   <li>{@link #authenticated()} — a verified identity is required; nothing more.</li>
+ *   <li>{@link #requiringAnyScope(Set)} / {@link #requiringAllScopes(Set)} — a verified identity carrying the
+ *       named OAuth2 scopes.</li>
+ * </ul>
+ *
+ * <p>Roles are deliberately absent. Scopes are what the transport edge checks — {@code security.md}
+ * states it plainly: "scopes are used for HTTP admission control and Bearer token permission checks",
+ * while roles resolve through {@code @RequiresRole} at the method level, against a build-time
+ * {@code methodId} the kernel cannot derive from a URL. Offering a role predicate here would invite
+ * callers to express at the edge something the edge cannot answer.
+ *
+ * <h2>Allocation</h2>
+ * <p>Instances are immutable and meant to be built once, at policy-declaration time, and returned
+ * repeatedly. A {@link HttpRoutePolicy} that constructs a requirement per request moves allocation
+ * onto the admission path and breaks the performance contract ADR-014 §5 fixes for the neighbouring
+ * RBAC decision. {@link #permitAll()} and {@link #authenticated()} return shared constants.
+ *
+ * @since 0.11.0
+ */
+// TooManyMethods: ten methods on an immutable value carrier — four factories (one per shape the
+// contract offers), two accessors that exist specifically to keep the decision path allocation-free,
+// kind(), and the three Object overrides a Valhalla-ready carrier is obliged to define. Splitting the
+// type to satisfy the count would put the shapes and the reads in different places for no gain.
+@SuppressWarnings("PMD.TooManyMethods")
+public final class RouteRequirement {
+
+    private static final RouteRequirement PERMIT_ALL = new RouteRequirement(Kind.PERMIT_ALL, Set.of());
+    private static final RouteRequirement AUTHENTICATED =
+            new RouteRequirement(Kind.AUTHENTICATED, Set.of());
+
+    /** How the declared scopes are matched. */
+    public enum Kind {
+        /** No identity required. */
+        PERMIT_ALL,
+        /** Verified identity required; no scope check. */
+        AUTHENTICATED,
+        /** Verified identity holding at least one of the declared scopes. */
+        ANY_SCOPE,
+        /** Verified identity holding every declared scope. */
+        ALL_SCOPES
+    }
+
+    private final Kind kind;
+    private final Set<String> scopes;
+    private final String[] scopeArray;
+
+    private RouteRequirement(Kind kind, Set<String> scopes) {
+        this.kind = kind;
+        this.scopes = scopes;
+        // Pre-flattened so the decision path iterates an array instead of an iterator over a Set.
+        this.scopeArray = scopes.toArray(new String[0]);
+    }
+
+    /**
+     * A route open to unauthenticated callers.
+     *
+     * @return the shared permit-all requirement
+     */
+    public static RouteRequirement permitAll() {
+        return PERMIT_ALL;
+    }
+
+    /**
+     * A route requiring a verified identity and nothing further.
+     *
+     * @return the shared authenticated-only requirement
+     */
+    public static RouteRequirement authenticated() {
+        return AUTHENTICATED;
+    }
+
+    /**
+     * A route requiring a verified identity holding at least one of {@code requiredScopes}.
+     *
+     * @param requiredScopes the accepted scopes; must be non-null and non-empty
+     * @return the requirement
+     * @throws IllegalArgumentException if {@code requiredScopes} is empty — an empty any-of set can
+     *                                  never be satisfied, so accepting it would silently create a
+     *                                  route nobody can call
+     */
+    public static RouteRequirement requiringAnyScope(Set<String> requiredScopes) {
+        return new RouteRequirement(Kind.ANY_SCOPE, validated(requiredScopes));
+    }
+
+    /**
+     * A route requiring a verified identity holding every one of {@code requiredScopes}.
+     *
+     * @param requiredScopes the required scopes; must be non-null and non-empty
+     * @return the requirement
+     * @throws IllegalArgumentException if {@code requiredScopes} is empty — an empty all-of set is
+     *                                  vacuously true, which would silently downgrade the route to
+     *                                  {@link #authenticated()}
+     */
+    public static RouteRequirement requiringAllScopes(Set<String> requiredScopes) {
+        return new RouteRequirement(Kind.ALL_SCOPES, validated(requiredScopes));
+    }
+
+    /**
+     * Returns how this requirement is evaluated.
+     *
+     * @return the requirement kind; never {@code null}
+     */
+    public Kind kind() {
+        return kind;
+    }
+
+    /**
+     * Returns how many scopes this requirement declares.
+     *
+     * <p>Paired with {@link #scopeAt(int)} so the decision path can walk the scopes without
+     * allocating an iterator, and without the carrier handing out its mutable backing array. This
+     * pair is the only read: a {@code Set}-returning accessor beside it would be a second way to the
+     * same field, and the convenient one is the one that allocates on the admission path.
+     *
+     * @return the scope count; zero for {@link Kind#PERMIT_ALL} and {@link Kind#AUTHENTICATED}
+     */
+    public int scopeCount() {
+        return scopeArray.length;
+    }
+
+    /**
+     * Returns the scope at {@code index}, in no guaranteed order.
+     *
+     * @param index position in {@code [0, scopeCount())}
+     * @return the scope name
+     * @throws ArrayIndexOutOfBoundsException if {@code index} is out of range
+     */
+    public String scopeAt(int index) {
+        return scopeArray[index];
+    }
+
+    private static Set<String> validated(Set<String> requiredScopes) {
+        Objects.requireNonNull(requiredScopes, "requiredScopes must not be null");
+        if (requiredScopes.isEmpty()) {
+            throw new IllegalArgumentException("requiredScopes must not be empty");
+        }
+        return Set.copyOf(requiredScopes);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // Value equality, not identity: permitAll() and authenticated() hand out shared constants, so
+        // a caller comparing requirements with == would be right by accident until someone built an
+        // equivalent one by hand. Valhalla-ready carriers must not be identity-sensitive.
+        return other instanceof RouteRequirement that
+                && kind == that.kind
+                && scopes.equals(that.scopes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, scopes);
+    }
+
+    @Override
+    public String toString() {
+        return "RouteRequirement[" + kind + (scopes.isEmpty() ? "" : ", scopes=" + scopes) + ']';
+    }
+}

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRoutePolicyTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/http/AbstractHttpRoutePolicyTck.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.tck.contract.http;
+
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
+import eu.exeris.kernel.spi.http.RouteRequirement;
+import eu.exeris.kernel.spi.security.ImmutablePrincipal;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TCK: contract for per-route authorization decisions (ADR-061).
+ *
+ * <h2>What this suite is built to catch</h2>
+ * <p>A route-authorization implementation that admits everything passes any suite that only checks
+ * admission. So the mandatory cases here are the ones where the answer is <em>no</em>: the denials, and
+ * the route the policy never described. Every admit case below is paired with the denial that proves
+ * the admit was a decision rather than a default — a binding that returns {@code ADMIT} unconditionally
+ * fails this suite on its first denial case, which is the point.
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@code PERMIT_ALL} admits with no identity — and is the <em>only</em> requirement that does.</li>
+ *   <li>Every other requirement denies as {@code UNAUTHENTICATED} when no identity is present. That
+ *       distinction is load-bearing: the caller maps it to {@code 401}, not {@code 403}.</li>
+ *   <li>{@code AUTHENTICATED} admits any verified identity, whatever scopes it carries.</li>
+ *   <li>{@code ANY_SCOPE} admits on intersection, denies as {@code FORBIDDEN} on none.</li>
+ *   <li>{@code ALL_SCOPES} admits only on full coverage; a partial match is {@code FORBIDDEN}.</li>
+ *   <li>An identity that lacks the scope is {@code FORBIDDEN}, never {@code UNAUTHENTICATED} —
+ *       telling an authenticated caller to authenticate again is a contract violation, not a nuance.</li>
+ *   <li>A policy returning {@code null} denies rather than propagating a failure into the transport.</li>
+ * </ul>
+ *
+ * <h2>How to use</h2>
+ * <pre>{@code
+ * class CommunityHttpRoutePolicyTckTest extends AbstractHttpRoutePolicyTck {
+ *     @Override
+ *     protected Decision decide(RouteRequirement requirement, PrincipalContext principal) {
+ *         return switch (RouteAuthorizationEnforcer.decide(requirement, principal)) {
+ *             case ADMIT -> Decision.ADMIT;
+ *             case UNAUTHENTICATED -> Decision.UNAUTHENTICATED;
+ *             case FORBIDDEN -> Decision.FORBIDDEN;
+ *         };
+ *     }
+ * }
+ * }</pre>
+ *
+ * @since 0.11.0
+ */
+@DisplayName("TCK: HTTP route-authorization policy (ADR-061)")
+public abstract class AbstractHttpRoutePolicyTck {
+
+    /** Binding-neutral mirror of the decision outcome, so the TCK does not depend on Core. */
+    public enum Decision {
+        /** Request may proceed. */
+        ADMIT,
+        /** No verified identity — maps to {@code 401}. */
+        UNAUTHENTICATED,
+        /** Verified identity lacking the declared scopes — maps to {@code 403}. */
+        FORBIDDEN
+    }
+
+    private static final String READ = "orders:read";
+    private static final String WRITE = "orders:write";
+    private static final String UNRELATED = "billing:read";
+
+    /**
+     * Decides one request against one requirement, using the binding under test.
+     *
+     * @param requirement what the route declares
+     * @param principal   the verified identity, or {@code null} when none was established
+     * @return the decision
+     */
+    protected abstract Decision decide(RouteRequirement requirement, PrincipalContext principal);
+
+    /**
+     * Resolves a requirement through a policy and decides, using the binding under test.
+     *
+     * @param policy    the policy to consult
+     * @param method    the request method
+     * @param path      the request path
+     * @param principal the verified identity, or {@code null}
+     * @return the decision
+     */
+    protected abstract Decision decide(HttpRoutePolicy policy,
+                                       HttpMethod method,
+                                       String path,
+                                       PrincipalContext principal);
+
+    @Nested
+    @DisplayName("Denials — the cases an admit-everything implementation fails")
+    class Denials {
+
+        @Test
+        @DisplayName("no identity is UNAUTHENTICATED, not FORBIDDEN, for every non-public requirement")
+        void noIdentityIsUnauthenticated() {
+            assertThat(decide(RouteRequirement.authenticated(), null))
+                    .as("the caller maps this to 401; returning FORBIDDEN would send a 403 to someone "
+                            + "who has not been asked to authenticate yet")
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+            assertThat(decide(RouteRequirement.requiringAnyScope(Set.of(READ)), null))
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+            assertThat(decide(RouteRequirement.requiringAllScopes(Set.of(READ, WRITE)), null))
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+        }
+
+        @Test
+        @DisplayName("an identity without any required scope is FORBIDDEN, not UNAUTHENTICATED")
+        void wrongScopeIsForbidden() {
+            PrincipalContext principal = principalWith(UNRELATED);
+
+            assertThat(decide(RouteRequirement.requiringAnyScope(Set.of(READ, WRITE)), principal))
+                    .as("the identity is verified; telling it to authenticate again is a contract "
+                            + "violation and an infinite retry loop for a well-behaved client")
+                    .isEqualTo(Decision.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("ALL_SCOPES denies a partial match")
+        void partialMatchIsForbiddenUnderAllScopes() {
+            PrincipalContext principal = principalWith(READ);
+
+            assertThat(decide(RouteRequirement.requiringAllScopes(Set.of(READ, WRITE)), principal))
+                    .as("holding one of two required scopes is not holding both — an implementation "
+                            + "that reads ALL_SCOPES as ANY_SCOPE passes every other case in this suite")
+                    .isEqualTo(Decision.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("a principal carrying no scopes at all is denied by any scope requirement")
+        void scopelessPrincipalIsForbidden() {
+            PrincipalContext principal = principalWith();
+
+            assertThat(decide(RouteRequirement.requiringAnyScope(Set.of(READ)), principal))
+                    .isEqualTo(Decision.FORBIDDEN);
+            assertThat(decide(RouteRequirement.requiringAllScopes(Set.of(READ)), principal))
+                    .isEqualTo(Decision.FORBIDDEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("Admissions — paired with the denial that proves each is a decision")
+    class Admissions {
+
+        @Test
+        @DisplayName("PERMIT_ALL admits without identity, and is the only requirement that does")
+        void permitAllAdmitsAnonymously() {
+            assertThat(decide(RouteRequirement.permitAll(), null)).isEqualTo(Decision.ADMIT);
+            assertThat(decide(RouteRequirement.authenticated(), null))
+                    .as("the control: if this also admitted, the case above would prove nothing")
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+        }
+
+        @Test
+        @DisplayName("AUTHENTICATED admits any verified identity regardless of scopes")
+        void authenticatedIgnoresScopes() {
+            assertThat(decide(RouteRequirement.authenticated(), principalWith())).isEqualTo(Decision.ADMIT);
+            assertThat(decide(RouteRequirement.authenticated(), principalWith(UNRELATED)))
+                    .isEqualTo(Decision.ADMIT);
+        }
+
+        @Test
+        @DisplayName("ANY_SCOPE admits on intersection")
+        void anyScopeAdmitsOnIntersection() {
+            assertThat(decide(RouteRequirement.requiringAnyScope(Set.of(READ, WRITE)), principalWith(WRITE)))
+                    .isEqualTo(Decision.ADMIT);
+        }
+
+        @Test
+        @DisplayName("ALL_SCOPES admits on full coverage, and extra scopes do not interfere")
+        void allScopesAdmitsOnFullCoverage() {
+            assertThat(decide(RouteRequirement.requiringAllScopes(Set.of(READ, WRITE)),
+                    principalWith(READ, WRITE, UNRELATED)))
+                    .isEqualTo(Decision.ADMIT);
+        }
+    }
+
+    @Nested
+    @DisplayName("The route the policy never described")
+    class UnmatchedRoute {
+
+        @Test
+        @DisplayName("a policy's answer for an undeclared route is honoured, whichever way it decides")
+        void undeclaredRouteFollowsThePolicy() {
+            HttpRoutePolicy failClosed = (method, path) ->
+                    "/api/orders".equals(path) ? RouteRequirement.permitAll() : HttpRoutePolicy.unmatched();
+
+            assertThat(decide(failClosed, HttpMethod.GET, "/api/orders", null))
+                    .isEqualTo(Decision.ADMIT);
+            assertThat(decide(failClosed, HttpMethod.GET, "/api/internal", null))
+                    .as("the undeclared route is the whole security posture; a kernel that silently "
+                            + "admitted it would make every declared rule decorative")
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+        }
+
+        @Test
+        @DisplayName("HttpRoutePolicy.unmatched() is fail-closed")
+        void unmatchedDefaultIsFailClosed() {
+            assertThat(decide(HttpRoutePolicy.unmatched(), null))
+                    .as("the contract names this the answer to prefer when unsure; if it admitted, the "
+                            + "advice would be actively harmful")
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+        }
+
+        @Test
+        @DisplayName("a policy returning null denies outright — it is a defect, not an unmatched route")
+        void nullAnswerDenies() {
+            HttpRoutePolicy broken = (method, path) -> null;
+
+            assertThat(decide(broken, HttpMethod.GET, "/anything", null))
+                    .as("a policy bug must cost one request a 401, not crash a reactor thread")
+                    .isEqualTo(Decision.UNAUTHENTICATED);
+            assertThat(decide(broken, HttpMethod.GET, "/anything", principalWith(READ)))
+                    .as("and it must NOT be read as unmatched(), which is authenticated-only: that "
+                            + "would let a broken policy admit any logged-in caller to a route that "
+                            + "may have demanded an admin scope. A broken policy grants nothing")
+                    .isEqualTo(Decision.FORBIDDEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("Requirement carrier")
+    class Carrier {
+
+        @Test
+        @DisplayName("an empty scope set is rejected at construction, not silently reinterpreted")
+        void emptyScopeSetIsRejected() {
+            assertThatThrownBy(() -> RouteRequirement.requiringAnyScope(Set.of()))
+                    .as("an empty any-of can never be satisfied — accepting it would create a route "
+                            + "nobody can call, and the failure would surface as a mystery 403")
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> RouteRequirement.requiringAllScopes(Set.of()))
+                    .as("an empty all-of is vacuously true — accepting it would silently downgrade the "
+                            + "route to authenticated-only")
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("equality is by value, so shared constants are not the only way to compare")
+        void equalityIsByValue() {
+            assertThat(RouteRequirement.requiringAnyScope(Set.of(READ)))
+                    .isEqualTo(RouteRequirement.requiringAnyScope(Set.of(READ)))
+                    .isNotEqualTo(RouteRequirement.requiringAllScopes(Set.of(READ)));
+        }
+
+        @Test
+        @DisplayName("scopeCount/scopeAt expose exactly the declared scopes")
+        void scopeAccessorsMatchTheDeclaredSet() {
+            RouteRequirement requirement = RouteRequirement.requiringAllScopes(Set.of(READ, WRITE));
+
+            assertThat(requirement.scopeCount()).isEqualTo(2);
+            assertThat(java.util.stream.IntStream.range(0, requirement.scopeCount())
+                    .mapToObj(requirement::scopeAt))
+                    .containsExactlyInAnyOrder(READ, WRITE);
+        }
+    }
+
+    private static PrincipalContext principalWith(String... scopes) {
+        return ImmutablePrincipal.ofScopes(UUID.randomUUID(), Set.of(scopes));
+    }
+}


### PR DESCRIPTION
Implements ADR-061 obligations 1, 2, 6, 7 and 8. **No behaviour change** — nothing reads the slot yet, so the dispatcher still gates on `/secure`.

Split deliberately: the contract shape and the request-path rewiring carry different risk. Part 2 covers obligations 4 and 5 (Community security `Subsystem`, dispatcher reading the slot, removal of the unreachable `isPublicPath` allowlist) plus the subsystem-doc updates. *(Corrected: obligation 3 — rules declared in code, no configuration-file rule surface — is satisfied here by construction, since no such surface is added. `docs/ROADMAP.md` had it right.)*

## What lands

**SPI** — `eu.exeris.kernel.spi.http`
- `HttpRoutePolicy`, bound via `HttpKernelProviders.HTTP_ROUTE_POLICY` with an `Optional` accessor (the ADR-036 `HttpRequestBodyDecoderRegistry` shape). `unmatched()` gives the undeclared-route choice a name — that route *is* the security posture, and leaving it implicit is how a forgotten endpoint becomes an unauthenticated one.
- `RouteRequirement` — `permitAll` / `authenticated` / `requiringAnyScope` / `requiringAllScopes`.

**Roles are deliberately absent from the requirement.** `security.md` fixes scopes as the edge check ("scopes are used for HTTP admission control"), while roles resolve through `@RequiresRole` against a build-time `methodId` the kernel cannot derive from a URL. A role predicate here would invite callers to express at the edge something the edge cannot answer.

**Core** — `RouteAuthorizationEnforcer`, beside `RoleCheckEnforcer` per ADR-014 §4. Three outcomes, not two: `UNAUTHENTICATED` → 401, `FORBIDDEN` → 403. Collapsing them would tell an authenticated caller to authenticate again. Allocation-free: `scopeCount()`/`scopeAt()` walk instead of an iterator.

## The TCK caught a fail-open in my own implementation

`nullAnswerDenies` failed the first version of the enforcer, which substituted `HttpRoutePolicy.unmatched()` — that is, `authenticated()` — when a policy returned `null`. So a **broken policy would have admitted any logged-in caller** to a route that may have demanded an admin scope.

A `null` answer is a policy *defect*, not an undeclared route. It now denies outright: 401 with no identity, 403 with one. Both branches are pinned.

This is what ADR-061's merge gate was written for: mandatory deny + unmatched-route cases, "because a suite that only proves admission would pass against an implementation that admits everything". It found something on first run.

## Unrelated gap found while placing the Core class

Writing new Core code that Community calls made it worth checking what guards that edge. **Nothing did.**

`ExerisArchitectureTest` carries thirteen rules — every one about what the SPI may reference, none about Core reaching down into a driver. That is a consequence of where it lives: `exeris-kernel-tck` depends only on the SPI, so a rule written there naming `eu.exeris.kernel.core..` matches zero classes and, with `allowEmptyShould(true)`, passes on the empty set forever.

`KernelTierDirectionArchitectureTest` lives in `exeris-kernel-community`, the first point in the reactor where all three tiers are visible — same reasoning and placement as the existing `CommunitySchedulingArchitectureTest`. It guards Core-does-not-depend-on-Community and SPI-depends-on-neither.

**Proven non-vacuous by mutation:** inverting the rule to Community-must-not-depend-on-Core fails with **816 violations**, so both tiers really are on the analysis classpath and the detection works. The suite also asserts all three tiers are present, so a classpath change cannot silently make it decorative.

Say the word if you would rather this went in its own PR.

## Suppression

One, justified in place: `PMD.TooManyMethods` on `RouteRequirement` — ten methods on an immutable value carrier (four factories, two accessors that exist to keep the decision path allocation-free, `kind()`, three obligatory `Object` overrides). Splitting the type to satisfy a count would scatter the shapes and the reads for no gain.

PMD also flagged `hasAnyScope`/`hasAllScopes` as predicate-shaped names returning a non-boolean. That one was a real defect, not lint noise — `PrincipalContext.hasAnyScope(...)` *is* a boolean predicate in the same domain. Renamed to `requiringAnyScope`/`requiringAllScopes`.

## Verification

| Gate | Result |
|---|---|
| `mvn clean install` (full reactor, no skip flags → lint-gated) | green |
| `mvn clean verify -P coverage` (what CI runs) | green |
| `ExerisArchitectureTest` | 13/13 |
| Route-policy TCK via Community binding | 14/14 |
| `KernelTierDirectionArchitectureTest` | 3/3, mutation-proven |

One `mvn clean install` hit the known JDK 26 SIGSEGV in G1 during `build-config` — unrelated to this diff; retried clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
