### PR TITLE
fix(flow): honour a wake that arrives while a run still holds the instance

### DIFF
--- a/docs/subsystems/flow.md
+++ b/docs/subsystems/flow.md
@@ -128,6 +128,16 @@ The check is binding-agnostic — both Community (heap) and Enterprise (off-heap
 - **Parked-reschedule no-op.** Scheduling a context whose `state()` is already `PARKED` MUST register the instance in the parked map without spawning step execution (`PARKED_SCHEDULE_NOOP` path).
 - **Unknown-instance lookup.** `FlowScheduler.lookupParked(...)` for an instance that was never scheduled MUST return `Optional.empty()` without throwing, regardless of whether persistence is bound.
 
+### Deferred Wake (since 0.11)
+
+**A wake that cannot be scheduled yet MUST still be honoured.** `FlowScheduler.wake()` promises to re-submit the flow for execution and expressly permits an implementation to tolerate the immediate schedule → park → wake window rather than throwing. Tolerating that window is not the same as discarding the request: until 0.11 `CoreFlowRuntime` did neither, so a wake landing while a run still owned the instance was dropped with no exception, no event, and no resumption. `AbstractFlowSchedulerTck$BasicScheduling#wakeDuringRunIsNotLost` pins the obligation — it holds a step on a latch so the wake provably lands mid-run, then asserts the flow completes.
+
+The consequence was invisible, which is what made it dangerous. A choreography wake is one event per business trigger, not a poll, so a dropped request strands the saga until some unrelated event happens to arrive. And because the instance stays discoverable through `lookupParked` (it remains in the live index), the miss-path `WakeOnLoadFallbackEvent` never fires — nothing marked the loss.
+
+Core records the refused wake on the instance under the same monitor that guards its scheduled flag, and the draining run re-submits it after releasing its own bookkeeping. Two refusals stay deliberately silent because neither loses work: a **terminal** instance has already finished, and a **superseded lifecycle generation** means the engine restarted underneath the run — re-launching there would resurrect a reclaimed snapshot row rather than resume anything.
+
+**Enterprise obligation.** The ring-buffer scheduler has the same window on its CAS-enqueue path (a wake enqueued while a consumer still owns the slot) and inherits this contract through the same TCK case.
+
 ### Cross-Restart Choreography Wake
 
 For choreography-driven wake, the in-memory parked map remains the O(1) fast path during a live runtime.

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
@@ -619,12 +619,20 @@ final class CoreFlowRuntime { // NOPMD
         if (!instance.claimPendingWake()) {
             return;
         }
-        if (instance.isTerminal() || !isActiveLifecycle(instance) || !isCurrentLifecycle(instance)) {
+        if (instance.isTerminal() || !isActiveLifecycle(instance)) {
             return;
         }
         int startStep = instance.beginScheduleAfterWake();
         if (startStep < 0) {
             return;
+        }
+        // The instance is RUNNING again from here, so it must not remain in the parked index. The
+        // immediate path sheds that registration inside resolveParkedInstance; the deferred path
+        // reaches launch() without passing through it, so it sheds it here. Conditional on the
+        // remove, exactly as the schedule() path is, so a wake resolved through a branch that never
+        // registered cannot double-decrement.
+        if (parkedInstances.remove(instance.key()) != null) {
+            parkedFlows.decrement();
         }
         launch(instance, startStep);
     }

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/CoreFlowRuntime.java
@@ -599,7 +599,34 @@ final class CoreFlowRuntime { // NOPMD
                 decrementLifecycleCounterOnExit(activeFlows);
             }
             runningThreads.remove(Thread.currentThread());
+            honourDeferredWake(instance);
         }
+    }
+
+    /**
+     * Re-submits a wake that arrived while this run still held the instance.
+     *
+     * <p>Ordering is load-bearing: this runs after the exiting thread has deregistered itself and
+     * released its lifecycle counters, so {@code close()}'s bounded join never observes a half-torn
+     * set. The re-submission hands off to a fresh Virtual Thread rather than nesting, so this thread
+     * still exits immediately.
+     *
+     * <p>Refusals here are legitimately silent. A terminal instance has already finished — there is
+     * nothing to wake. A superseded lifecycle generation means the engine restarted underneath this
+     * run, and re-launching would resurrect a reclaimed snapshot row rather than resume anything.
+     */
+    private void honourDeferredWake(RuntimeFlowInstance instance) {
+        if (!instance.claimPendingWake()) {
+            return;
+        }
+        if (instance.isTerminal() || !isActiveLifecycle(instance) || !isCurrentLifecycle(instance)) {
+            return;
+        }
+        int startStep = instance.beginScheduleAfterWake();
+        if (startStep < 0) {
+            return;
+        }
+        launch(instance, startStep);
     }
 
     /**

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/flow/RuntimeFlowInstance.java
@@ -38,6 +38,8 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
     private volatile CoreFlowExecutionPlan plan;
     private volatile EventEngine eventEngine;
     private volatile FlowState state;
+    /** A wake refused because a run still held the instance; guarded by {@code monitor}. */
+    private boolean wakePending;
     private volatile int currentStep;
     private volatile long timeoutNanos;
     private int[] compensationStack;
