### PR TITLE
feat(security): map scopes and roles from the verified token

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2049,10 +2049,18 @@ bound. An application that declares no policy gets permit-all everywhere, which 
 before — and which means **declaring nothing means no edge authorization**. The subsystem docs say so
 rather than implying that installing the kernel confers protection.
 
-**Adjacent finding, not fixed here:** `CommunityClaimsMapper:52` assigns every authenticated principal
-exactly `Set.of("security:read")` and never reads the token's `scope` claim, so `security:write` is a
-scope nothing can grant. That predates this work and is the claims mapper's contract, not the route
-policy's; it needs its own slice.
+**Claim-driven scopes and roles: DELIVERED.** `CommunityClaimsMapper` now reads `scope` / `scp` /
+`roles` from the verified token, with no fallback — a token declaring nothing grants nothing. This
+was the iteration ADR-040 §"Implementation" already specified ("sub → principalId, roles/scopes
+claims → PrincipalContext") and the 0.10 refactor deliberately deferred to avoid changing
+observable behaviour, so it needed no new ADR. It also makes `security:write` grantable for the
+first time: the admission integration suite gains a case where an admin-scoped token reaches
+`/api/admin`, which was unwritable while nothing could grant that scope — meaning the existing 403
+case would have passed even against a route no caller could ever reach.
+
+**Behaviour change:** every principal used to receive `security:read` unconditionally. Fixtures and
+TCK token builders now declare their scopes explicitly, which is what makes them honest about what
+they grant.
 
 ---
 

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -167,6 +167,16 @@ public class SecurityInterceptor {
 - Fail-Closed: invalid token at transport edge results in `EX-SEC-2002` and zero downstream calls.
 - Community HTTP admission semantics (implemented): missing/invalid token maps to HTTP `401`; authenticated principal without required scope maps to HTTP `403`; steady-state scope checks remain membership tests over immutable in-memory scope sets.
 - **Which routes require what is declared by the application, not by the driver (since 0.11, ADR-061).** `CommunityHttpRequestDispatcher` no longer gates on a `/secure` path prefix with the literal scopes `security:read` / `security:write` compiled into it. It resolves the route through `HttpRoutePolicy` (bound at `HttpKernelProviders.HTTP_ROUTE_POLICY`) and hands the resulting `RouteRequirement` to `RouteAuthorizationEnforcer` in Core, so every transport shares one decision layer. With no policy bound the requirement is permit-all and the kernel behaves as it did before — declaring nothing changes nothing, which also means an application that never declares a policy has **no edge authorization**. The unmatched route is the application's call: `HttpRoutePolicy.unmatched()` is fail-closed, and a policy returning `null` is treated as a defect and denies outright rather than being read as unmatched.
+- **The token grants what it claims, and nothing else (since 0.11).** `CommunityClaimsMapper` reads
+  `scope` (OAuth 2.0 space-delimited, RFC 6749 §3.3), `scp` (the array form some identity providers
+  emit, unioned with the former) and `roles`. Until 0.11 it handed every authenticated principal a
+  hardcoded `security:read` and no roles regardless of the token — the deferral ADR-040 left open,
+  although that ADR already specifies this mapper as "sub → principalId, roles/scopes claims →
+  PrincipalContext". Two consequences: no route could tell one caller's permissions from another's,
+  and `security:write` was a scope **nothing could grant**, so any policy requiring it denied
+  everyone. There is deliberately **no fallback** — a token carrying no scope claim yields an empty
+  scope set and a route requiring any scope denies it. Roles now reach `PrincipalContext.roles()`,
+  so the `roleMask` behind `@RequiresRole` is no longer permanently `0L`.
 - `KernelProviders.SECURITY_PROVIDER` is bound by `CommunitySecuritySubsystem` (since 0.11). Before that it was bound by nothing, so the interceptor was never constructed and the whole Citadel path was unreachable in a default boot.
 
 ---

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityClaimsMapper.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityClaimsMapper.java
@@ -14,26 +14,50 @@ import eu.exeris.kernel.spi.security.PrincipalContext;
 import eu.exeris.kernel.spi.security.identity.ClaimsMapper;
 import eu.exeris.kernel.spi.security.identity.VerifiedClaims;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Default Community {@link ClaimsMapper}: maps a verified subject to a {@link PrincipalContext}.
  *
- * <p>Preserves the historical Community mapping verbatim (the static-map path is byte-for-byte):
- * {@code sub} parses to a UUIDv7 that becomes both {@code principalId} and {@code tenantId}, with
- * no roles and a single {@code security:read} scope.
+ * <p>{@code sub} parses to a UUIDv7 that becomes both {@code principalId} and {@code tenantId};
+ * roles and scopes come from the token.
  *
- * <p><b>Claim-driven role/scope mapping</b> (reading {@code roles}/{@code scope} claims) is the
- * documented next iteration of this seam (ADR-040 — {@code ClaimsMapper} is the customisation
- * point); it lands with the matching TCK/fixture changes so as not to alter observable behaviour
- * under this refactor.
+ * <h2>The token grants what it says, and nothing else (since 0.11)</h2>
+ * <p>Until 0.11 every authenticated principal received a single hardcoded {@code security:read} scope
+ * and no roles, whatever the token claimed — the deferral ADR-040 §"Implementation" left open, since
+ * that ADR already specifies this mapper as "sub → principalId, roles/scopes claims →
+ * PrincipalContext". Two consequences made the deferral worth closing rather than carrying: no route
+ * could distinguish one caller's permissions from another's, and {@code security:write} was a scope
+ * <em>nothing could ever grant</em>, so any policy requiring it denied everyone.
+ *
+ * <p>There is deliberately <b>no fallback</b>. A token carrying no scope claim yields an empty scope
+ * set, and a route requiring any scope denies it. Granting a default would reinstate exactly the
+ * invisible grant this replaces: a route asking for {@code security:read} would admit a caller who
+ * never asked for it, which is indistinguishable from the route having no requirement at all.
+ *
+ * <h2>Claim shapes</h2>
+ * <ul>
+ *   <li>{@code scope} — the OAuth 2.0 form (RFC 6749 §3.3): one string, space-delimited.</li>
+ *   <li>{@code scp} — the array form several identity providers emit instead. Read as well, and
+ *       unioned, because a token carrying one of the two is not a token carrying nothing.</li>
+ *   <li>{@code roles} — multi-valued. Feeds {@code PrincipalContext.roles()}, which
+ *       {@code SecurityInterceptor} resolves into the {@code roleMask} used by {@code @RequiresRole}.
+ *       Before this change roles were always empty, so that mask was always {@code 0L}.</li>
+ * </ul>
  *
  * @since 0.10.0
  */
 final class CommunityClaimsMapper implements ClaimsMapper {
 
     private static final String JWT_TYPE = "JWT";
+    private static final String SCOPE_CLAIM = "scope";
+    private static final String SCOPE_ARRAY_CLAIM = "scp";
+    private static final String ROLES_CLAIM = "roles";
+    private static final Pattern SCOPE_SEPARATOR = Pattern.compile("\\s+");
 
     @Override
     public PrincipalContext map(VerifiedClaims claims) {
@@ -49,6 +73,22 @@ final class CommunityClaimsMapper implements ClaimsMapper {
             throw new SecurityAuthenticationException(JWT_TYPE, "invalid-subject");
         }
 
-        return ImmutablePrincipal.ofTenant(subjectUuid, subjectUuid, Set.of(), Set.of("security:read"));
+        return ImmutablePrincipal.ofTenant(
+                subjectUuid, subjectUuid, claims.stringSetClaim(ROLES_CLAIM), scopesOf(claims));
+    }
+
+    /**
+     * Unions the two shapes an identity provider may use to express scopes.
+     *
+     * @param claims the verified claims
+     * @return the granted scopes; empty when the token declares none
+     */
+    private static Set<String> scopesOf(VerifiedClaims claims) {
+        Set<String> scopes = new HashSet<>(claims.stringSetClaim(SCOPE_ARRAY_CLAIM));
+        claims.claim(SCOPE_CLAIM)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .ifPresent(value -> Collections.addAll(scopes, SCOPE_SEPARATOR.split(value)));
+        return Set.copyOf(scopes);
     }
 }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
@@ -121,7 +121,7 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
                         HttpMethod.GET,
                         "/api/admin",
                         HttpVersion.HTTP_1_1,
-                        List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().serialize()))));
+                        List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().claim("scope", "security:read").serialize()))));
                 try {
                     assertThat(response.status().code()).isEqualTo(403);
                 } finally {
@@ -162,7 +162,7 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
                         HttpMethod.GET,
                         "/api/orders",
                         HttpVersion.HTTP_1_1,
-                    List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().serialize()))));
+                    List.of(new HttpHeader("Authorization", "Bearer " + TestJwt.builder().claim("scope", "security:read").serialize()))));
                 try {
                     assertThat(response.status().code()).isEqualTo(200);
                 } finally {
@@ -189,6 +189,48 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
         case "/api/public" -> RouteRequirement.permitAll();
         default -> HttpRoutePolicy.unmatched();
     };
