### PR TITLE
feat(security): wire the route policy into HTTP admission (ADR-061, part 2)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2026,24 +2026,33 @@ does. (The stale `security.md:6` note is a separate matter: it stated something 
 so it was corrected with ADR-061 itself.) Release notes record the default-boot behaviour change:
 `/secure/*` stops answering `401` unconditionally once a provider is bound.
 
-**Status (v0.11): PARTIAL — contract and decision landed, wiring pending.**
+**Status (v0.11): DELIVERED.**
 
 `HttpRoutePolicy` + `RouteRequirement` in `eu.exeris.kernel.spi.http` behind
-`HttpKernelProviders.HTTP_ROUTE_POLICY`, and `RouteAuthorizationEnforcer` in
-`eu.exeris.kernel.core.security` beside `RoleCheckEnforcer`, with
-`AbstractHttpRoutePolicyTck` + the Community binding green. No behaviour change yet: nothing reads
-the slot, so the dispatcher still gates on `/secure`.
+`HttpKernelProviders.HTTP_ROUTE_POLICY`, `RouteAuthorizationEnforcer` in `eu.exeris.kernel.core.security`
+beside `RoleCheckEnforcer`, `CommunitySecuritySubsystem` binding `KernelProviders.SECURITY_PROVIDER`,
+and `CommunityHttpRequestDispatcher` resolving the route through the policy instead of
+`SECURE_PATH_PREFIX`. The unreachable `isPublicPath` allowlist is gone with the prefix constants.
 
-The TCK earned its place before the wiring did. Its `nullAnswerDenies` case caught a fail-open in the
-first implementation of the enforcer, which substituted `HttpRoutePolicy.unmatched()` — that is
-`authenticated()` — when a policy returned `null`. A broken policy would therefore have admitted any
-logged-in caller to a route that may have demanded an admin scope. A `null` answer is a policy defect,
-not an undeclared route, and now denies outright.
+Two defects were caught by the gates rather than by review. `AbstractHttpRoutePolicyTck`'s
+`nullAnswerDenies` case failed the first enforcer, which substituted `HttpRoutePolicy.unmatched()` —
+that is `authenticated()` — for a `null` policy answer, so a broken policy would have admitted any
+logged-in caller to a route that may have demanded an admin scope. And placing new Core code that
+Community calls surfaced that **nothing guarded the tier direction at all**: `ExerisArchitectureTest`
+lives in `exeris-kernel-tck`, which has only the SPI on its analysis classpath, so a
+Core-must-not-depend-on-Community rule written there would have matched zero classes and passed
+forever. `KernelTierDirectionArchitectureTest` now holds that line from `exeris-kernel-community`,
+mutation-proven non-vacuous.
 
-**Still open:** obligations 4 and 5 — the Community security `Subsystem` binding
-`KernelProviders.SECURITY_PROVIDER`, the dispatcher reading the slot instead of `SECURE_PATH_PREFIX`,
-removal of the unreachable `isPublicPath` allowlist, and the `security.md` / `http.md` /
-`bootstrap.md` updates that describe the wired behaviour.
+**Behaviour change:** `/secure/*` no longer answers `401` unconditionally, because a provider is now
+bound. An application that declares no policy gets permit-all everywhere, which is what the kernel did
+before — and which means **declaring nothing means no edge authorization**. The subsystem docs say so
+rather than implying that installing the kernel confers protection.
+
+**Adjacent finding, not fixed here:** `CommunityClaimsMapper:52` assigns every authenticated principal
+exactly `Set.of("security:read")` and never reads the token's `scope` claim, so `security:write` is a
+scope nothing can grant. That predates this work and is the claims mapper's contract, not the route
+policy's; it needs its own slice.
 
 ---
 

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -37,6 +37,10 @@ Memory) are fully operational before higher‑level logic (Transport, Flow) is a
 
 - **Virtual Thread Parallelization**  
   L1 and L2 subsystems (Security, Persistence, Graph, Transport) initialize in parallel using `StructuredTaskScope`.
+  > **Note (0.11):** Community ships `CommunitySecuritySubsystem` from 0.11 onward. Before that this
+  > document described a Security subsystem the Community module did not have, so
+  > `KernelProviders.SECURITY_PROVIDER` was bound by nothing and the Citadel path was unreachable
+  > in a default boot. Closed as drift repair by ADR-061.
 
 - **Fail‑Fast vs Degrade**  
   Configurable failure policies:

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -199,6 +199,17 @@ shape: optional, application-bound, empty meaning "none supplied".
 same reason the decoder registry is captured there. The admission path runs on reactor threads that
 are not structured forks of the boot scope, so a request-time read would see an unbound slot.
 
+**Operational trap when adopting a policy.** Before 0.11 the driver's own `/health`, `/health/live`,
+`/health/ready` and `/db/ping` routes were unconditionally reachable — they did not start with
+`/secure`, so the admission test was always false for them. They are now ordinary routes: a policy
+with a fail-closed unmatched default denies them, and an orchestrator's liveness and readiness probes
+start failing against a perfectly healthy process. This bites the deployment that binds a policy but
+**no** `HTTP_SERVER_HANDLER`, since that is exactly when the driver installs its built-in health
+handler (`CommunityHttpSubsystem` falls back to `CommunityHttpHealthRoutes` only when the application
+supplied no handler). Declare those paths `permitAll()`. The kernel deliberately does not exempt them:
+ADR-061 obligation 5 rules that a driver-local notion of "public" would be a competing answer to a
+question the policy now owns.
+
 The policy answers `RouteRequirement` (`permitAll` / `authenticated` / `requiringAnyScope` /
 `requiringAllScopes`); `RouteAuthorizationEnforcer` in Core turns that plus the bound
 `PrincipalContext` into admit / `401` / `403`. Roles are not expressible here — see

--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -189,6 +189,23 @@ the sink transfers the buffer to the returned `HttpEncodedBody` on success and r
 failure path. The mirror-image `CommunityJsonRequestBodyEncoder` (client request bodies) streams
 through the same `SegmentSink` with identical ownership semantics.
 
