### PR TITLE
fix(ci): make the persistence integration gate run the tests it is named after

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2056,6 +2056,46 @@ policy's; it needs its own slice.
 
 ---
 
+### CI: The Persistence Gate Ran None of the Tests It Is Named After (surfaced 2026-08-05) — DELIVERED
+
+**Gap:** `exeris-kernel-community` held 11 `@Tag("integration")` classes, every one named `*IT`, and the
+CI job that exists to run them selected **none**.
+
+`.github/workflows/maven.yml:194-201` runs
+`mvn -pl exeris-kernel-community -DincludedGroups=integration -DexcludedGroups= test`. That is Surefire,
+whose 3.2.5 defaults are `Test*` / `*Test` / `*Tests` / `*TestCase` — and the module declared no
+`<includes>`. So the job named **"persistence RLS integration gate" ran no persistence RLS test**. What
+kept it green were three unrelated `*Test` classes that happen to carry the tag (crypto TLS loopback,
+transport ingress, carrier pinning).
+
+Dead alongside them: the JDBC event-stream TCK bindings, the graph parity and churn ITs, the S3 blob
+TCK, and the Keycloak OIDC conformance test. Several are the only executable evidence behind contracts
+ADR-012 and ADR-056 rest on.
+
+**The fix already existed one module away.** `exeris-kernel-community-kafka` added exactly this
+`<includes>` block in v0.8 Sprint 6 (Coverage C-P0-02), with a comment describing the same failure —
+"the three IT files end in IT and were silently dead before this include addition". It was never
+applied to `exeris-kernel-community`, and the Kafka gate has been genuinely running its ITs ever since
+while the persistence gate has not.
+
+**Resolution:** the same `<includes>` block, in `exeris-kernel-community/pom.xml`.
+
+**Evidence, by the two commands that matter:**
+
+- `mvn -pl exeris-kernel-community test` selects **zero** `*IT` classes — every one is
+  `@Tag("integration")`, so no Testcontainers start in a default build.
+- `mvn -pl exeris-kernel-community -DincludedGroups=integration -DexcludedGroups= test` — the gate's
+  own command — now runs all 11: **74 tests, 0 failures**. They were never broken. They had simply
+  never run.
+
+**Lesson this repeats.** Same shape as the "verify skips PMD" myth (PR #238) and the JaCoCo floor that
+only began applying once a module gained its first test: a gate believed because it was green, when
+green meant it had nothing to check. A gate's name is not evidence; the `Running …` lines in its log
+are.
+
+---
+
+
 ## Known Gaps / Future Work planned for v0.12
 
 ### HTTP: `WebSocketProvider` SPI (or SSE-Only Commitment)

--- a/exeris-kernel-community/pom.xml
+++ b/exeris-kernel-community/pom.xml
@@ -210,6 +210,30 @@
                     <groups>${includedGroups}</groups>
                     <!-- Exclude @Tag("flamegraph") tests from regular CI runs -->
                     <excludedGroups>${excludedGroups}</excludedGroups>
+                    <!--
+                        Pick up *IT.java alongside the Surefire defaults, so the persistence-rls-gate
+                        CI job (`-DincludedGroups=integration -DexcludedGroups=` against this module)
+                        actually discovers the classes its name promises.
+
+                        Surefire 3.2.5 defaults to Test*.java / *Test.java / *Tests.java /
+                        *TestCase.java only. Every integration test in this module ends in IT, so the
+                        gate selected none of them: not the persistence isolation suite it is named
+                        after, nor the JDBC event-stream TCK bindings, the graph parity/churn ITs, the
+                        S3 blob TCK, or the Keycloak OIDC conformance test. The job was green because
+                        it ran three unrelated *Test classes that happen to carry the tag.
+
+                        exeris-kernel-community-kafka fixed exactly this in v0.8 Sprint 6 (Coverage
+                        C-P0-02) and the same block never reached this module. Default tag-exclusion
+                        still keeps these out of `mvn test` / `mvn install` — every one of them is
+                        @Tag("integration"), so no Testcontainers start without the group override.
+                    -->
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
                 </configuration>
                 <executions>
                     <!--


### PR DESCRIPTION
`exeris-kernel-community` holds **11** `@Tag("integration")` classes, every one named `*IT`, and the CI job that exists to run them selected **none**.

## What was happening

The gate runs (`.github/workflows/maven.yml:194-201`):

```
mvn -pl exeris-kernel-community -DincludedGroups=integration -DexcludedGroups= test
```

That is **Surefire**, whose 3.2.5 defaults are `Test*` / `*Test` / `*Tests` / `*TestCase`, and the module declared no `<includes>`. `*IT` matches none of them.

So the job named **"persistence RLS integration gate" ran no persistence RLS test.** It stayed green on three unrelated `*Test` classes that happen to carry the tag — crypto TLS loopback, transport ingress, carrier pinning.

Dead alongside them:

| | |
|---|---|
| Persistence isolation | `CommunityPersistenceTenantIsolationIT`, `CommunityPersistenceSharedScopeIT`, `CommunityPersistenceIsolationLeakTckIT`, `CommunityIsolationStrategyEndToEndIT` |
| Events | `CommunityJdbcEventStreamAppenderTckIT`, `CommunityJdbcEventStreamReaderTckIT` |
| Flow | `CommunityJdbcFlowSnapshotStoreTckIT` |
| Graph | `CommunityGraphBackendParityIT`, `CommunityGraphChurnRatioTckIT` |
| Storage | `CommunityS3BlobStorageTckIT` |
| Security | `CommunityOidcKeycloakIT` |

Several are the only executable evidence behind contracts **ADR-012** and **ADR-056** rest on.

## The fix already existed one module away

`exeris-kernel-community-kafka` added this exact `<includes>` block in **v0.8 Sprint 6 (Coverage C-P0-02)**, with a comment describing the same failure in almost the same words — *"the three IT files end in IT and were silently dead before this include addition"*.

It never reached `exeris-kernel-community`. So the Kafka gate has been genuinely running its ITs ever since, while the persistence gate has not. Same block, same reason, now here.

## Evidence — the two commands that matter

**Default build still excludes them** (no Docker required):

```
mvn -pl exeris-kernel-community test   →  0 *IT classes selected
```

Safe because **every one of the eleven is `@Tag("integration")`** — I verified that per file with an anchored grep rather than assuming it. (My first pass used an unanchored pattern and wrongly reported two Core ITs as tagged when the match was inside a comment; the anchored re-run is what this rests on.)

**The gate's own command now runs them all:**

```
mvn -pl exeris-kernel-community -DincludedGroups=integration -DexcludedGroups= test
  →  11 IT classes, 74 tests, 0 failures
```

They were never broken. They had simply never run.

## Consequence worth stating

This gate can now go red. That is the point.

There is a live example: #279 changes `CommunityClaimsMapper` to read real token claims, which breaks `CommunityOidcKeycloakIT` — a test this gate has never executed. #279 carries its own fix, so either merge order is safe; but until this PR, nothing would have caught it.

## Verification

| Gate | Result |
|---|---|
| `mvn clean install` (full reactor, no skip flags) | green |
| `mvn clean verify -P coverage` (what CI runs) | green |
| Default build IT selection | 0 |
| Integration gate IT selection | 11 classes / 74 tests, 0 failures |

## The lesson this repeats

Same shape as the "verify skips PMD" myth (PR #238) and the JaCoCo floor that only started applying once a module gained its first test: **a gate believed because it was green, when green meant it had nothing to check.** A gate's name is not evidence — the `Running …` lines in its log are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)