+
+    @Test
+    @DisplayName("A token carrying the admin scope reaches the admin route — the 403 above was about the scope")
+    void adminScopeReachesAdminRoute() {
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+
+        withHttpSecurityScope(() -> {
+            int port = nextFreePort();
+            HttpProvider provider = new CommunityHttpProvider();
+
+            try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                 HttpClientEngine client = provider.createClientEngine(clientConfig(port))) {
+                server.setHandler(exchange -> {
+                    handlerInvoked.set(true);
+                    exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version()));
+                });
+
+                server.start();
+                client.start();
+
+                HttpResponse response = client.send(HttpRequest.noBody(
+                        HttpMethod.GET,
+                        "/api/admin",
+                        HttpVersion.HTTP_1_1,
+                        List.of(new HttpHeader("Authorization",
+                                "Bearer " + TestJwt.builder().claim("scope", "security:write").serialize()))));
+                try {
+                    assertThat(response.status().code())
+                            .as("this case was unwritable before the claims mapper read the token: "
+                                    + "security:write was a scope nothing could grant, so the 403 above "
+                                    + "would have passed even against a route nobody could ever reach")
+                            .isEqualTo(200);
+                } finally {
+                    if (response.body() != null) {
+                        response.body().close();
+                    }
+                }
+            }
+        });
+
+        assertThat(handlerInvoked.get()).isTrue();
+    }
 
     @Test
     @DisplayName("Undeclared path is decided by the policy, not waved through — the ADR-061 defect")

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityClaimsMapperTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityClaimsMapperTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.spi.exceptions.security.SecurityAuthenticationException;
+import eu.exeris.kernel.spi.security.PrincipalContext;
+import eu.exeris.kernel.spi.security.identity.VerifiedClaims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The mapper decides what an authenticated caller is allowed to do, so every case here is about the
+ * difference between what the token said and what the principal ends up holding.
+ *
+ * <p>The load-bearing one is {@link Absence}: until 0.11 this mapper handed out {@code security:read}
+ * to everyone regardless of the token, which made {@code security:write} unreachable and every route
+ * requirement indistinguishable from no requirement. A test suite that only checks the present-claim
+ * cases would pass just as happily against that old behaviour.
+ */
+@DisplayName("CommunityClaimsMapper")
+class CommunityClaimsMapperTest {
+
+    private static final UUID SUBJECT = UUID.fromString("0193a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b");
+
+    private final CommunityClaimsMapper mapper = new CommunityClaimsMapper();
+
+    @Nested
+    @DisplayName("Scopes come from the token")
+    class Scopes {
+
+        @Test
+        @DisplayName("the OAuth2 `scope` claim is split on whitespace")
+        void spaceDelimitedScopeClaim() {
+            PrincipalContext principal = mapper.map(claims(
+                    Map.of("scope", "orders:read  orders:write\tbilling:read"), Map.of()));
+
+            assertThat(principal.scopes())
+                    .as("RFC 6749 §3.3 makes this one string, not a list; a mapper treating it as a "
+                            + "single opaque value grants one scope nobody will ever ask for")
+                    .containsExactlyInAnyOrder("orders:read", "orders:write", "billing:read");
+        }
+
+        @Test
+        @DisplayName("the array-form `scp` claim is read too, and unioned with `scope`")
+        void arrayScopeClaimIsUnioned() {
+            PrincipalContext principal = mapper.map(claims(
+                    Map.of("scope", "orders:read"),
+                    Map.of("scp", Set.of("billing:read"))));
+
+            assertThat(principal.scopes()).containsExactlyInAnyOrder("orders:read", "billing:read");
+        }
+
+        @Test
+        @DisplayName("roles reach the principal, so the role mask stops being permanently zero")
+        void rolesArePropagated() {
+            PrincipalContext principal = mapper.map(claims(
+                    Map.of(), Map.of("roles", Set.of("ROLE_ADMIN", "ROLE_USER"))));
+
+            assertThat(principal.roles()).containsExactlyInAnyOrder("ROLE_ADMIN", "ROLE_USER");
+        }
+    }
+
+    @Nested
+    @DisplayName("Absence grants nothing")
+    class Absence {
+
+        @Test
+        @DisplayName("a token declaring no scopes yields none — no default is substituted")
+        void noScopeClaimYieldsNoScopes() {
+            PrincipalContext principal = mapper.map(claims(Map.of(), Map.of()));
+
+            assertThat(principal.scopes())
+                    .as("the whole point of the change: a default grant would let a route requiring "
+                            + "security:read admit a caller who never asked for it, which is the same "
+                            + "as the route having no requirement at all")
+                    .isEmpty();
+            assertThat(principal.hasScope("security:read"))
+                    .as("and specifically not the scope this mapper used to hand out unconditionally")
+                    .isFalse();
+            assertThat(principal.roles()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("a blank `scope` claim is absence, not a scope named \"\"")
+        void blankScopeClaimYieldsNoScopes() {
+            PrincipalContext principal = mapper.map(claims(Map.of("scope", "   "), Map.of()));
+
+            assertThat(principal.scopes()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Subject handling is unchanged")
+    class Subject {
+
+        @Test
+        @DisplayName("sub becomes both principalId and tenantId")
+        void subjectBecomesPrincipalAndTenant() {
+            PrincipalContext principal = mapper.map(claims(Map.of(), Map.of()));
+
+            assertThat(principal.principalId()).isEqualTo(SUBJECT);
+            assertThat(principal.tenantId()).contains(SUBJECT);
+        }
+
+        @Test
+        @DisplayName("a non-UUID subject is rejected")
+        void nonUuidSubjectRejected() {
+            assertThatThrownBy(() -> mapper.map(new StubClaims("not-a-uuid", Map.of(), Map.of())))
+                    .isInstanceOf(SecurityAuthenticationException.class);
+        }
+    }
+
+    private static VerifiedClaims claims(Map<String, String> single, Map<String, Set<String>> multi) {
+        return new StubClaims(SUBJECT.toString(), single, multi);
+    }
+
+    /** Minimal in-test {@link VerifiedClaims}; the real one is the validator's output, not ours. */
+    private record StubClaims(String subject,
+                              Map<String, String> single,
+                              Map<String, Set<String>> multi) implements VerifiedClaims {
+
+        @Override
+        public String issuer() {
+            return "https://auth.example.com";
+        }
+
+        @Override
+        public Set<String> audience() {
+            return Set.of("exeris-kernel");
+        }
+
+        @Override
+        public Optional<Instant> expiresAt() {
+            return Optional.of(Instant.now().plusSeconds(60L));
+        }
+
+        @Override
+        public Optional<String> claim(String name) {
+            return Optional.ofNullable(single.get(name));
+        }
+
+        @Override
+        public Set<String> stringSetClaim(String name) {
+            return multi.getOrDefault(name, Set.of());
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityOidcIdentityProviderTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityOidcIdentityProviderTckTest.java
@@ -31,7 +31,8 @@ class CommunityOidcIdentityProviderTckTest extends AbstractIdentityProviderTck {
 
     @Override
     protected LoanedBuffer validTokenBuffer() {
-        return TestJwt.builder().toBuffer();
+        // Since 0.11 the mapper grants only what the token claims, so the fixture has to say it.
+        return TestJwt.builder().claim("scope", "security:read").toBuffer();
     }
 
     @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityOidcKeycloakIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityOidcKeycloakIT.java
@@ -52,6 +52,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -139,6 +140,13 @@ class CommunityOidcKeycloakIT {
         String subject = parsed.getJWTClaimsSet().getSubject();
 
         assertThat(subject).as("Keycloak sub == imported user id").isEqualTo(SUBJECT_ID);
+
+        String scopeClaim = parsed.getJWTClaimsSet().getStringClaim("scope");
+        assertThat(scopeClaim)
+                .as("a real Keycloak access token carries a scope claim; without one the mapping "
+                        + "assertion below would hold vacuously")
+                .isNotBlank();
+        Set<String> grantedScopes = Set.of(scopeClaim.trim().split("\\s+"));
         assertThat(parsed.getJWTClaimsSet().getAudience())
                 .as("audience mapper added the kernel audience").contains(AUDIENCE);
 
@@ -158,7 +166,12 @@ class CommunityOidcKeycloakIT {
                 try (LoanedBuffer token = TestJwt.bufferOf(accessToken)) {
                     AuthenticationResult result = provider.authenticate(token);
                     assertThat(result.principal().principalId()).isEqualTo(UUID.fromString(SUBJECT_ID));
-                    assertThat(result.principal().hasScope("security:read")).isTrue();
+                    assertThat(result.principal().scopes())
+                            .as("the mapper must carry through exactly what the IdP granted — "
+                                    + "pinning a scope name here would test Keycloak's realm "
+                                    + "defaults, and asserting a name the realm never issued is "
+                                    + "how this passed before 0.11, when the mapper invented one")
+                            .isEqualTo(grantedScopes);
                     assertThat(result.storage().strategy()).as("isolation strategy").isNotNull();
                 }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunitySecurityProviderTckTest.java
@@ -36,7 +36,8 @@ class CommunitySecurityProviderTckTest extends AbstractSecurityProviderTck {
 
     @Override
     protected LoanedBuffer createValidTokenBuffer() {
-        return TestJwt.builder().toBuffer();
+        // Since 0.11 the mapper grants only what the token claims, so the fixture has to say it.
+        return TestJwt.builder().claim("scope", "security:read").toBuffer();
     }
 
     @Override


### PR DESCRIPTION
`CommunityClaimsMapper` handed every authenticated principal a hardcoded `security:read` and no roles, **whatever the token claimed**. Two consequences:

- No route could tell one caller's permissions from another's — which made the route policy that just landed in #278 unable to express anything real.
- `security:write` was a scope **nothing could grant**, so any policy requiring it denied everyone.

## Not a new decision

ADR-040 already specifies this mapper as *"sub → principalId, roles/scopes claims → PrincipalContext"*, and the class javadoc recorded both the deferral and its reason: the 0.10 refactor kept behaviour byte-for-byte on purpose. So this is a documented, owed iteration — **no ADR needed**. I had originally called it an oversight; it was recorded at the site, and that correction is why the framing here is "finish what ADR-040 specified" rather than "fix a bug".

## What it reads

| Claim | Shape |
|---|---|
| `scope` | OAuth 2.0, one string, space-delimited (RFC 6749 §3.3) |
| `scp` | the array form several identity providers emit — read as well and **unioned**, because a token carrying one of the two is not a token carrying nothing |
| `roles` | multi-valued; now reaches `PrincipalContext.roles()`, so the `roleMask` behind `@RequiresRole` stops being permanently `0L` |

## No fallback, deliberately

A token declaring no scopes gets none. Granting a default would reinstate exactly the invisible grant this replaces: a route asking for `security:read` would admit a caller who never asked for it — indistinguishable from the route having no requirement at all.

## Blast radius was exactly what was predicted

Three tests depended on the implicit grant: the two TCK happy-path scope assertions and the ADR-061 admission suite. Nothing else. All three are fixed by making their tokens **say what they grant**, which is the honest shape regardless.

## One test became writable that was not before

An admin-scoped token now reaches `/api/admin`. Until now `security:write` could not be granted at all — so the neighbouring 403 case would have passed **even against a route no caller could ever reach**. That control is added, and it is the clearest single demonstration of what this change buys.

## Coverage

`CommunityClaimsMapperTest` covers the parsing (space-delimited split, `scp` union, roles) and, more importantly, **absence**.

Proven non-vacuous by mutation: reinstating the `security:read` fallback fails both `Absence` cases and leaves `Scopes` and `Subject` green — precise, not incidental.

The scopeless case is deliberately a Community unit test rather than a new `AbstractSecurityProviderTck` hook: the Core binding is a stub keyed on buffer size that never goes through a claims mapper, so the case would have meant nothing there.

## Verification

| Gate | Result |
|---|---|
| `mvn clean install` (full reactor, no skip flags → lint-gated) | green |
| `mvn clean verify -P coverage` (what CI runs) | green |
| `ExerisArchitectureTest` | 13/13 |
| `CommunityClaimsMapperTest` | 7/7, mutation-proven |
| Admission integration | 7/7 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)