### PR TITLE
fix(transport): drain waits for in-flight requests, not open connections (#282)

### DIFF
--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -311,9 +311,9 @@ When PAQS sheds a stream or the Kernel initiates graceful shutdown:
 
 1. **Close ingress** — the listening channel closes and the acceptor joins. No new connections; the
    reactors keep serving the ones already admitted.
-2. **Drain** — `PaqsScheduler.close()` waits for the admission controller's active-stream count to
-   reach zero under its 60-second hard deadline. The reactors are deliberately still looping here, so
-   a handler that completes during the drain can still have its response flushed.
+2. **Drain** — `PaqsScheduler.close()` marks the engine draining and waits for the count of **busy**
+   streams to reach zero, under its 60-second hard deadline. The reactors are deliberately still
+   looping here, so a handler that completes during the drain can still have its response flushed.
 3. **Teardown** — reactors are woken and joined, then the selector and all remaining channels close.
 
 Until 0.11 the drain ran *after* teardown, which made it inert: handlers were waited on while their
@@ -322,10 +322,35 @@ observed a connection closed with no reply, and an idempotent client retried int
 already gone. `AbstractTransportEngineTck$GracefulDrain` now pins the contract — it holds a stream
 mid-exchange across `stop()` and asserts the response still arrives.
 
+**Busy, not open — and busy by default (since 0.11, issue #282).** The drain waits for streams being
+*served*, not for streams being *open*. Until this was separated it waited on the admission
+controller's active-stream count, which counts connections: a keep-alive connection holds a slot for
+its whole life, so an idle one burned the entire 60-second deadline. Every connection-pooling client,
+load balancer and service mesh holds connections idle, and a container runtime's default grace period
+is shorter than the deadline — so the normal outcome was SIGKILL mid-shutdown on every rollout.
+
+A stream is **busy from the moment it starts** and stays busy unless its protocol reports otherwise
+(`DrainCoordinator.StreamWork`). The default is load-bearing in the opposite direction from the
+obvious one: counting only work a protocol explicitly declares means a protocol that declares nothing
+looks finished, so teardown severs a handler still writing its response — the very regression the
+phase order above exists to prevent. A raw `StreamHandler` therefore keeps the full drain; only a
+codec that knows it is parked between requests — the HTTP/1.1 keep-alive loop — reports idle.
+
+**`Connection: close` while draining.** A response encoded after the drain has begun carries it,
+whatever the request asked for. Without it a well-behaved peer has no way to learn it should release a
+pooled connection, and the next shutdown waits on the same idle connection again.
+
+The question is asked when the response is written, not when the request was parsed — and the
+distinction is the whole point. The request that most needs to tell its peer to let go is the one
+already in flight when shutdown began; answered at parse time it always gets the pre-shutdown answer,
+so the peer keeps a connection it will never be asked about again.
+
 **Telemetry.** `CommunityTransportDrainEvent` (JFR `eu.exeris.kernel.transport.CommunityTransportDrain`)
-records each drain's stream count at start, count remaining, and duration. A non-zero
-`streamsRemaining` means the deadline fired before the drain finished — the signal that in-flight work
-was severed, and the number to tune `terminationGracePeriodSeconds` against.
+records `busyAtStart`, `busyRemaining`, `openAtStart` and duration. A non-zero `busyRemaining` means
+the deadline fired while work was still in flight — the signal that in-flight work was severed, and
+the number to tune `terminationGracePeriodSeconds` against. `openAtStart` is reported for context: it
+is the number the drain waited on before 0.11, and the gap between it and `busyAtStart` is exactly the
+idle connections that used to hold shutdown open.
 
 ---
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpExchange.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpExchange.java
@@ -9,6 +9,8 @@
 package eu.exeris.kernel.community.http;
 
 import eu.exeris.kernel.core.http.http1.Http1ResponseEncoder;
+import eu.exeris.kernel.core.transport.TransportScopes;
+import eu.exeris.kernel.core.transport.scheduler.DrainCoordinator;
 import eu.exeris.kernel.spi.http.HttpEncodedBody;
 import eu.exeris.kernel.spi.http.HttpExchange;
 import eu.exeris.kernel.spi.http.HttpHeader;
@@ -23,22 +25,19 @@ import eu.exeris.kernel.spi.memory.MemoryAllocator;
 import eu.exeris.kernel.spi.transport.TransportStream;
 
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 final class CommunityHttpExchange implements HttpExchange {
 
-    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
-    private static final String HEADER_CONNECTION = "Connection";
-    private static final String HEADER_CLOSE = "close";
     private static final int RESPONSE_HEADROOM_BYTES = 2048;
 
     private final HttpRequest request;
     private final TransportStream stream;
     private final MemoryAllocator allocator;
-    private final boolean keepAlive;
+    private final boolean requestedKeepAlive;
+    private final DrainCoordinator drainCoordinator;
     private final HttpResponseBodyEncoderRegistry encoderRegistry;
     private final AtomicBoolean responded = new AtomicBoolean(false);
 
@@ -50,7 +49,14 @@ final class CommunityHttpExchange implements HttpExchange {
         this.request = Objects.requireNonNull(request, "request must not be null");
         this.stream = Objects.requireNonNull(stream, "stream must not be null");
         this.allocator = Objects.requireNonNull(allocator, "allocator must not be null");
-        this.keepAlive = keepAlive;
+        this.requestedKeepAlive = keepAlive;
+        // Captured here, not read in respond(): this constructor runs on the stream's own Virtual
+        // Thread where the scope is bound, while an application is free to complete its exchange
+        // from elsewhere. An unbound slot (a carrier that drains without a coordinator, or a unit
+        // test) leaves this null and the connection behaves exactly as the request asked.
+        this.drainCoordinator = TransportScopes.DRAIN_COORDINATOR.isBound()
+                ? TransportScopes.DRAIN_COORDINATOR.get()
+                : null;
         this.encoderRegistry = Objects.requireNonNull(encoderRegistry, "encoderRegistry must not be null");
     }
 
@@ -66,6 +72,33 @@ final class CommunityHttpExchange implements HttpExchange {
         respondInternalClaimed(response);
     }
 
+    @Override
+    public void respond(HttpTypedResponse typedResponse) {
+        Objects.requireNonNull(typedResponse, "typedResponse must not be null");
+        Object payload = typedResponse.payload();
+        Class<?> payloadType = payload == null ? Void.class : payload.getClass();
+        HttpResponseBodyEncoder encoder = encoderRegistry.resolve(payloadType);
+        if (encoder == null) {
+            throw new UnsupportedOperationException("No encoder registered for payload type: " + payloadType.getName());
+        }
+        HttpResponseEncodingContext context = new HttpResponseEncodingContext(request, allocator);
+        HttpEncodedBody encoded = encoder.encode(typedResponse.payload(), context);
+        List<HttpHeader> mergedHeaders =
+                CommunityHttpResponseHeaders.merge(typedResponse.headers(), encoded.headers());
+        try {
+            respond(new HttpResponse(typedResponse.status(), request.version(), mergedHeaders, encoded.body()));
+        } catch (IllegalStateException ex) {
+            if (encoded.body() != null) {
+                encoded.body().close();
+            }
+            throw ex;
+        }
+    }
+
+    /* default */ boolean isResponded() {
+        return responded.get();
+    }
+
     private void claimResponse() {
         if (!responded.compareAndSet(false, true)) {
             throw new IllegalStateException("respond() already called for this exchange");
@@ -76,6 +109,9 @@ final class CommunityHttpExchange implements HttpExchange {
         LoanedBuffer responseBody = response.body();
         int bodyBytes = responseBody == null ? 0 : (int) responseBody.size();
         int bufferSize = RESPONSE_HEADROOM_BYTES + bodyBytes;
+        // Resolved once, here: the header written below and the socket teardown after it must agree,
+        // and the drain flag can flip between them.
+        boolean keepAlive = resolveKeepAlive();
 
         try (LoanedBuffer bodyOwned = responseBody;
              LoanedBuffer outbound = allocator.allocateNetwork(bufferSize)) {
@@ -85,7 +121,8 @@ final class CommunityHttpExchange implements HttpExchange {
                     position,
                     response.status().code(),
                     response.status().reasonPhrase());
-            position = writeHeaders(outbound.segment(), response.headers(), bodyBytes, position);
+            position = CommunityHttpResponseHeaders.write(
+                    outbound.segment(), response.headers(), bodyBytes, position, keepAlive);
 
             if (bodyOwned != null && bodyBytes > 0) {
                 MemorySegment.copy(bodyOwned.segment(), 0, outbound.segment(), position, bodyBytes);
@@ -100,76 +137,15 @@ final class CommunityHttpExchange implements HttpExchange {
         }
     }
 
-    /* default */ boolean isResponded() {
-        return responded.get();
-    }
-
-    @Override
-    public void respond(HttpTypedResponse typedResponse) {
-        Objects.requireNonNull(typedResponse, "typedResponse must not be null");
-        Object payload = typedResponse.payload();
-        Class<?> payloadType = payload == null ? Void.class : payload.getClass();
-        HttpResponseBodyEncoder encoder = encoderRegistry.resolve(payloadType);
-        if (encoder == null) {
-            throw new UnsupportedOperationException("No encoder registered for payload type: " + payloadType.getName());
-        }
-        HttpResponseEncodingContext context = new HttpResponseEncodingContext(request, allocator);
-        HttpEncodedBody encoded = encoder.encode(typedResponse.payload(), context);
-        List<HttpHeader> mergedHeaders = mergeHeaders(typedResponse.headers(), encoded.headers());
-        try {
-            respond(new HttpResponse(typedResponse.status(), request.version(), mergedHeaders, encoded.body()));
-        } catch (IllegalStateException ex) {
-            if (encoded.body() != null) {
-                encoded.body().close();
-            }
-            throw ex;
-        }
-    }
-
-    private static List<HttpHeader> mergeHeaders(List<HttpHeader> typedHeaders, List<HttpHeader> encodedHeaders) {
-        if (typedHeaders.isEmpty()) {
-            return encodedHeaders;
-        }
-        if (encodedHeaders.isEmpty()) {
-            return typedHeaders;
-        }
-        List<HttpHeader> merged = new ArrayList<>(typedHeaders.size() + encodedHeaders.size());
-        merged.addAll(typedHeaders);
-        merged.addAll(encodedHeaders);
-        return merged;
-    }
-
-    private long writeHeaders(MemorySegment target,
-                              List<HttpHeader> headers,
-                              int bodyBytes,
-                              long position) {
-        long pos = position;
-        boolean hasContentLength = false;
-        boolean hasConnection = false;
-        for (HttpHeader header : headers) {
-            if (header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH)) {
-                hasContentLength = true;
-            }
-            if (header.nameEqualsIgnoreCase(HEADER_CONNECTION)) {
-                hasConnection = true;
-            }
-            pos = Http1ResponseEncoder.writeHeader(target, pos, header.name(), header.value());
-        }
-
-        if (!hasContentLength) {
-            pos = Http1ResponseEncoder.writeHeader(
-                    target,
-                    pos,
-                    HEADER_CONTENT_LENGTH,
-                    Integer.toString(bodyBytes));
-        }
-        if (!hasConnection) {
-            pos = Http1ResponseEncoder.writeHeader(
-                    target,
-                    pos,
-                    HEADER_CONNECTION,
-                    keepAlive ? "keep-alive" : HEADER_CLOSE);
-        }
-        return Http1ResponseEncoder.writeHeaderEnd(target, pos);
+    /**
+     * Whether this response may keep the connection alive.
+     *
+     * <p>Asked <em>now</em>, not when the request was parsed. The request that most needs to tell its
+     * peer to let go is the one already in flight when graceful shutdown began; answered at parse
+     * time it always gets the pre-shutdown answer, so the peer keeps a pooled connection it will
+     * never be asked about again and the next shutdown waits on it as idle.
+     */
+    private boolean resolveKeepAlive() {
+        return requestedKeepAlive && (drainCoordinator == null || !drainCoordinator.isDraining());
     }
 }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -193,6 +193,11 @@ public final class CommunityHttpRequestProcessor {
             // Shutdown began while this connection was being served. Extending it would put the
             // connection back into the idle state the drain cannot wait out; the response already
             // told the peer to close (see CommunityHttpExchange#resolveKeepAlive).
+            //
+            // Accepted residual: the drain can begin between that write and this check, so a peer can
+            // be told keep-alive and then find the connection closed. There is no I/O between the two
+            // to widen the window, and RFC 9112 §9.6 requires a client to tolerate exactly this — a
+            // persistent connection may close at any time, and an idempotent request is retried.
             return false;
         }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -12,6 +12,7 @@ import eu.exeris.kernel.core.http.routing.HttpRouter;
 import eu.exeris.kernel.community.persistence.PersistenceSessionBox;
 import eu.exeris.kernel.core.http.http1.Http1Codec;
 import eu.exeris.kernel.core.security.GeneratedRoleRegistryLoader;
+import eu.exeris.kernel.core.transport.TransportScopes;
 import eu.exeris.kernel.core.security.SecurityInterceptor;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpConfig;
@@ -150,7 +151,16 @@ public final class CommunityHttpRequestProcessor {
             state.resetBufferForNewAggregate();
         }
 
-        ReadResult readResult = readRequest(codec, stream, handler, state, state.bufferedBytes());
+        // Parked on the next request, this connection is serving nothing — it must not hold graceful
+        // shutdown open, because an idle keep-alive connection never closes on its own (issue #282).
+        // Streams are busy by default, so a protocol that cannot tell simply never reaches this.
+        markIdle();
+        ReadResult readResult;
+        try {
+            readResult = readRequest(codec, stream, handler, state, state.bufferedBytes());
+        } finally {
+            markBusy();
+        }
         if (readResult == null) {
             return false;
         }
@@ -179,10 +189,33 @@ public final class CommunityHttpRequestProcessor {
         if (!readResult.keepAlive()) {
             return false;
         }
+        if (isDraining()) {
+            // Shutdown began while this connection was being served. Extending it would put the
+            // connection back into the idle state the drain cannot wait out; the response already
+            // told the peer to close (see CommunityHttpExchange#resolveKeepAlive).
+            return false;
+        }
 
         CommunityHttpAggregateTelemetry.applyAndRelease(state, MAX_AGGREGATE_BYTES);
         state.releaseAggregateIfIdle();
         return true;
+    }
+
+    private static void markIdle() {
+        if (TransportScopes.STREAM_WORK.isBound()) {
+            TransportScopes.STREAM_WORK.get().markIdle();
+        }
+    }
+
+    private static void markBusy() {
+        if (TransportScopes.STREAM_WORK.isBound()) {
+            TransportScopes.STREAM_WORK.get().markBusy();
+        }
+    }
+
+    private static boolean isDraining() {
+        return TransportScopes.DRAIN_COORDINATOR.isBound()
+                && TransportScopes.DRAIN_COORDINATOR.get().isDraining();
     }
 
     private boolean handleRequest(ReadResult readResult,
@@ -244,6 +277,8 @@ public final class CommunityHttpRequestProcessor {
             return true;
         }
 
+        // The exchange decides Connection: keep-alive when it writes, not here — see
+        // CommunityHttpExchange#resolveKeepAlive.
         CommunityHttpExchange exchange = new CommunityHttpExchange(
                 request, stream, allocator, readResult.keepAlive(), encoderRegistry);
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpResponseHeaders.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpResponseHeaders.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.core.http.http1.Http1ResponseEncoder;
+import eu.exeris.kernel.spi.http.HttpHeader;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Assembles the HTTP/1.1 response header block.
+ *
+ * <p>Split out of {@code CommunityHttpExchange} so that class is about one thing — respond-once
+ * semantics and the connection's fate — while header assembly lives next to the encoder it drives.
+ */
+final class CommunityHttpResponseHeaders {
+
+    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
+    private static final String HEADER_CONNECTION = "Connection";
+    private static final String HEADER_CLOSE = "close";
+    private static final String HEADER_KEEP_ALIVE = "keep-alive";
+
+    private CommunityHttpResponseHeaders() {
+    }
+
+    /**
+     * Writes the header block, supplying {@code Content-Length} and {@code Connection} only where the
+     * response did not already state them — an explicit header from the application wins.
+     *
+     * @param keepAlive whether the connection survives this response; see
+     *                  {@code CommunityHttpExchange#resolveKeepAlive()} for when that is decided
+     * @return the position just past the terminating blank line
+     */
+    /* default */ static long write(MemorySegment target,
+                                    List<HttpHeader> headers,
+                                    int bodyBytes,
+                                    long position,
+                                    boolean keepAlive) {
+        long pos = position;
+        boolean hasContentLength = false;
+        boolean hasConnection = false;
+        for (HttpHeader header : headers) {
+            hasContentLength |= header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH);
+            hasConnection |= header.nameEqualsIgnoreCase(HEADER_CONNECTION);
+            pos = Http1ResponseEncoder.writeHeader(target, pos, header.name(), header.value());
+        }
+
+        if (!hasContentLength) {
+            pos = Http1ResponseEncoder.writeHeader(
+                    target, pos, HEADER_CONTENT_LENGTH, Integer.toString(bodyBytes));
+        }
+        if (!hasConnection) {
+            pos = Http1ResponseEncoder.writeHeader(
+                    target, pos, HEADER_CONNECTION, keepAlive ? HEADER_KEEP_ALIVE : HEADER_CLOSE);
+        }
+        return Http1ResponseEncoder.writeHeaderEnd(target, pos);
+    }
+
+    /** Concatenates application headers with encoder-supplied ones, allocating only when both exist. */
+    /* default */ static List<HttpHeader> merge(List<HttpHeader> typedHeaders,
+                                                List<HttpHeader> encodedHeaders) {
+        if (typedHeaders.isEmpty()) {
+            return encodedHeaders;
+        }
+        if (encodedHeaders.isEmpty()) {
+            return typedHeaders;
+        }
+        List<HttpHeader> merged = new ArrayList<>(typedHeaders.size() + encodedHeaders.size());
+        merged.addAll(typedHeaders);
+        merged.addAll(encodedHeaders);
+        return merged;
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
@@ -27,8 +27,10 @@ import jdk.jfr.StackTrace;
  * second case, and the first leaves no trace at all — so an operator tuning
  * {@code terminationGracePeriodSeconds} has nothing to tune against.
  *
- * <p>{@code streamsRemaining > 0} is the signal that matters: the deadline fired first. Pair it with
- * {@code durationNanos} to tell "handlers are genuinely slow" from "one handler is stuck".
+ * <p>{@code busyRemaining > 0} is the signal that matters: the deadline fired first. Pair it with
+ * {@code durationNanos} to tell "handlers are genuinely slow" from "one handler is stuck". The gap
+ * between {@code openAtStart} and {@code busyAtStart} is the idle connections that used to hold
+ * shutdown open before 0.11.
  *
  * <p>Counts only — no peer identity, no request content. Single-phase {@code commit()} on the platform
  * thread driving shutdown; never on a virtual thread, so the carrier-pinning hazard that afflicts

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/CommunityTransportDrainEvent.java
@@ -46,18 +46,27 @@ final class CommunityTransportDrainEvent extends Event {
     @Label("Engine Name")
     /* default */ String engineName;
 
-    @Label("Streams In Flight At Drain Start")
-    /* default */ int streamsAtStart;
+    @Label("Busy Streams At Drain Start")
+    @Description("Streams actively being served when the drain began — what the drain waits on")
+    /* default */ int busyAtStart;
 
-    @Label("Streams Remaining After Drain")
-    /* default */ int streamsRemaining;
+    @Label("Busy Streams Remaining After Drain")
+    @Description("Non-zero means the deadline fired while work was still in flight")
+    /* default */ int busyRemaining;
+
+    @Label("Open Streams At Drain Start")
+    @Description("Connections admitted when the drain began, busy or idle. Reported for context: "
+            + "before 0.11 the drain waited on THIS number, which an idle keep-alive connection "
+            + "never lowers, so shutdown burned its full deadline")
+    /* default */ int openAtStart;
 
     @Label("Drain Duration (ns)")
     /* default */ long durationNanos;
 
     /* default */ static void emit(String engineName,
-                                   int streamsAtStart,
-                                   int streamsRemaining,
+                                   int busyAtStart,
+                                   int busyRemaining,
+                                   int openAtStart,
                                    long durationNanos) {
         if (!FlightRecorder.isInitialized()) {
             return;
@@ -65,8 +74,9 @@ final class CommunityTransportDrainEvent extends Event {
         CommunityTransportDrainEvent event = new CommunityTransportDrainEvent();
         if (event.isEnabled()) {
             event.engineName = engineName;
-            event.streamsAtStart = streamsAtStart;
-            event.streamsRemaining = streamsRemaining;
+            event.busyAtStart = busyAtStart;
+            event.busyRemaining = busyRemaining;
+            event.openAtStart = openAtStart;
             event.durationNanos = durationNanos;
             event.commit();
         }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -229,16 +229,18 @@ public final class NativeTcpCarrier implements TransportEngine {
 
         // Phase 2 — drain in-flight streams while the write path is still alive.
         long drainStartNanos = System.nanoTime();
-        int inFlightAtStart = paqsActiveStreams();
         PaqsScheduler localPaqs = paqs;
+        int openAtStart = paqsActiveStreams();
+        int busyAtStart = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyStreams();
         if (localPaqs != null) {
             localPaqs.close();
         }
-        int inFlightRemaining = paqsActiveStreams();
+        int busyRemaining = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyStreams();
         CommunityTransportDrainEvent.emit(
                 engineName(),
-                inFlightAtStart,
-                inFlightRemaining,
+                busyAtStart,
+                busyRemaining,
+                openAtStart,
                 System.nanoTime() - drainStartNanos);
 
         // Phase 3 — the drain is over by completion or by deadline; take the loops down.

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpDrainIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpDrainIntegrationTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.core.transport.TransportScopes;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.http.HttpConfig;
+import eu.exeris.kernel.spi.http.HttpMode;
+import eu.exeris.kernel.spi.http.HttpProvider;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpServerEngine;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Shutdown must wait for requests, not for connections (issue #282).
+ *
+ * <p>The distinction only exists above the transport: a raw stream handler that parks is
+ * indistinguishable from one that is working, so the transport correctly treats it as busy. Only the
+ * HTTP codec knows it is between requests. That is why this case lives here and not in
+ * {@code AbstractTransportEngineTck} — the first version of this test asserted an HTTP property
+ * through a raw handler and failed for the right reason.
+ */
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+@DisplayName("Community HTTP: graceful drain and idle keep-alive connections")
+class CommunityHttpDrainIntegrationTest {
+
+    private static final MemoryAllocator ALLOCATOR =
+            new CommunityMemoryProvider().createAllocator(MemoryProviderConfig.defaults());
+
+    /** Well under the drain's 60 s deadline, well over an unblocked shutdown. */
+    private static final long ACCEPTABLE_SHUTDOWN_SECONDS = 15L;
+
+    @AfterAll
+    @SuppressWarnings("unused")
+    static void closeAllocator() {
+        ALLOCATOR.close();
+    }
+
+    @Test
+    @DisplayName("an idle keep-alive connection does not hold stop() to the drain deadline")
+    void idleKeepAliveConnectionDoesNotHoldShutdown() throws Exception {
+        int port = nextFreePort();
+
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR).run(() -> {
+            HttpProvider provider = new CommunityHttpProvider();
+            HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+            server.setHandler(exchange ->
+                    exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version())));
+            server.start();
+
+            try (Socket client = new Socket("127.0.0.1", port)) {
+                client.setSoTimeout((int) TimeUnit.SECONDS.toMillis(10L));
+                exchangeOneKeepAliveRequest(client);
+
+                // The client deliberately keeps its socket open. This is what every connection-pooling
+                // HTTP client, load balancer and service mesh does between requests — and before the
+                // fix it made shutdown wait out the full 60 s drain deadline, so a container runtime
+                // SIGKILLed the process mid-shutdown on every rollout.
+                long startNanos = System.nanoTime();
+                server.close();
+                long elapsedSeconds = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startNanos);
+
+                assertThat(elapsedSeconds)
+                        .as("nothing is in flight — the response was fully received before shutdown "
+                                + "began — so the drain has nothing to wait for. An idle keep-alive "
+                                + "connection never closes on its own; that is what keep-alive means")
+                        .isLessThan(ACCEPTABLE_SHUTDOWN_SECONDS);
+            } catch (IOException e) {
+                throw new IllegalStateException("keep-alive exchange failed", e);
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("a response issued while draining tells the peer to close")
+    void drainingResponseAsksPeerToClose() throws Exception {
+        int port = nextFreePort();
+
+        ScopedValue.where(KernelProviders.MEMORY_ALLOCATOR, ALLOCATOR).run(() -> {
+            CountDownLatch handlerEntered = new CountDownLatch(1);
+            AtomicBoolean secondRequest = new AtomicBoolean(false);
+
+            HttpProvider provider = new CommunityHttpProvider();
+            HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+            server.setHandler(exchange -> {
+                if (secondRequest.get()) {
+                    // Hold this request IN FLIGHT so the drain has something to wait for. Ordering
+                    // matters and the first version of this test had it backwards: it started the
+                    // shutdown while the connection was idle, which — by the very fix under test —
+                    // completes the drain at once and tears the connection down before a second
+                    // request can arrive. A response can only be encoded during a drain if a request
+                    // was already in flight when the drain began.
+                    handlerEntered.countDown();
+                    // Release itself when the drain is actually marked. The engine's isRunning()
+                    // flips false in stop()'s entry guard, BEFORE phase 2 marks draining, so it is
+                    // the wrong signal — releasing on it encodes the response too early and the test
+                    // sees keep-alive. Only the coordinator knows, and only this thread can read it.
+                    awaitDrainingInScope();
+                }
+                exchange.respond(HttpResponse.noBody(HttpStatus.OK, exchange.request().version()));
+            });
+            server.start();
+
+            Thread stopper = null;
+            try (Socket client = new Socket("127.0.0.1", port)) {
+                client.setSoTimeout((int) TimeUnit.SECONDS.toMillis(30L));
+
+                assertThat(exchangeOneKeepAliveRequest(client))
+                        .as("the control: before draining, a keep-alive response must not carry "
+                                + "Connection: close, or the assertion below proves nothing")
+                        .doesNotContain("Connection: close");
+
+                secondRequest.set(true);
+                sendKeepAliveRequest(client);
+                assertThat(awaitQuietly(handlerEntered))
+                        .as("the second request must be in flight before shutdown starts").isTrue();
+
+                stopper = Thread.ofPlatform().start(server::close);
+
+                assertThat(readResponseHead(client))
+                        .as("a peer holding a pooled connection has no other way to learn it should "
+                                + "release it; without this header it keeps the connection and the "
+                                + "next shutdown waits on it again")
+                        .contains("Connection: close");
+            } catch (IOException e) {
+                throw new IllegalStateException("keep-alive exchange failed", e);
+            } finally {
+                if (stopper != null) {
+                    joinQuietly(stopper);
+                }
+                server.close();
+            }
+        });
+    }
+
+    /** Spins on the stream's own scope until the drain is marked. Runs on the handler thread. */
+    private static void awaitDrainingInScope() {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20L);
+        while (System.nanoTime() < deadline) {
+            if (TransportScopes.DRAIN_COORDINATOR.isBound()
+                    && TransportScopes.DRAIN_COORDINATOR.get().isDraining()) {
+                return;
+            }
+            Thread.onSpinWait();
+        }
+    }
+
+    private static void joinQuietly(Thread thread) {
+        try {
+            thread.join(TimeUnit.SECONDS.toMillis(30L));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static boolean awaitQuietly(CountDownLatch latch) {
+        try {
+            return latch.await(30L, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static String exchangeOneKeepAliveRequest(Socket client) throws IOException {
+        sendKeepAliveRequest(client);
+        String head = readResponseHead(client);
+        assertThat(head)
+                .as("the exchange must complete before shutdown, so nothing is genuinely in flight")
+                .startsWith("HTTP/1.1 200");
+        return head;
+    }
+
+    private static void sendKeepAliveRequest(Socket client) throws IOException {
+        OutputStream out = client.getOutputStream();
+        out.write(("GET /ping HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+        out.flush();
+    }
+
+    private static String readResponseHead(Socket client) throws IOException {
+        InputStream in = client.getInputStream();
+        StringBuilder response = new StringBuilder(128);
+        int b;
+        while ((b = in.read()) != -1) {
+            response.append((char) b);
+            if (response.length() >= 4 && response.lastIndexOf("\r\n\r\n") == response.length() - 4) {
+                break;
+            }
+        }
+        return response.toString();
+    }
+
+    private static HttpConfig serverConfig(int port) {
+        return new HttpConfig(
+                HttpMode.SERVER, "127.0.0.1", port,
+                HttpConfig.DEFAULT_MAX_CONNECTIONS, HttpConfig.DEFAULT_IDLE_TIMEOUT_MS,
+                HttpConfig.DEFAULT_MAX_HEADER_COUNT, HttpConfig.DEFAULT_MAX_HEADER_SIZE,
+                HttpConfig.DEFAULT_MAX_REQUEST_BODY_BYTES, false, HttpVersion.HTTP_1_1);
+    }
+
+    private static int nextFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to allocate free TCP port", ex);
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/TransportScopes.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/TransportScopes.java
@@ -57,6 +57,33 @@ public final class TransportScopes {
      */
     public static final ScopedValue<String> ENGINE_NAME = ScopedValue.newInstance();
 
+    /**
+     * The engine's {@link eu.exeris.kernel.core.transport.scheduler.DrainCoordinator}.
+     *
+     * <p>Bound by {@code PaqsScheduler} around every stream handler, so a protocol layer can mark
+     * the work a graceful shutdown must wait for without the transport having to know what a
+     * "request" is. Read defensively — a carrier that does not bind it leaves the slot unbound, and
+     * a protocol that does not read it simply never marks, which drains immediately rather than
+     * hanging.
+     *
+     * @since 0.11.0
+     */
+    public static final ScopedValue<eu.exeris.kernel.core.transport.scheduler.DrainCoordinator>
+            DRAIN_COORDINATOR = ScopedValue.newInstance();
+
+    /**
+     * This stream's {@link eu.exeris.kernel.core.transport.scheduler.DrainCoordinator.StreamWork}.
+     *
+     * <p>A protocol layer that can tell when it is between units of work reports idleness through
+     * this handle, so an idle connection stops holding graceful shutdown open. A protocol that never
+     * reports stays busy for the stream's lifetime, which is the safe default.
+     *
+     * @since 0.11.0
+     */
+    public static final ScopedValue<
+            eu.exeris.kernel.core.transport.scheduler.DrainCoordinator.StreamWork> STREAM_WORK =
+            ScopedValue.newInstance();
+
     private TransportScopes() {
     }
 }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.transport.scheduler;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+/**
+ * Core: counts the streams a graceful shutdown must actually wait for, and tells protocol layers when
+ * that shutdown has begun.
+ *
+ * <h2>Why this is not the admission counter</h2>
+ * <p>{@link AdmissionController#activeStreamCount()} answers a capacity question: how many
+ * Virtual-Thread-per-stream handlers are running, which is what admission and load-shedding must
+ * respect. For a keep-alive connection that handler runs for the whole connection — correct for
+ * capacity, wrong for draining. An idle connection occupies a slot and has nothing being served, and
+ * it will not go away on its own; that is what keep-alive means. Waiting on it burns the whole drain
+ * deadline, and a container runtime SIGKILLs the process mid-shutdown on every rollout.
+ *
+ * <h2>Busy by default — the direction that matters</h2>
+ * <p>A stream is <b>busy from the moment it starts</b> and stays busy unless its protocol says
+ * otherwise. Only a protocol that knows it is between units of work — an HTTP/1.1 loop parked on the
+ * next request — reports itself idle.
+ *
+ * <p>The default is load-bearing, and the opposite default is a trap this class was written with and
+ * then corrected. Counting only work that protocols explicitly declare means a protocol that declares
+ * nothing looks finished, so the drain completes at once and teardown severs a handler still writing
+ * its response — which is the exact regression graceful shutdown exists to prevent. Defaulting to busy
+ * costs an unparticipating protocol a wait; defaulting to idle costs it its response.
+ *
+ * <h2>Allocation</h2>
+ * <p>One shared instance per engine plus one {@link StreamWork} handle per stream — the same order as
+ * the Virtual Thread PAQS already spawns per stream, and nothing per request. The handle's own flag is
+ * confined to its stream's thread, so only the shared counter is atomic.
+ *
+ * @since 0.11.0
+ */
+public final class DrainCoordinator {
+
+    private static final VarHandle BUSY_STREAMS;
+    private static final VarHandle DRAINING;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            BUSY_STREAMS = lookup.findVarHandle(DrainCoordinator.class, "busyStreams", int.class);
+            DRAINING = lookup.findVarHandle(DrainCoordinator.class, "draining", boolean.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @SuppressWarnings("unused") // VarHandle-accessed
+    private volatile int busyStreams;
+
+    @SuppressWarnings("unused") // VarHandle-accessed
+    private volatile boolean draining;
+
+    /**
+     * Registers a starting stream as busy.
+     *
+     * <p>Called by {@link PaqsScheduler} for every admitted stream, before the handler runs.
+     *
+     * @return the handle the protocol layer uses to report idleness; must be closed on stream exit
+     */
+    public StreamWork registerStream() {
+        BUSY_STREAMS.getAndAdd(this, 1);
+        return new StreamWork(this);
+    }
+
+    /**
+     * Returns how many streams are currently being served.
+     *
+     * @return the busy count; {@code 0} means shutdown may proceed to teardown
+     */
+    public int busyStreams() {
+        return (int) BUSY_STREAMS.getAcquire(this);
+    }
+
+    /**
+     * Signals that graceful shutdown has begun.
+     *
+     * <p>Protocol layers read this to stop extending connections they would otherwise keep alive, and
+     * to tell the peer so — an HTTP/1.1 codec responds {@code Connection: close}. Without that, a
+     * well-behaved client has no way to know it should release the connection.
+     */
+    public void markDraining() {
+        DRAINING.setRelease(this, true);
+    }
+
+    /**
+     * Returns whether graceful shutdown has begun.
+     *
+     * @return {@code true} once {@link #markDraining()} has been called
+     */
+    public boolean isDraining() {
+        return (boolean) DRAINING.getAcquire(this);
+    }
+
+    private void release() {
+        BUSY_STREAMS.getAndAdd(this, -1);
+    }
+
+    /**
+     * One stream's contribution to the busy count.
+     *
+     * <p>The flag is confined to the stream's own thread — the protocol loop that reports it is the
+     * only caller — so the handle needs no synchronisation of its own.
+     */
+    public static final class StreamWork implements AutoCloseable {
+
+        private final DrainCoordinator owner;
+        private boolean busy = true;
+
+        private StreamWork(DrainCoordinator owner) {
+            this.owner = owner;
+        }
+
+        /** Reports that this stream is between units of work and must not hold shutdown open. */
+        public void markIdle() {
+            if (busy) {
+                busy = false;
+                owner.release();
+            }
+        }
+
+        /** Reports that this stream has work in flight again. */
+        public void markBusy() {
+            if (!busy) {
+                busy = true;
+                BUSY_STREAMS.getAndAdd(owner, 1);
+            }
+        }
+
+        /** Releases this stream's contribution; idempotent with {@link #markIdle()}. */
+        @Override
+        public void close() {
+            markIdle();
+        }
+    }
+}

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -87,6 +87,7 @@ public final class PaqsScheduler implements AutoCloseable {
     private static final String PHASE_HANDLER = "HANDLER";
 
     private final AdmissionController admissionController;
+    private final DrainCoordinator drainCoordinator = new DrainCoordinator();
     private final StreamLoadShedder loadShedder;
     private final StreamHandler handler;
     private final Function<TransportStream, StreamPriority> priorityExtractor;
@@ -208,6 +209,18 @@ public final class PaqsScheduler implements AutoCloseable {
     }
 
     /**
+     * Returns the engine's {@link DrainCoordinator}, for carriers reporting drain telemetry.
+     *
+     * <p>Distinct from {@link #admissionController()} on purpose: that one counts open streams,
+     * which is the capacity question, while this one counts streams being served.
+     *
+     * @return the coordinator; never {@code null}
+     */
+    public DrainCoordinator drainCoordinator() {
+        return drainCoordinator;
+    }
+
+    /**
      * Returns the {@link StreamLoadShedder} for diagnostic inspection (e.g., shed count).
      *
      * @return the load shedder; never {@code null}
@@ -223,15 +236,22 @@ public final class PaqsScheduler implements AutoCloseable {
      */
     @Override
     public void close() {
+        // Tell the protocol layers first: a codec that knows shutdown started stops extending
+        // connections it would otherwise keep alive, so the count below can actually reach zero.
+        drainCoordinator.markDraining();
+
         final long deadlineNanos = System.nanoTime() + 60_000_000_000L;
         long spins = 0L;
-        while (admissionController.activeStreamCount() > 0) {
+        // Waits on streams being SERVED, not on streams being OPEN. A stream is busy from the moment
+        // it starts and only a protocol that knows it is between requests reports otherwise, so a raw
+        // handler still gets the full drain while an idle keep-alive connection stops holding it.
+        while (drainCoordinator.busyStreams() > 0) {
             if (System.nanoTime() >= deadlineNanos) {
-                int remaining = admissionController.activeStreamCount();
+                int remaining = drainCoordinator.busyStreams();
                 if (remaining > 0) {
                     LOG.log(System.Logger.Level.WARNING,
-                            "PaqsScheduler.close() timed out waiting for {0} active streams"
-                                    + " to complete; proceeding with shutdown",
+                            "PaqsScheduler.close() timed out waiting for {0} busy"
+                                    + " streams to finish; proceeding with shutdown",
                             remaining);
                 }
                 break;
@@ -296,10 +316,14 @@ public final class PaqsScheduler implements AutoCloseable {
         String outcome = StreamLifecycleEvent.OUTCOME_COMPLETE;
 
         try {
-            ScopedValue.where(TransportScopes.STREAM_PRIORITY, priority)
-                    .where(TransportScopes.STREAM_ID, streamId)
-                    .where(TransportScopes.ENGINE_NAME, engineName)
-                    .run(() -> handler.handle(stream));
+            try (DrainCoordinator.StreamWork work = drainCoordinator.registerStream()) {
+                ScopedValue.where(TransportScopes.STREAM_PRIORITY, priority)
+                        .where(TransportScopes.STREAM_ID, streamId)
+                        .where(TransportScopes.ENGINE_NAME, engineName)
+                        .where(TransportScopes.DRAIN_COORDINATOR, drainCoordinator)
+                        .where(TransportScopes.STREAM_WORK, work)
+                        .run(() -> handler.handle(stream));
+            }
         } catch (Error error) { //NOPMD AvoidCatchingGenericException — outcome must be set before rethrow
             outcome = StreamLifecycleEvent.OUTCOME_ERROR;
             PaqsHandlerFailureEvent.emit(streamId, engineName, error.getClass().getName(), PHASE_HANDLER);

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -63,6 +63,8 @@ import java.util.function.Function;
  *   <li>{@link TransportScopes#STREAM_PRIORITY} — the stream's business priority</li>
  *   <li>{@link TransportScopes#STREAM_ID} — the stream's unique identifier</li>
  *   <li>{@link TransportScopes#ENGINE_NAME} — the transport engine name for diagnostics</li>
+ *   <li>{@link TransportScopes#DRAIN_COORDINATOR} — whether graceful shutdown has begun</li>
+ *   <li>{@link TransportScopes#STREAM_WORK} — this stream's handle for reporting itself idle</li>
  * </ul>
  *
  * <h2>JFR-First Telemetry</h2>
@@ -230,9 +232,13 @@ public final class PaqsScheduler implements AutoCloseable {
     }
 
     /**
-     * Waits until the {@link AdmissionController}'s active stream count reaches zero,
-     * applying a spin-then-yield backoff strategy to avoid burning CPU, and enforcing
-     * a hard timeout to keep shutdown operationally safe even if a handler misbehaves.
+     * Marks the drain, then waits until no stream is being served.
+     *
+     * <p>Waits on {@link DrainCoordinator#busyStreams()} rather than the {@link AdmissionController}'s
+     * active count: the latter counts open streams, and a keep-alive connection stays open with
+     * nothing in flight for as long as its peer holds it, so waiting on it burned the whole deadline.
+     * Applies a spin-then-yield backoff to avoid burning CPU, and enforces a hard timeout so shutdown
+     * stays operationally safe even if a handler misbehaves.
      */
     @Override
     public void close() {

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.core.transport.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The counter a graceful shutdown waits on (issue #282).
+ *
+ * <p>Its invariants are cheap to state and expensive to get wrong: an over-decrement makes the drain
+ * finish early and sever a live exchange, an under-decrement makes it hang to the deadline and get
+ * SIGKILLed. The two socket-level tests in the transport TCK and the Community HTTP module prove the
+ * mechanism end to end but cannot isolate the arithmetic from stream timing, so it is pinned here.
+ */
+@DisplayName("DrainCoordinator — what a graceful shutdown waits on")
+class DrainCoordinatorTest {
+
+    @Nested
+    @DisplayName("Busy accounting")
+    class BusyAccounting {
+
+        @Test
+        @DisplayName("a fresh coordinator has nothing to wait for")
+        void startsEmpty() {
+            assertThat(new DrainCoordinator().busyStreams()).isZero();
+        }
+
+        @Test
+        @DisplayName("a registered stream is busy before its protocol says anything")
+        void registeredStreamIsBusyByDefault() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            coordinator.registerStream();
+
+            assertThat(coordinator.busyStreams())
+                    .as("busy by default is the load-bearing direction: a protocol that reports "
+                            + "nothing must still hold the drain, or teardown severs a handler "
+                            + "still writing its response")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("markIdle() twice does not decrement twice")
+        void markIdleIsIdempotent() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork first = coordinator.registerStream();
+            coordinator.registerStream();
+
+            first.markIdle();
+            first.markIdle();
+
+            assertThat(coordinator.busyStreams())
+                    .as("a double decrement would drop the count below the work actually in flight, "
+                            + "and the drain would finish while another stream is still being served")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("markBusy() after markIdle() puts the stream back on the drain's books")
+        void markBusyRestoresTheStream() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+            work.markIdle();
+            work.markBusy();
+
+            assertThat(coordinator.busyStreams())
+                    .as("this is the keep-alive loop taking the next request: parked it is idle, "
+                            + "reading a request it is busy again")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("markBusy() twice does not increment twice")
+        void markBusyIsIdempotent() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+            work.markBusy();
+            work.markBusy();
+
+            assertThat(coordinator.busyStreams())
+                    .as("an inflated count never reaches zero, so the drain waits out its full "
+                            + "deadline and the runtime SIGKILLs a shutdown that was already done")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("close() after markIdle() is a no-op")
+        void closeAfterMarkIdleDoesNotDecrementAgain() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork first = coordinator.registerStream();
+            coordinator.registerStream();
+
+            first.markIdle();
+            first.close();
+
+            assertThat(coordinator.busyStreams())
+                    .as("try-with-resources closes a handle the protocol loop already reported idle; "
+                            + "that is the normal path, not an error path")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("close() releases a stream that never reported itself idle")
+        void closeReleasesABusyStream() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+            work.close();
+
+            assertThat(coordinator.busyStreams())
+                    .as("a raw handler stays busy for its whole life and is released only on exit")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("streams account for themselves independently")
+        void streamsAreIndependent() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork first = coordinator.registerStream();
+            DrainCoordinator.StreamWork second = coordinator.registerStream();
+            DrainCoordinator.StreamWork third = coordinator.registerStream();
+
+            first.markIdle();
+            third.markIdle();
+
+            assertThat(coordinator.busyStreams()).isEqualTo(1);
+
+            second.close();
+            assertThat(coordinator.busyStreams()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("Draining flag")
+    class DrainingFlag {
+
+        @Test
+        @DisplayName("a running engine is not draining")
+        void notDrainingUntilMarked() {
+            assertThat(new DrainCoordinator().isDraining()).isFalse();
+        }
+
+        @Test
+        @DisplayName("markDraining() is one-way")
+        void drainingIsMonotonic() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+
+            coordinator.markDraining();
+            coordinator.markDraining();
+
+            assertThat(coordinator.isDraining())
+                    .as("shutdown never un-starts; a protocol that saw the flag must not later be "
+                            + "told the connection may be kept alive after all")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("draining does not by itself change what the drain waits for")
+        void drainingDoesNotTouchTheBusyCount() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            coordinator.registerStream();
+
+            coordinator.markDraining();
+
+            assertThat(coordinator.busyStreams())
+                    .as("marking the drain announces shutdown; it does not abandon work in flight")
+                    .isEqualTo(1);
+        }
+    }
+}


### PR DESCRIPTION
Closes #282.

## The defect

`PaqsScheduler.close()` waited on `AdmissionController.activeStreamCount()`, which counts **connections**. One Virtual Thread serves a whole keep-alive connection, so an idle one occupied a slot with nothing in flight — and it never closes on its own, because that is what keep-alive means. Every drain burned the full 60-second deadline. A container runtime's default grace period is shorter, so the normal outcome was SIGKILL mid-shutdown on every rollout.

Every connection-pooling client, load balancer and service mesh holds connections idle, so this fired on ordinary traffic, not an edge case.

## The fix

Admission and draining ask different questions, so they now have different counters:

| | counts | serves |
|---|---|---|
| `AdmissionController.activeStreamCount()` | open streams | capacity / load-shedding (ADR-010) — **unchanged** |
| `DrainCoordinator.busyStreams()` | streams being served | graceful shutdown |

**Busy by default.** A stream is busy from the moment it starts and stays busy unless its protocol reports otherwise; only the HTTP/1.1 loop, which knows it is parked between requests, reports idle. The opposite default was implemented first and is a trap — counting only work a protocol explicitly declares makes a protocol that declares nothing look finished, so teardown severs a handler still writing its response. That is the regression graceful shutdown exists to prevent, and `AbstractTransportEngineTck$GracefulDrain` (from #272) caught it. A raw `StreamHandler` and any non-participating carrier therefore keep the full drain.

**`Connection: close` is resolved when the response is written**, not when the request was parsed. The request that most needs to tell its peer to let go is the one already in flight when shutdown began; decided at parse time it always got the pre-shutdown answer, so the peer kept a pooled connection it would never be asked about again — and the next shutdown waited on it as idle. This was a real hole, not a test artifact: the new integration case failed against the parse-time version.

**Telemetry.** `CommunityTransportDrainEvent` now records `busyAtStart` / `busyRemaining` / `openAtStart`. The gap between `openAtStart` and `busyAtStart` is exactly the idle connections that used to hold shutdown open.

## Verification

Both new cases are mutation-proven, not just green:

- `idleKeepAliveConnectionDoesNotHoldShutdown` — with the pre-fix wait condition it hits the 60 s deadline and times out; with the fix, 0.29 s.
- `drainingResponseAsksPeerToClose` — against parse-time resolution it fails 3/3 showing `Connection: keep-alive`; after the fix, 5/5 green at ~0.31 s.
- `AbstractTransportEngineTck$GracefulDrain` (the #272 guarantee) stays green — and failed under the idle-by-default draft, which is what forced the inversion.

The transport TCK deliberately does **not** carry the idle case: a raw stream handler parked on a read is indistinguishable from one that is working, so the transport is right to treat it as busy. Only the HTTP codec knows it is between requests, so the case lives in the Community HTTP module. An earlier draft asserted this HTTP property through a raw handler and failed for the right reason.

Gates run on this branch:

| Gate | Command | Result |
|---|---|---|
| Full reactor, lint-gated | `mvn clean install` (no skip flags) | green |
| CI profile | `mvn clean verify -P coverage` | green, no JaCoCo floor violation |
| The Wall | `ExerisArchitectureTest` | 13/13 |
| Stress (PAQS touched) | `-DincludedGroups=stress` | 4/4 |

## Scope notes

- No ADR. `transport.md` already documented the drain as waiting on in-flight streams; the code never matched it. This is repair, and `transport.md` is updated to name *when* the keep-alive question is asked, since that was the second half of the defect.
- `CommunityHttpResponseHeaders` is extracted from `CommunityHttpExchange`: moving the keep-alive decision into the exchange pushed it over the PMD complexity gate, and header assembly was never that class's subject. No suppression added.
- **Unrelated pre-existing flake observed** (not fixed here): `CommunityConnectionRefusalTest` failed once under full-reactor load. `NativeTcpCarrier:539-540` increments the refusal counter *before* emitting the JFR event, and the test spins on the counter then immediately stops the recording — so a scheduling gap between those two lines closes the recording before the event lands. Green 6/6 in isolation and 2/2 in the module suite. Worth its own issue: the counter and the event should not be able to disagree.