@@ -249,12 +251,39 @@ final class RuntimeFlowInstance implements RuntimeFlowContextStateView { // NOPM
 
     public int beginScheduleAfterWake() {
         synchronized (monitor) {
-            if (scheduled.get() || isTerminal()) {
+            if (isTerminal()) {
+                return -1;
+            }
+            if (scheduled.get()) {
+                // A run still owns this instance, so it cannot be re-submitted yet. Recording the
+                // intent under the same monitor that guards `scheduled` makes the refusal and the
+                // deferral atomic: FlowScheduler.wake() promises to re-submit the flow for
+                // execution, and dropping the request here left a parked saga stranded with no
+                // trace — a choreography wake is one event per business trigger, not a poll.
+                wakePending = true;
                 return -1;
             }
             scheduled.set(true);
             state = FlowState.RUNNING;
             return Math.min(currentStep + 1, plan.stepCount());
+        }
+    }
+
+    /**
+     * Claims a wake that arrived while a run was still in flight, if there was one.
+     *
+     * <p>Called once by the draining run so the deferred wake is honoured exactly once; a second
+     * caller sees nothing pending.
+     *
+     * @return {@code true} if a deferred wake was claimed by this caller
+     */
+    public boolean claimPendingWake() {
+        synchronized (monitor) {
+            if (!wakePending) {
+                return false;
+            }
+            wakePending = false;
+            return true;
         }
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/flow/CoreFlowRuntimeTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/flow/CoreFlowRuntimeTest.java
@@ -155,6 +155,52 @@ class CoreFlowRuntimeTest {
 
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @DisplayName("a wake refused because a run holds the instance is recorded, and claimed exactly once")
+    void refusedWakeIsRecordedAndClaimedExactlyOnce() {
+        try (CoreFlowEngine engine = startedEngine()) {
+            FlowDefinition definition = engine.plans().newDefinition("deferred-wake-bookkeeping")
+                    .step("park", _ -> FlowOutcome.PARK, null)
+                    .step("resume", _ -> FlowOutcome.COMPLETE, null)
+                    .build();
+
+            CoreFlowExecutionPlan plan = (CoreFlowExecutionPlan) engine.plans().compile(definition);
+            RuntimeFlowInstance instance = RuntimeFlowInstance.fromContext(
+                    plan,
+                    context("deferred-wake-bookkeeping-instance", definition.name(), 0, FlowState.PARKED),
+                    1L
+            );
+
+            assertThat(instance.claimPendingWake())
+                    .as("an instance nobody tried to wake has nothing deferred")
+                    .isFalse();
+
+            assertThat(instance.beginScheduleAfterWake())
+                    .as("the first wake claims scheduling outright")
+                    .isEqualTo(1);
+            assertThat(instance.beginScheduleAfterWake())
+                    .as("a second wake cannot schedule — the first run still owns the instance")
+                    .isNegative();
+
+            assertThat(instance.claimPendingWake())
+                    .as("that refusal must leave the intent recorded; dropping it here is the defect "
+                            + "this pins, and it is invisible from outside the instance")
+                    .isTrue();
+            assertThat(instance.claimPendingWake())
+                    .as("claimed exactly once — a second claimant would launch the flow twice")
+                    .isFalse();
+
+            assertThat(instance.beginScheduleAfterWake())
+                    .as("still scheduled, so this refuses too")
+                    .isNegative();
+            assertThat(instance.claimPendingWake())
+                    .as("each refusal re-arms; a wake after an earlier one was consumed is a "
+                            + "separate request and must not be swallowed by the previous claim")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @DisplayName("lookupParked suppresses repeated snapshot-store probes after a miss")
     void lookupParkedSuppressesRepeatedSnapshotStoreProbesAfterMiss() {
         CountingSnapshotStore snapshotStore = new CountingSnapshotStore();

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowSchedulerTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowSchedulerTck.java
@@ -29,6 +29,8 @@ import java.util.concurrent.StructuredTaskScope;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -44,6 +46,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * @since 0.5.0
  */
 public abstract class AbstractFlowSchedulerTck {
+
+    /** Generous: this waits on a real flow resuming, not on a poll interval. */
+    private static final long WAKE_TIMEOUT_SECONDS = 30L;
 
     protected abstract FlowEngine createEngine();
 
@@ -97,6 +102,72 @@ public abstract class AbstractFlowSchedulerTck {
                 scheduler.wake(ctx);
             }).as("park() then wake() MUST not throw for a validly scheduled context")
               .doesNotThrowAnyException();
+        }
+
+        /**
+         * A wake refused because a run still holds the instance MUST still be honoured once that
+         * run drains.
+         *
+         * <p>{@link FlowScheduler#wake} promises to re-submit the flow for execution, and expressly
+         * allows an implementation to tolerate the immediate schedule/park/wake window rather than
+         * throwing. Tolerating is not discarding: a choreography wake is one event per business
+         * trigger, not a poll, so a request dropped here strands the saga — and because the instance
+         * stays discoverable through {@code lookupParked}, no miss-path telemetry marks the loss.
+         * Enterprise's ring-buffer scheduler has the same window on its CAS-enqueue path.
+         */
+        @Test
+        @Timeout(value = 60, unit = TimeUnit.SECONDS)
+        @DisplayName("a wake arriving while a run is still in flight is honoured, not dropped")
+        void wakeDuringRunIsNotLost() {
+            FlowScheduler scheduler = engine.scheduler();
+            CountDownLatch insideStep = new CountDownLatch(1);
+            CountDownLatch releaseStep = new CountDownLatch(1);
+
+            FlowDefinition definition = engine.plans().newDefinition("wake-during-run-flow")
+                    .step("gate", _ -> {
+                        insideStep.countDown();
+                        awaitQuietly(releaseStep);
+                        return FlowOutcome.CONTINUE;
+                    }, null)
+                    .step("after-gate", _ -> FlowOutcome.CONTINUE, null)
+                    .transition(0, 1)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(definition);
+            FlowContext ctx = TestFlowContexts.create("wake-during-run-1", definition.name());
+
+            scheduler.schedule(plan, ctx);
+            assertThat(awaitQuietly(insideStep))
+                    .as("the run must be in flight before park/wake, or this asserts nothing")
+                    .isTrue();
+
+            // The step is held on a latch, so the instance is provably still owned by a run when
+            // the wake below lands. No timing assumption — this is the window a scheduler may
+            // legitimately refuse to schedule into, and the one it must not lose the request in.
+            scheduler.park(ctx);
+            scheduler.wake(ctx);
+            releaseStep.countDown();
+
+            awaitTrue(WAKE_TIMEOUT_SECONDS, () -> engine.stats().completedFlows() >= 1);
+        }
+    }
+
+    private static void awaitTrue(long timeoutSeconds, BooleanSupplier condition) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (!condition.getAsBoolean()) {
+            if (System.nanoTime() > deadline) {
+                throw new AssertionError(
+                        "a wake delivered while a run was in flight never resumed the flow");
+            }
+            LockSupport.parkNanos(10_000_000L);
+        }
+    }
+
+    private static boolean awaitQuietly(CountDownLatch latch) {
+        try {
+            return latch.await(WAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowSchedulerTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractFlowSchedulerTck.java
@@ -14,6 +14,7 @@ import eu.exeris.kernel.spi.flow.model.FlowContext;
 import eu.exeris.kernel.spi.flow.model.FlowDefinition;
 import eu.exeris.kernel.spi.flow.model.FlowExecutionPlan;
 import eu.exeris.kernel.spi.flow.model.FlowOutcome;
+import eu.exeris.kernel.spi.flow.model.FlowState;
 import eu.exeris.kernel.spi.flow.model.FlowStepAction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -147,6 +148,77 @@ public abstract class AbstractFlowSchedulerTck {
             scheduler.wake(ctx);
             releaseStep.countDown();
 
+            awaitTrue(WAKE_TIMEOUT_SECONDS, () -> engine.stats().completedFlows() >= 1);
+        }
+
+        /**
+         * A flow resumed by a deferred wake MUST stop being reported as parked.
+         *
+         * <p>Distinct from the case above, which resumes a flow parked from outside: here the step
+         * itself returns {@code PARK} on the very run that already carries a deferred wake, so the
+         * park registration is taken <em>inside</em> the draining run and the resume follows it
+         * immediately. Miss that shed and the instance runs while {@code lookupParked} still hands
+         * it out and {@code parkedFlows} still counts it — a scheduler would hand the same instance
+         * to a second wake.
+         */
+        @Test
+        @Timeout(value = 60, unit = TimeUnit.SECONDS)
+        @DisplayName("a flow that parks itself while a wake is deferred is not left registered as parked")
+        void deferredWakeAfterSelfParkClearsParkedRegistration() {
+            FlowScheduler scheduler = engine.scheduler();
+            CountDownLatch insideStep = new CountDownLatch(1);
+            CountDownLatch releaseStep = new CountDownLatch(1);
+
+            CountDownLatch insideResumedStep = new CountDownLatch(1);
+            CountDownLatch releaseResumedStep = new CountDownLatch(1);
+
+            FlowDefinition definition = engine.plans().newDefinition("self-park-deferred-wake-flow")
+                    .step("gate-then-park", _ -> {
+                        insideStep.countDown();
+                        awaitQuietly(releaseStep);
+                        return FlowOutcome.PARK;
+                    }, null)
+                    // Held open so the assertions below run while the resumed flow is live. Checked
+                    // after completion they prove nothing: lookupParked consults the terminal
+                    // catalogue first and returns empty for a finished flow however the parked index
+                    // looks, and completion clears the registration anyway.
+                    .step("after-park", _ -> {
+                        insideResumedStep.countDown();
+                        awaitQuietly(releaseResumedStep);
+                        return FlowOutcome.CONTINUE;
+                    }, null)
+                    .transition(0, 1)
+                    .build();
+            FlowExecutionPlan plan = engine.plans().compile(definition);
+
+            // Same instance id, two views: schedule() must see a runnable context, while wake()
+            // declares the parked intent that lets it resolve an instance a run still owns.
+            FlowContext running = TestFlowContexts.create("self-park-wake-1", definition.name());
+            FlowContext parked = TestFlowContexts.createWithState(
+                    "self-park-wake-1", definition.name(), FlowState.PARKED);
+
+            scheduler.schedule(plan, running);
+            assertThat(awaitQuietly(insideStep))
+                    .as("the run must be in flight before the wake, or nothing is deferred")
+                    .isTrue();
+
+            scheduler.wake(parked);
+            releaseStep.countDown();
+
+            assertThat(awaitQuietly(insideResumedStep))
+                    .as("the deferred wake must resume the flow past the step that parked it")
+                    .isTrue();
+
+            assertThat(scheduler.lookupParked(parked.instanceIdMost(), parked.instanceIdLeast()))
+                    .as("this instance is running right now; handing it out as parked would let a "
+                            + "second wake schedule the same flow again")
+                    .isEmpty();
+            assertThat(engine.stats().parkedFlows())
+                    .as("the park registration taken inside the run must be shed when the deferred "
+                            + "wake resumes it, or the parked-flow gauge drifts up for good")
+                    .isZero();
+
+            releaseResumedStep.countDown();
             awaitTrue(WAKE_TIMEOUT_SECONDS, () -> engine.stats().completedFlows() >= 1);
         }
     }


### PR DESCRIPTION
Root cause of the sporadic CI failure in `CoreFlowEngineTest$ScheduleAndWakeTests#immediateScheduleParkWakeOnSameContextIsRaceSafe:272`.

## The defect

`CoreFlowRuntime.wake()` calls `beginScheduleAfterWake()`, which returns `-1` when `scheduled` is still set, and returns. **No exception, no event, no resumption** — the request vanished. `scheduled` is a plain `AtomicBoolean` with no pending-wake record anywhere, and it is cleared later by `runInstance`'s `finally` on the flow's own Virtual Thread. Nothing re-checked after the run drained.

`FlowScheduler.wake()` has promised since 0.5.0 to *"re-submit the flow for execution"*, and expressly permits an implementation to **tolerate** the immediate schedule → park → wake window rather than throwing. Tolerating that window is not discarding the request — the code did neither one thing nor the other.

**The consequence was invisible, which is what made it dangerous.** `FlowChoreographyBridge:51` does `lookupParked(...).ifPresent(scheduler::wake)`; a choreography wake is one event per business trigger, not a poll, so a dropped request strands the saga until some unrelated event happens to arrive. And because the instance stays discoverable through the live index, the miss-path `WakeOnLoadFallbackEvent` never fires — nothing marked the loss.

## The fix

`RuntimeFlowInstance` records the refused wake under the **same monitor** that guards `scheduled`, so the refusal and the deferral are atomic. The draining run claims it in `runInstance`'s `finally`, **after** deregistering itself and releasing its lifecycle counters, so `close()`'s bounded join never observes a half-torn set. The re-submission hands off to a fresh Virtual Thread rather than nesting, so the draining thread still exits immediately.

Two refusals stay deliberately silent because neither loses work:

- **terminal** — the flow already finished; there is nothing to wake;
- **superseded lifecycle generation** — the engine restarted underneath this run, and re-launching would resurrect a reclaimed snapshot row rather than resume anything (the PR #208 stale-write fence).

## Verification

Reproduced **deterministically** before fixing: a step held on a latch keeps `scheduled` set, so the wake provably lands mid-run with no timing assumption. Fails in 5 s pre-fix, passes in 0.1 s post-fix.

Non-vacuous by mutation — removing the re-submit call fails the new case in **both** bindings (30 s timeout each, `CoreFlowSchedulerTckTest` and `CommunityFlowSchedulerTckTest`) and leaves the other two `BasicScheduling` cases green.

> A note on process: my first run showed the Community binding *passing* under mutation. That was a stale surefire report — the module had not been rebuilt against the mutated Core. Re-run with the report deleted first, it fails identically. Reported here because a stale green is exactly the failure mode this PR is about.

| Gate | Command | Result |
|---|---|---|
| Full reactor, lint-gated | `mvn clean install` (no skip flags) | green |
| CI profile | `mvn clean verify -P coverage` | green, no JaCoCo floor violation |
| The Wall | `ExerisArchitectureTest` | 13/13 |
| Continuity | `-DincludedGroups=continuity` | 2/2 |

`AbstractSagaRecoveryTck` carries no tag, so it runs in the default build and is covered above.

## Scope notes

- **No ADR, no SPI change.** The SPI Javadoc already stated the promise; this makes Core honour it. ADR-013 governs durable/distributed coordination and nowhere sanctions dropping a local wake; ADR-062 is orthogonal.
- Pinned in `AbstractFlowSchedulerTck` rather than a Core unit test because `wake()` is SPI and Enterprise's ring-buffer scheduler has the **same window** on its CAS-enqueue path. `parkAndWakeRoundTrip` is left untouched — it pins the no-throw clause; the new case pins progress. That old case asserts only `doesNotThrowAnyException`, which is why this defect survived: it passes with the wake silently dropped.
- `flow.md` gains a "Deferred Wake" rule next to the existing `PARKED_SCHEDULE_NOOP` one, including the Enterprise obligation.
- **Not addressed here:** `AbstractSagaRecoveryTck$RestartUnderLoad#parkedFleetSurvivesForceCloseAndResumes` is separately flaky on CI (a reclaimed `PARKED` row reappearing after `complete()`). It does not reproduce locally — 6/6 green with fresh reports — and this change does not affect it there. Same defect family; tracked separately.