+### Route authorization (since 0.11, ADR-061)
+
+`HttpKernelProviders.HTTP_ROUTE_POLICY` carries an application-supplied `HttpRoutePolicy`, read
+defensively via `httpRoutePolicy()`. The slot follows the ADR-036 `HTTP_REQUEST_BODY_DECODER_REGISTRY`
+shape: optional, application-bound, empty meaning "none supplied".
+
+`CommunityHttpRequestProcessor` captures it at construction rather than reading it per request — the
+same reason the decoder registry is captured there. The admission path runs on reactor threads that
+are not structured forks of the boot scope, so a request-time read would see an unbound slot.
+
+The policy answers `RouteRequirement` (`permitAll` / `authenticated` / `requiringAnyScope` /
+`requiringAllScopes`); `RouteAuthorizationEnforcer` in Core turns that plus the bound
+`PrincipalContext` into admit / `401` / `403`. Roles are not expressible here — see
+[`security.md`](security.md) for why the edge checks scopes and `@RequiresRole` stays at the method.
+
+---
+
 ### HTTP/2 stream admission (since v0.8 Sprint 5, HTTP-112)
 
 `Http2SessionContext.admitClientStreamId(int)` enforces two RFC 7540 invariants that the Community h2c session previously did not validate:

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -166,6 +166,8 @@ public class SecurityInterceptor {
   cross-tenant access and asserting row count is zero.
 - Fail-Closed: invalid token at transport edge results in `EX-SEC-2002` and zero downstream calls.
 - Community HTTP admission semantics (implemented): missing/invalid token maps to HTTP `401`; authenticated principal without required scope maps to HTTP `403`; steady-state scope checks remain membership tests over immutable in-memory scope sets.
+- **Which routes require what is declared by the application, not by the driver (since 0.11, ADR-061).** `CommunityHttpRequestDispatcher` no longer gates on a `/secure` path prefix with the literal scopes `security:read` / `security:write` compiled into it. It resolves the route through `HttpRoutePolicy` (bound at `HttpKernelProviders.HTTP_ROUTE_POLICY`) and hands the resulting `RouteRequirement` to `RouteAuthorizationEnforcer` in Core, so every transport shares one decision layer. With no policy bound the requirement is permit-all and the kernel behaves as it did before — declaring nothing changes nothing, which also means an application that never declares a policy has **no edge authorization**. The unmatched route is the application's call: `HttpRoutePolicy.unmatched()` is fail-closed, and a policy returning `null` is treated as a defect and denies outright rather than being read as unmatched.
+- `KernelProviders.SECURITY_PROVIDER` is bound by `CommunitySecuritySubsystem` (since 0.11). Before that it was bound by nothing, so the interceptor was never constructed and the whole Citadel path was unreachable in a default boot.
 
 ---
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/AbstractSingleProviderSubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/AbstractSingleProviderSubsystem.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
+
+/**
+ * A subsystem whose whole job is: discover one provider, bind it into one slot.
+ *
+ * <p>Security and crypto are exactly that, and were exactly the same twenty lines apart from the type
+ * names — extracting only the {@code ServiceLoader} call left the skeleton behind and made the
+ * duplication ratio worse, because the file got shorter while the repeated part did not. What varies
+ * between the two is the contract type, the slot, and the DAG position; everything else is this class.
+ *
+ * <p>Persistence and HTTP deliberately do not extend it. They build engines and own lifecycles that
+ * are not "one provider, one slot", and bending them to fit would trade honest difference for a
+ * shared shape that lies.
+ *
+ * @param <T> the SPI provider contract this subsystem discovers
+ */
+/* default */ abstract class AbstractSingleProviderSubsystem<T> extends AbstractCommunitySubsystem {
+
+    private T provider;
+
+    /**
+     * Returns the SPI contract to discover through {@link java.util.ServiceLoader}.
+     *
+     * @return the contract type
+     */
+    protected abstract Class<T> contract();
+
+    /**
+     * Returns the provider's priority accessor, used to pick a winner deterministically.
+     *
+     * @return the priority reader
+     */
+    protected abstract ToIntFunction<T> priority();
+
+    /**
+     * Returns the kernel slot the discovered provider is bound into.
+     *
+     * @return the target slot
+     */
+    protected abstract ScopedValue<T> slot();
+
+    /**
+     * Returns the discovered provider, or {@code null} when none is on the classpath.
+     *
+     * @return the provider or {@code null}
+     */
+    protected final T provider() {
+        return provider;
+    }
+
+    @Override
+    public final void initialize() {
+        provider = CommunityProviderDiscovery.highestPriority(contract(), priority());
+    }
+
+    @Override
+    public void start() {
+        markRunning(provider != null);
+    }
+
+    @Override
+    public void stop() {
+        markRunning(false);
+    }
+
+    /**
+     * Binds the provider, or leaves the slot untouched when none was found.
+     *
+     * <p>Absence is a configuration, not a failure. Leaving the slot unbound is what makes the readers
+     * downstream fail closed — binding a placeholder would turn "no provider" into "a provider that
+     * says yes to nothing in particular", which is far harder to diagnose.
+     *
+     * @return the carrier enricher for this subsystem
+     */
+    @Override
+    public final UnaryOperator<ScopedValue.Carrier> providerBindings() {
+        if (provider == null) {
+            return defaultProviderBindings();
+        }
+        return CommunityCarrierBindings.operator(CommunityCarrierBindings.binding(slot(), provider));
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityCryptoSubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityCryptoSubsystem.java
@@ -12,9 +12,7 @@ import eu.exeris.kernel.spi.bootstrap.BootstrapPhase;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.crypto.KernelCryptoProvider;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.function.UnaryOperator;
 
 @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
@@ -39,12 +37,8 @@ final class CommunityCryptoSubsystem extends AbstractCommunitySubsystem {
 
     @Override
     public void initialize() {
-        cryptoProvider = ServiceLoader.load(KernelCryptoProvider.class)
-                .stream()
-                .map(ServiceLoader.Provider::get)
-                .max(Comparator.comparingInt(KernelCryptoProvider::priority)
-                        .thenComparing(provider -> provider.getClass().getName()))
-                .orElse(null);
+        cryptoProvider = CommunityProviderDiscovery.highestPriority(
+                KernelCryptoProvider.class, KernelCryptoProvider::priority);
     }
 
     @Override

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityCryptoSubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityCryptoSubsystem.java
@@ -13,12 +13,10 @@ import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.crypto.KernelCryptoProvider;
 
 import java.util.List;
-import java.util.function.UnaryOperator;
+import java.util.function.ToIntFunction;
 
 @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
-final class CommunityCryptoSubsystem extends AbstractCommunitySubsystem {
-
-    private KernelCryptoProvider cryptoProvider;
+final class CommunityCryptoSubsystem extends AbstractSingleProviderSubsystem<KernelCryptoProvider> {
 
     @Override
     public String name() {
@@ -36,20 +34,25 @@ final class CommunityCryptoSubsystem extends AbstractCommunitySubsystem {
     }
 
     @Override
-    public void initialize() {
-        cryptoProvider = CommunityProviderDiscovery.highestPriority(
-                KernelCryptoProvider.class, KernelCryptoProvider::priority);
+    protected Class<KernelCryptoProvider> contract() {
+        return KernelCryptoProvider.class;
     }
 
     @Override
-    public void start() {
-        markRunning(cryptoProvider != null);
+    protected ToIntFunction<KernelCryptoProvider> priority() {
+        return KernelCryptoProvider::priority;
     }
 
+    @Override
+    protected ScopedValue<KernelCryptoProvider> slot() {
+        return KernelProviders.CRYPTO_PROVIDER;
+    }
+
+    /** Crypto is the one that owns a native handle, so it closes on the way down. */
     @Override
     public void stop() {
-        markRunning(false);
-        if (cryptoProvider instanceof AutoCloseable closeable) {
+        super.stop();
+        if (provider() instanceof AutoCloseable closeable) {
             try {
                 closeable.close();
             } catch (InterruptedException _) {
@@ -58,15 +61,5 @@ final class CommunityCryptoSubsystem extends AbstractCommunitySubsystem {
                 // best effort close, ignore any exception
             }
         }
-    }
-
-    @Override
-    public UnaryOperator<ScopedValue.Carrier> providerBindings() {
-        if (cryptoProvider == null) {
-            return defaultProviderBindings();
-        }
-        return CommunityCarrierBindings.operator(
-                CommunityCarrierBindings.binding(KernelProviders.CRYPTO_PROVIDER, cryptoProvider)
-        );
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityProviderDiscovery.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityProviderDiscovery.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import java.util.Comparator;
+import java.util.ServiceLoader;
+import java.util.function.ToIntFunction;
+
+/**
+ * Picks one provider out of everything {@link ServiceLoader} finds.
+ *
+ * <p>Highest {@code priority()} wins; ties break on fully-qualified class name so two providers at the
+ * same tier resolve identically on every JVM and every classpath ordering. That determinism is the
+ * point — a boot that picked a different driver depending on jar order would be diagnosed as anything
+ * but what it is.
+ */
+final class CommunityProviderDiscovery {
+
+    private CommunityProviderDiscovery() {
+    }
+
+    /**
+     * Returns the highest-priority provider of {@code contract}, or {@code null} when none is present.
+     *
+     * <p>Absence is a configuration, not a failure: the caller decides whether an unbound slot is
+     * acceptable for its subsystem.
+     *
+     * @param contract the SPI type to discover
+     * @param priority reads the provider's priority
+     * @param <T>      the provider type
+     * @return the selected provider, or {@code null}
+     */
+    /* default */ static <T> T highestPriority(Class<T> contract, ToIntFunction<T> priority) {
+        return ServiceLoader.load(contract)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .max(Comparator.comparingInt(priority)
+                        .thenComparing(provider -> provider.getClass().getName()))
+                .orElse(null);
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
@@ -12,9 +12,7 @@ import eu.exeris.kernel.spi.bootstrap.BootstrapPhase;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.security.SecurityProvider;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.function.UnaryOperator;
 
 /**
@@ -61,12 +59,8 @@ final class CommunitySecuritySubsystem extends AbstractCommunitySubsystem {
 
     @Override
     public void initialize() {
-        securityProvider = ServiceLoader.load(SecurityProvider.class)
-                .stream()
-                .map(ServiceLoader.Provider::get)
-                .max(Comparator.comparingInt(SecurityProvider::priority)
-                        .thenComparing(provider -> provider.getClass().getName()))
-                .orElse(null);
+        securityProvider = CommunityProviderDiscovery.highestPriority(
+                SecurityProvider.class, SecurityProvider::priority);
     }
 
     @Override

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.spi.bootstrap.BootstrapPhase;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.security.SecurityProvider;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.UnaryOperator;
+
+/**
+ * Binds the discovered {@link SecurityProvider} into {@link KernelProviders#SECURITY_PROVIDER}.
+ *
+ * <h2>Why this did not exist</h2>
+ * <p>{@code bootstrap.md} has always placed Security among the L1 subsystems — it appears in the
+ * parallel-init description, in the {@code scope.fork(() -> security.start())} sketch, and in the
+ * DAG-cycle diagnostic example. Community shipped every other subsystem in that list and not this one.
+ * {@code CommunitySecurityProvider} existed and was {@code ServiceLoader}-registered, but nothing bound
+ * it, so {@code CommunityHttpRequestProcessor} always saw an unbound slot, built no
+ * {@code SecurityInterceptor}, and the whole Citadel path — token authentication, role-mask population,
+ * {@code StorageContextBridge} derivation — was unreachable in a default boot. ADR-061 treats closing
+ * that as drift repair against the bootstrap contract rather than a new decision.
+ *
+ * <h2>Absence is not failure</h2>
+ * <p>A deployment with no {@code SecurityProvider} on the classpath is a legitimate configuration —
+ * an internal service behind a mesh, say — so discovery finding nothing leaves the subsystem not
+ * running rather than failing the boot. What it must never do is bind a placeholder: an unbound slot
+ * is read as "no authentication available" and denies, which is the fail-closed behaviour the Citadel
+ * contract depends on.
+ */
+final class CommunitySecuritySubsystem extends AbstractCommunitySubsystem {
+
+    private SecurityProvider securityProvider;
+
+    @Override
+    public String name() {
+        return "security";
+    }
+
+    @Override
+    public List<String> dependsOn() {
+        // Token buffers are LoanedBuffers, so the allocator has to exist first. Crypto is deliberately
+        // absent: a provider that needs it resolves it itself, and naming it here would serialise two
+        // subsystems the bootstrap contract runs in parallel.
+        return List.of("memory");
+    }
+
+    @Override
+    public BootstrapPhase phase() {
+        return BootstrapPhase.SERVICES;
+    }
+
+    @Override
+    public void initialize() {
+        securityProvider = ServiceLoader.load(SecurityProvider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .max(Comparator.comparingInt(SecurityProvider::priority)
+                        .thenComparing(provider -> provider.getClass().getName()))
+                .orElse(null);
+    }
+
+    @Override
+    public void start() {
+        markRunning(securityProvider != null);
+    }
+
+    @Override
+    public void stop() {
+        markRunning(false);
+    }
+
+    @Override
+    public UnaryOperator<ScopedValue.Carrier> providerBindings() {
+        if (securityProvider == null) {
+            return defaultProviderBindings();
+        }
+        return CommunityCarrierBindings.operator(
+                CommunityCarrierBindings.binding(KernelProviders.SECURITY_PROVIDER, securityProvider)
+        );
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystem.java
@@ -13,7 +13,7 @@ import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.security.SecurityProvider;
 
 import java.util.List;
-import java.util.function.UnaryOperator;
+import java.util.function.ToIntFunction;
 
 /**
  * Binds the discovered {@link SecurityProvider} into {@link KernelProviders#SECURITY_PROVIDER}.
@@ -35,9 +35,7 @@ import java.util.function.UnaryOperator;
  * is read as "no authentication available" and denies, which is the fail-closed behaviour the Citadel
  * contract depends on.
  */
-final class CommunitySecuritySubsystem extends AbstractCommunitySubsystem {
-
-    private SecurityProvider securityProvider;
+final class CommunitySecuritySubsystem extends AbstractSingleProviderSubsystem<SecurityProvider> {
 
     @Override
     public String name() {
@@ -58,28 +56,17 @@ final class CommunitySecuritySubsystem extends AbstractCommunitySubsystem {
     }
 
     @Override
-    public void initialize() {
-        securityProvider = CommunityProviderDiscovery.highestPriority(
-                SecurityProvider.class, SecurityProvider::priority);
+    protected Class<SecurityProvider> contract() {
+        return SecurityProvider.class;
     }
 
     @Override
-    public void start() {
-        markRunning(securityProvider != null);
+    protected ToIntFunction<SecurityProvider> priority() {
+        return SecurityProvider::priority;
     }
 
     @Override
-    public void stop() {
-        markRunning(false);
-    }
-
-    @Override
-    public UnaryOperator<ScopedValue.Carrier> providerBindings() {
-        if (securityProvider == null) {
-            return defaultProviderBindings();
-        }
-        return CommunityCarrierBindings.operator(
-                CommunityCarrierBindings.binding(KernelProviders.SECURITY_PROVIDER, securityProvider)
-        );
+    protected ScopedValue<SecurityProvider> slot() {
+        return KernelProviders.SECURITY_PROVIDER;
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemProvider.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemProvider.java
@@ -31,6 +31,7 @@ public final class CommunitySubsystemProvider implements SubsystemProvider {
         return List.of(
                 new CommunityMemorySubsystem(),
                 new CommunityCryptoSubsystem(),
+                new CommunitySecuritySubsystem(),
                 new CommunityPersistenceSubsystem(),
                 new CommunityEventsSubsystem(),
                 new CommunityGraphSubsystem(),

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
@@ -9,6 +9,7 @@
 package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.community.persistence.PersistenceSessionBox;
+import eu.exeris.kernel.core.security.RouteAuthorizationEnforcer;
 import eu.exeris.kernel.core.security.SecurityInterceptor;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpExchange;
@@ -18,9 +19,11 @@ import eu.exeris.kernel.spi.http.HttpKernelProviders;
 import eu.exeris.kernel.spi.http.HttpMethod;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpRequestBodyDecoderRegistry;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
 import eu.exeris.kernel.spi.http.HttpResponse;
 import eu.exeris.kernel.spi.http.HttpStatus;
 import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.http.RouteRequirement;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.persistence.PersistenceEngine;
@@ -34,37 +37,33 @@ import java.util.Objects;
 
 // CyclomaticComplexity: route dispatch table (auth, health, user handlers) — each branch is a
 // terminal decision, not reducible without introducing opaque indirection.
-// TooManyMethods: one method per HTTP verb/route category — mirrors the CommunityHttpSubsystem route surface.
 // AvoidCatchingGenericException: catch-all wraps user-provided handler invocations; must absorb
 // any handler exception at the HTTP boundary.
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.TooManyMethods", "PMD.AvoidCatchingGenericException"})
+// TooManyMethods was suppressed here until ADR-061 removed the four path-convention helpers
+// (requiresAdmission / isPublicPath / isAuthorized / requiresAdminScope); the class is now under the
+// threshold on its own, and PMD flags the leftover suppression as unnecessary.
+@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidCatchingGenericException"})
 final class CommunityHttpRequestDispatcher {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final String HEALTH_PATH = "/health";
-    private static final String HEALTH_LIVE_PATH = "/health/live";
-    private static final String HEALTH_READY_PATH = "/health/ready";
-    private static final String DB_PING_PATH = "/db/ping";
-    private static final String DB_ROUNDTRIP_PATH = "/db/roundtrip";
-    private static final String SECURE_PATH_PREFIX = "/secure";
-    private static final String ADMIN_PATH_PREFIX = "/secure/admin";
-    private static final String READ_SCOPE = "security:read";
-    private static final String WRITE_SCOPE = "security:write";
 
     private final MemoryAllocator allocator;
     private final SecurityInterceptor securityInterceptor;
     private final PersistenceEngine persistenceEngine;
     private final HttpRequestBodyDecoderRegistry requestBodyDecoderRegistry;
+    private final HttpRoutePolicy routePolicy;
 
     /* default */ CommunityHttpRequestDispatcher(MemoryAllocator allocator,
                                    SecurityInterceptor securityInterceptor,
                                    PersistenceEngine persistenceEngine,
-                                   HttpRequestBodyDecoderRegistry requestBodyDecoderRegistry) {
+                                   HttpRequestBodyDecoderRegistry requestBodyDecoderRegistry,
+                                   HttpRoutePolicy routePolicy) {
         this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
         this.securityInterceptor = securityInterceptor;
         this.persistenceEngine = persistenceEngine;
         this.requestBodyDecoderRegistry = requestBodyDecoderRegistry;
+        this.routePolicy = routePolicy;
     }
 
     /* default */ void dispatch(HttpRequest request, HttpExchange exchange, HttpHandler handler) {
@@ -83,17 +82,25 @@ final class CommunityHttpRequestDispatcher {
             }
         }
 
-        if (requiresAdmission(path)) {
+        // A route the application never described about is decided by the policy, not by this
+        // driver. With no policy bound the requirement is permit-all, which is exactly how the kernel
+        // behaved before ADR-061 — declaring nothing changes nothing.
+        RouteRequirement requirement =
+                routePolicy == null ? RouteRequirement.permitAll() : routePolicy.requirementFor(method, path);
+
+        if (requirement != null && requirement.kind() == RouteRequirement.Kind.PERMIT_ALL) {
+            handleWithinRequestSession(method, request, exchange, handler);
+        } else {
+            // Identity is required — or the policy returned null, which is a defect the enforcer
+            // turns into a denial rather than an admission.
             boolean admitted = securityInterceptor != null
                     && interceptRequest(
                     request,
-                    () -> handleAuthorizedRequest(path, method, request, exchange, handler));
+                    () -> handleAuthorizedRequest(requirement, method, request, exchange, handler));
             if (!admitted) {
                 exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
                 return;
             }
-        } else {
-            handleWithinRequestSession(method, request, exchange, handler);
         }
 
         if (!isResponded(exchange)) {
@@ -116,16 +123,22 @@ final class CommunityHttpRequestDispatcher {
         }
     }
 
-    private void handleAuthorizedRequest(String path,
+    private void handleAuthorizedRequest(RouteRequirement requirement,
                                          HttpMethod method,
                                          HttpRequest request,
                                          HttpExchange exchange,
                                          HttpHandler handler) {
-        if (!isAuthorized(path)) {
-            exchange.respond(HttpResponse.noBody(HttpStatus.FORBIDDEN, request.version()));
-            return;
+        PrincipalContext principal = KernelProviders.PRINCIPAL_CONTEXT.isBound()
+                ? KernelProviders.PRINCIPAL_CONTEXT.get()
+                : null;
+
+        switch (RouteAuthorizationEnforcer.decide(requirement, principal)) {
+            case ADMIT -> handleWithinRequestSession(method, request, exchange, handler);
+            case FORBIDDEN ->
+                    exchange.respond(HttpResponse.noBody(HttpStatus.FORBIDDEN, request.version()));
+            case UNAUTHENTICATED ->
+                    exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
         }
-        handleWithinRequestSession(method, request, exchange, handler);
     }
 
     private void handleWithinRequestSession(HttpMethod method,
@@ -202,37 +215,6 @@ final class CommunityHttpRequestDispatcher {
         }
         String token = value.substring(BEARER_PREFIX.length()).trim();
         return token.isEmpty() ? "" : token;
-    }
-
-    private static boolean requiresAdmission(String path) {
-        return path != null && path.startsWith(SECURE_PATH_PREFIX) && !isPublicPath(path);
-    }
-
-    private static boolean isPublicPath(String path) {
-        if (path == null) {
-            return false;
-        }
-        return HEALTH_PATH.equals(path)
-                || HEALTH_LIVE_PATH.equals(path)
-                || HEALTH_READY_PATH.equals(path)
-                || DB_PING_PATH.equals(path)
-                || path.startsWith(DB_ROUNDTRIP_PATH);
-    }
-
-    private static boolean isAuthorized(String path) {
-        if (!KernelProviders.PRINCIPAL_CONTEXT.isBound()) {
-            return false;
-        }
-
-        PrincipalContext principal = KernelProviders.PRINCIPAL_CONTEXT.get();
-        if (requiresAdminScope(path)) {
-            return principal.hasAnyScope(WRITE_SCOPE);
-        }
-        return principal.hasAnyScope(READ_SCOPE);
-    }
-
-    private static boolean requiresAdminScope(String path) {
-        return path != null && path.startsWith(ADMIN_PATH_PREFIX);
     }
 
     private static boolean isReadOnlyMethod(HttpMethod method) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -19,6 +19,7 @@ import eu.exeris.kernel.spi.http.HttpHandler;
 import eu.exeris.kernel.spi.http.HttpKernelProviders;
 import eu.exeris.kernel.spi.http.HttpRequest;
 import eu.exeris.kernel.spi.http.HttpRequestBodyDecoderRegistry;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
 import eu.exeris.kernel.spi.http.HttpResponseBodyEncoderRegistry;
 import eu.exeris.kernel.spi.memory.LoanedBuffer;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
@@ -98,11 +99,16 @@ public final class CommunityHttpRequestProcessor {
         HttpRequestBodyDecoderRegistry requestBodyDecoderRegistry =
                 HttpKernelProviders.httpRequestBodyDecoderRegistry().orElse(null);
 
+        // ADR-061: captured here for the same reason as the decoder registry above — the route policy
+        // is read on the admission path, which runs on reactor threads outside this carrier scope.
+        HttpRoutePolicy routePolicy = HttpKernelProviders.httpRoutePolicy().orElse(null);
+
         this.requestDispatcher = new CommunityHttpRequestDispatcher(
                 this.allocator,
                 securityInterceptor,
                 persistenceEngine,
-                requestBodyDecoderRegistry);
+                requestBodyDecoderRegistry,
+                routePolicy);
         this.streamDispatcher = new CommunityHttpStreamDispatcher(this.allocator);
         this.http2SessionProcessor = new CommunityHttp2SessionProcessor(
                 this.allocator,

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystemTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySecuritySubsystemTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.bootstrap;
+
+import eu.exeris.kernel.spi.bootstrap.BootstrapPhase;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.security.SecurityProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The subsystem whose absence made the whole Citadel path unreachable.
+ *
+ * <p>The admission integration test binds {@code SECURITY_PROVIDER} by hand, so it never runs
+ * {@code initialize()} / {@code start()} — which is exactly the code that was missing. These cases
+ * drive the lifecycle itself.
+ */
+@DisplayName("CommunitySecuritySubsystem")
+class CommunitySecuritySubsystemTest {
+
+    @Nested
+    @DisplayName("Placement in the bootstrap DAG")
+    class Placement {
+
+        @Test
+        @DisplayName("is named 'security' and depends on memory only")
+        void identityAndDependencies() {
+            CommunitySecuritySubsystem subsystem = new CommunitySecuritySubsystem();
+
+            assertThat(subsystem.name())
+                    .as("CommunityProviderInventory already discovers SecurityProvider under this name; "
+                            + "a different one here would split the same subsystem in two")
+                    .isEqualTo("security");
+            assertThat(subsystem.dependsOn())
+                    .as("token buffers need the allocator; naming crypto too would serialise two "
+                            + "subsystems bootstrap.md runs in parallel")
+                    .containsExactly("memory");
+            assertThat(subsystem.phase()).isEqualTo(BootstrapPhase.SERVICES);
+        }
+
+        @Test
+        @DisplayName("is registered with the Community subsystem provider")
+        void isRegistered() {
+            assertThat(new CommunitySubsystemProvider().getSubsystems(null))
+                    .as("an unregistered subsystem is bound by nothing, which is the defect ADR-061 "
+                            + "closed — the class existing is not the same as it running")
+                    .anyMatch(CommunitySecuritySubsystem.class::isInstance);
+        }
+    }
+
+    @Nested
+    @DisplayName("Lifecycle")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("discovers the Community provider and binds it into the slot")
+        void discoversAndBinds() {
+            CommunitySecuritySubsystem subsystem = new CommunitySecuritySubsystem();
+            subsystem.initialize();
+            subsystem.start();
+
+            assertThat(subsystem.isRunning())
+                    .as("exeris-kernel-community registers CommunitySecurityProvider via ServiceLoader")
+                    .isTrue();
+
+            AtomicBoolean boundInScope = new AtomicBoolean(false);
+            subsystem.providerBindings()
+                    .apply(ScopedValue.where(KernelProviders.PRINCIPAL_CONTEXT, null))
+                    .run(() -> boundInScope.set(KernelProviders.SECURITY_PROVIDER.isBound()));
+
+            assertThat(boundInScope)
+                    .as("binding the slot is the entire job — before this subsystem existed, "
+                            + "CommunityHttpRequestProcessor always read it unbound and built no "
+                            + "SecurityInterceptor")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("stop() leaves the subsystem not running")
+        void stopMarksNotRunning() {
+            CommunitySecuritySubsystem subsystem = new CommunitySecuritySubsystem();
+            subsystem.initialize();
+            subsystem.start();
+            subsystem.stop();
+
+            assertThat(subsystem.isRunning()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Provider discovery")
+    class Discovery {
+
+        @Test
+        @DisplayName("highest priority wins, ties break on class name")
+        void highestPriorityWinsDeterministically() {
+            assertThat(CommunityProviderDiscovery.highestPriority(SecurityProvider.class,
+                    SecurityProvider::priority))
+                    .isNotNull();
+            assertThat(CommunityProviderDiscovery.highestPriority(Runnable.class, r -> 0))
+                    .as("absence must yield null rather than throwing — a deployment with no provider "
+                            + "is a configuration, and the unbound slot then denies fail-closed")
+                    .isNull();
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
@@ -15,15 +15,18 @@ import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpClientEngine;
 import eu.exeris.kernel.spi.http.HttpConfig;
 import eu.exeris.kernel.spi.http.HttpHeader;
+import eu.exeris.kernel.spi.http.HttpKernelProviders;
 import eu.exeris.kernel.spi.http.HttpMethod;
 import eu.exeris.kernel.spi.http.HttpMode;
 import eu.exeris.kernel.spi.http.HttpProvider;
 import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpRoutePolicy;
 import eu.exeris.kernel.spi.http.HttpResponse;
 import eu.exeris.kernel.spi.http.HttpServerEngine;
 import eu.exeris.kernel.spi.http.HttpStatus;
 import eu.exeris.kernel.spi.http.HttpVersion;
 import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.http.RouteRequirement;
 import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayName;
@@ -32,11 +35,21 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Community: HTTP security admission integration")
+/**
+ * The same three admission outcomes the hardcoded {@code /secure} prefix used to produce — 401, 403,
+ * 200 — now driven by a declared {@link HttpRoutePolicy} on paths that have nothing to do with that
+ * prefix. That is the point of ADR-061: the routes are the application's, not the driver's.
+ *
+ * <p>The fourth case is the one the old code could not express at all. Under the prefix convention
+ * {@code /api/internal} reached its handler with no identity bound, because it did not start with
+ * {@code /secure}. It is now decided by the policy like any other route.
+ */
+@DisplayName("Community: HTTP route-policy admission integration (ADR-061)")
 class CommunityHttpSecurityAdmissionIntegrationTest {
 
     private static final MemoryAllocator ALLOCATOR =
@@ -69,7 +82,7 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
 
                 HttpResponse response = client.send(HttpRequest.noBody(
                         HttpMethod.GET,
-                        "/secure",
+                        "/api/orders",
                         HttpVersion.HTTP_1_1,
                         List.of()));
                 try {
@@ -106,7 +119,7 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
 
                 HttpResponse response = client.send(HttpRequest.noBody(
                         HttpMethod.GET,
-                        "/secure/admin",
+                        "/api/admin",
                         HttpVersion.HTTP_1_1,
                         List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().serialize()))));
                 try {
@@ -147,7 +160,7 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
 
                 HttpResponse response = client.send(HttpRequest.noBody(
                         HttpMethod.GET,
-                        "/secure",
+                        "/api/orders",
                         HttpVersion.HTTP_1_1,
                     List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().serialize()))));
                 try {
@@ -165,10 +178,105 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
         assertThat(storageBound.get()).isTrue();
     }
 
+    /**
+     * Every authenticated principal carries exactly {@code security:read} — {@code CommunityClaimsMapper}
+     * assigns it and does not read the token's {@code scope} claim — so {@code security:write} is the
+     * scope nothing grants, which is what makes the 403 case a genuine denial rather than a typo.
+     */
+    private static final HttpRoutePolicy ROUTE_POLICY = (method, path) -> switch (path) {
+        case "/api/orders" -> RouteRequirement.requiringAnyScope(Set.of("security:read"));
+        case "/api/admin" -> RouteRequirement.requiringAnyScope(Set.of("security:write"));
+        case "/api/public" -> RouteRequirement.permitAll();
+        default -> HttpRoutePolicy.unmatched();
+    };
+
+    @Test
+    @DisplayName("Undeclared path is decided by the policy, not waved through — the ADR-061 defect")
+    void undeclaredPathIsDeniedWithoutIdentity() {
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+
+        withHttpSecurityScope(() -> {
+            int port = nextFreePort();
+            HttpProvider provider = new CommunityHttpProvider();
+
+            try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                 HttpClientEngine client = provider.createClientEngine(clientConfig(port))) {
+                server.setHandler(exchange -> {
+                    handlerInvoked.set(true);
+                    exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version()));
+                });
+
+                server.start();
+                client.start();
+
+                HttpResponse response = client.send(HttpRequest.noBody(
+                        HttpMethod.GET,
+                        "/api/internal",
+                        HttpVersion.HTTP_1_1,
+                        List.of()));
+                try {
+                    assertThat(response.status().code())
+                            .as("under the prefix convention this path reached the handler with no "
+                                    + "identity bound, purely because it did not start with /secure")
+                            .isEqualTo(401);
+                } finally {
+                    if (response.body() != null) {
+                        response.body().close();
+                    }
+                }
+            }
+        });
+
+        assertThat(handlerInvoked.get())
+                .as("and the handler must never have run")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("A path the policy declares public still reaches the handler without a token")
+    void declaredPublicPathReachesHandler() {
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+
+        withHttpSecurityScope(() -> {
+            int port = nextFreePort();
+            HttpProvider provider = new CommunityHttpProvider();
+
+            try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                 HttpClientEngine client = provider.createClientEngine(clientConfig(port))) {
+                server.setHandler(exchange -> {
+                    handlerInvoked.set(true);
+                    exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version()));
+                });
+
+                server.start();
+                client.start();
+
+                HttpResponse response = client.send(HttpRequest.noBody(
+                        HttpMethod.GET,
+                        "/api/public",
+                        HttpVersion.HTTP_1_1,
+                        List.of()));
+                try {
+                    assertThat(response.status().code())
+                            .as("without this control the denial cases above would also pass against "
+                                    + "a dispatcher that rejects every request")
+                            .isEqualTo(200);
+                } finally {
+                    if (response.body() != null) {
+                        response.body().close();
+                    }
+                }
+            }
+        });
+
+        assertThat(handlerInvoked.get()).isTrue();
+    }
+
     private static void withHttpSecurityScope(Runnable testCase) {
         ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
             .where(KernelProviders.SECURITY_PROVIDER,
                 new CommunitySecurityProvider(TestJwt.keySet(), TestJwt.EXPECTED_ISSUER, TestJwt.EXPECTED_AUDIENCE))
+            .where(HttpKernelProviders.HTTP_ROUTE_POLICY, ROUTE_POLICY)
                 .run(testCase);
     }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
@@ -272,6 +272,52 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
         assertThat(handlerInvoked.get()).isTrue();
     }
 
+    @Test
+    @DisplayName("No policy bound: every route reaches the handler — the pre-0.11 compatibility guarantee")
+    void noPolicyBoundAdmitsEverything() {
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+
+        // Deliberately NOT withHttpSecurityScope: this case is about the absence of HTTP_ROUTE_POLICY.
+        // The release notes lean on "an application that declares nothing behaves as it did before",
+        // and until now nothing exercised that branch end-to-end.
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
+            .where(KernelProviders.SECURITY_PROVIDER,
+                new CommunitySecurityProvider(TestJwt.keySet(), TestJwt.EXPECTED_ISSUER, TestJwt.EXPECTED_AUDIENCE))
+            .run(() -> {
+                int port = nextFreePort();
+                HttpProvider provider = new CommunityHttpProvider();
+
+                try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                     HttpClientEngine client = provider.createClientEngine(clientConfig(port))) {
+                    server.setHandler(exchange -> {
+                        handlerInvoked.set(true);
+                        exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version()));
+                    });
+
+                    server.start();
+                    client.start();
+
+                    HttpResponse response = client.send(HttpRequest.noBody(
+                            HttpMethod.GET,
+                            "/api/orders",
+                            HttpVersion.HTTP_1_1,
+                            List.of()));
+                    try {
+                        assertThat(response.status().code())
+                                .as("the same path answers 401 once a policy declares a scope for it, so "
+                                        + "this 200 is the unbound-slot branch and nothing else")
+                                .isEqualTo(200);
+                    } finally {
+                        if (response.body() != null) {
+                            response.body().close();
+                        }
+                    }
+                }
+            });
+
+        assertThat(handlerInvoked.get()).isTrue();
+    }
+
     private static void withHttpSecurityScope(Runnable testCase) {
         ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR)
             .where(KernelProviders.SECURITY_PROVIDER,

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RouteAuthorizationEnforcer.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/security/RouteAuthorizationEnforcer.java
@@ -53,26 +53,42 @@ public final class RouteAuthorizationEnforcer {
     /**
      * Decides whether a request satisfies the requirement its route declares.
      *
-     * @param requirement what the route demands; must not be {@code null}
+     * <p>A {@code null} requirement means the policy broke its own contract, and a broken policy must
+     * not grant. Reading it as {@link HttpRoutePolicy#unmatched()} would admit any authenticated
+     * caller — so a policy bug would hand an ordinary user a route that may have demanded an admin
+     * scope. It denies outright instead, in the shape the caller can act on: no identity is still a
+     * {@code 401}, an identity we cannot authorize is a {@code 403}. This method owns that rule, so
+     * callers that resolve a requirement themselves need not re-derive it.
+     *
+     * @param requirement what the route demands, or {@code null} if the policy returned none
      * @param principal   the verified identity, or {@code null} when none was established
      * @return the decision
      */
     public static RouteDecision decide(RouteRequirement requirement, PrincipalContext principal) {
+        if (requirement == null) {
+            return deny(principal);
+        }
         if (requirement.kind() == RouteRequirement.Kind.PERMIT_ALL) {
             return RouteDecision.ADMIT;
         }
         if (principal == null) {
             return RouteDecision.UNAUTHENTICATED;
         }
+        return satisfiesScopes(requirement, principal) ? RouteDecision.ADMIT : RouteDecision.FORBIDDEN;
+    }
+
+    /** Denies in the shape the caller can act on: {@code 401} with no identity, {@code 403} with one. */
+    private static RouteDecision deny(PrincipalContext principal) {
+        return principal == null ? RouteDecision.UNAUTHENTICATED : RouteDecision.FORBIDDEN;
+    }
+
+    private static boolean satisfiesScopes(RouteRequirement requirement, PrincipalContext principal) {
+        // Exhaustive over Kind on purpose: a new variant fails the compile here rather than falling
+        // through to true, which would open every route carrying it.
         return switch (requirement.kind()) {
-            case AUTHENTICATED -> RouteDecision.ADMIT;
-            case ANY_SCOPE -> hasAny(requirement, principal)
-                    ? RouteDecision.ADMIT : RouteDecision.FORBIDDEN;
-            case ALL_SCOPES -> hasAll(requirement, principal)
-                    ? RouteDecision.ADMIT : RouteDecision.FORBIDDEN;
-            // PERMIT_ALL returned above; listed so a new Kind fails the compile rather than
-            // falling through to ADMIT, which would open every route carrying it.
-            case PERMIT_ALL -> RouteDecision.ADMIT;
+            case PERMIT_ALL, AUTHENTICATED -> true;
+            case ANY_SCOPE -> hasAny(requirement, principal);
+            case ALL_SCOPES -> hasAll(requirement, principal);
         };
     }
 
@@ -89,16 +105,7 @@ public final class RouteAuthorizationEnforcer {
                                        HttpMethod method,
                                        String path,
                                        PrincipalContext principal) {
-        RouteRequirement requirement = policy.requirementFor(method, path);
-        if (requirement == null) {
-            // A policy that breaks the never-null contract is broken, and a broken policy must not
-            // grant. Substituting unmatched() here would admit any authenticated caller — so a policy
-            // bug would hand an ordinary user a route that may have demanded an admin scope. Deny
-            // outright instead, and deny in the shape the caller can act on: no identity is still a
-            // 401, an identity we cannot authorize is a 403.
-            return principal == null ? RouteDecision.UNAUTHENTICATED : RouteDecision.FORBIDDEN;
-        }
-        return decide(requirement, principal);
+        return decide(policy.requirementFor(method, path), principal);
     }
 
     private static boolean hasAny(RouteRequirement requirement, PrincipalContext principal) {

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRoutePolicy.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpRoutePolicy.java
@@ -70,6 +70,14 @@ public interface HttpRoutePolicy {
      * route still demands identity. {@link RouteRequirement#permitAll()} is fail-open: an undeclared
      * route is public, which is how a forgotten endpoint becomes an unauthenticated one.
      *
+     * <p><b>Before choosing fail-closed, account for the routes you did not write.</b> A deployment
+     * that binds a policy but no {@code HTTP_SERVER_HANDLER} gets the driver's built-in liveness,
+     * readiness and database-probe endpoints — and those are routes like any other, so a fail-closed
+     * unmatched answer denies them. An orchestrator's probes then fail against a healthy process.
+     * Declare them {@link RouteRequirement#permitAll()} explicitly. The kernel does not exempt them
+     * for you: a driver-local notion of "public" would be a second answer to the question this
+     * contract now owns, and the first thing it would do is disagree with yours.
+     *
      * @return the fail-closed answer, which is the one to prefer when unsure
      */
     static RouteRequirement unmatched() {


### PR DESCRIPTION
Closes ADR-061 obligations 4 and 5. **This is the half that changes what a default boot does.**

## What lands

**`CommunitySecuritySubsystem`** binds `KernelProviders.SECURITY_PROVIDER`. `bootstrap.md` has always placed Security among the L1 subsystems — in the parallel-init description, the `scope.fork(() -> security.start())` sketch, and the DAG-cycle example — and Community shipped every subsystem in that list *except this one*. `CommunitySecurityProvider` existed and was `ServiceLoader`-registered, but nothing bound it, so the interceptor was never constructed and the Citadel path was unreachable.

Discovery finding no provider leaves the subsystem **not running** rather than failing the boot: a deployment behind a mesh is legitimate, and an unbound slot already reads as "no authentication available" and denies. What it must never do is bind a placeholder.

**`CommunityHttpRequestDispatcher`** resolves the route through `HttpRoutePolicy` and hands the `RouteRequirement` to `RouteAuthorizationEnforcer`. Gone with the prefix constants: `requiresAdmission`, `isPublicPath`, `isAuthorized`, `requiresAdminScope` — including the allowlist that was unreachable because it was only consulted behind `startsWith("/secure")`.

`CommunityHttpRequestProcessor` captures the policy at construction, for the same reason the decoder registry is captured there: the admission path runs on reactor threads that are not structured forks of the boot scope.

**One change to part-1 code:** `RouteAuthorizationEnforcer.decide(RouteRequirement, PrincipalContext)` is now null-tolerant. The dispatcher must know the requirement *before* it can decide whether to authenticate at all, so it resolves the policy itself — and making the enforcer accept `null` keeps "a broken policy grants nothing" in exactly one place instead of copying the rule into the driver.

## The test was repurposed, not replaced

`CommunityHttpSecurityAdmissionIntegrationTest` keeps its three outcomes — 401, 403, 200 — but on `/api/orders` and `/api/admin` instead of `/secure` and `/secure/admin`. A pass therefore cannot come from the old prefix rule; the same behaviour now has to be produced by a declared policy.

Two cases added:

- **`/api/internal` → 401.** Undeclared, so the policy's `unmatched()` decides. Under the prefix convention this path went **straight to the handler with no identity bound**, purely because it did not start with `/secure`. This is the defect ADR-061 was written to close, now under test.
- **`/api/public` → 200.** The control: without it, the denial cases would also pass against a dispatcher that rejects everything.

The 403 case is a genuine denial rather than a typo because `CommunityClaimsMapper` gives every principal exactly `security:read`, so `security:write` is a scope nothing grants.

## Behaviour change (for the release notes)

`/secure/*` stops answering `401` unconditionally, because a provider is now bound.

An application that declares no policy gets permit-all everywhere — the pre-0.11 behaviour — which also means **declaring nothing means no edge authorization**. `security.md` now says that plainly rather than implying the kernel confers protection by being installed.

## Adjacent finding, deliberately not fixed here

`CommunityClaimsMapper:52` assigns every authenticated principal exactly `Set.of("security:read")` and never reads the token's `scope` claim — so `security:write` is a scope nothing can grant, and any policy requiring it denies everyone. That predates this work and belongs to the claims mapper's contract, not the route policy's. Recorded in the ROADMAP; it needs its own slice.

## Suppression removed, not added

Removing the four dead helpers dropped the dispatcher below the method threshold, so its `PMD.TooManyMethods` suppression became unnecessary — and PMD flagged it. Removed, with the reason recorded where it stood.

## Verification

| Gate | Result |
|---|---|
| `mvn clean install` (full reactor, no skip flags → lint-gated) | green |
| `mvn clean verify -P coverage` (what CI runs) | green |
| `ExerisArchitectureTest` | 13/13 |
| Admission integration (end-to-end, real server + client) | 5/5 |

Docs updated in this slice, not before it: `security.md` (policy replaces the prefix; the no-policy exposure stated), `http.md` (the new slot and why it is captured at construction), `bootstrap.md` (Community now ships the subsystem the contract always described). ROADMAP entry flipped to DELIVERED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)