### PR TITLE
test(flow): await the reclaim itself in RestartUnderLoad, not the counter

### DIFF
--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
@@ -144,6 +144,16 @@ public abstract class AbstractSagaRecoveryTck {
         return snapshotStore().load(ctx.instanceIdMost(), ctx.instanceIdLeast());
     }
 
+    /** Whether every instance's durable checkpoint has been reclaimed. */
+    private boolean allCheckpointsReclaimed(List<FlowContext> contexts) {
+        for (FlowContext ctx : contexts) {
+            if (loadSnapshot(ctx).isPresent()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private boolean awaitCondition(BooleanSupplier condition, int timeoutSeconds) {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
         while (System.nanoTime() < deadline) {
@@ -560,6 +570,14 @@ public abstract class AbstractSagaRecoveryTck {
                     () -> engine.stats().completedFlows() >= expectedCompleted, 15))
                     .as("Rebuilt engine MUST drive all %d resumed instances to COMPLETED", expectedCompleted)
                     .isTrue();
+
+            // The counter above is not a proxy for the reclaim. complete() increments
+            // completedFlows, publishes progress, and only then deletes the checkpoint, so the
+            // fleet-size gate is satisfied while the last instance's row is still in the store —
+            // and reading it in the same breath makes this a race, not an assertion. Await the
+            // reclaim itself; the per-instance check below still names the offender if it never
+            // lands, rather than reporting an anonymous timeout.
+            awaitCondition(() -> allCheckpointsReclaimed(parked), 15);
 
             for (FlowContext ctx : parked) {
                 assertThat(loadSnapshot(ctx))

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/flow/AbstractSagaRecoveryTck.java
@@ -462,8 +462,11 @@ public abstract class AbstractSagaRecoveryTck {
         private static final String DEF_NAME = "restart-under-load-saga";
         private static final String WORKER_THREAD_PREFIX = "exeris-flow-";
 
+        // 60s, not the suite's usual 30s: this method's own await budgets sum to 35s (10 + 5 + 15 +
+        // 5), so a 30s ceiling can kill it mid-await and report an anonymous timeout instead of the
+        // assertion that would name what actually went wrong.
         @Test
-        @Timeout(value = 30, unit = TimeUnit.SECONDS)
+        @Timeout(value = 60, unit = TimeUnit.SECONDS)
         @DisplayName("N parked snapshots survive close(); all resume to COMPLETED; no re-exec, no orphans, counters reset")
         void parkedFleetSurvivesForceCloseAndResumes() {
             int n = restartLoadCount();
@@ -577,7 +580,11 @@ public abstract class AbstractSagaRecoveryTck {
             // and reading it in the same breath makes this a race, not an assertion. Await the
             // reclaim itself; the per-instance check below still names the offender if it never
             // lands, rather than reporting an anonymous timeout.
-            awaitCondition(() -> allCheckpointsReclaimed(parked), 15);
+            // 5s, not the 15s the line above uses: that one waits for sixteen flows to execute,
+            // this one for a finalization step that is sub-millisecond in practice (50ms with the
+            // window widened far enough to reproduce the race). Deliberately not asserted — a
+            // timeout here falls through to the per-instance loop, which names the offender.
+            awaitCondition(() -> allCheckpointsReclaimed(parked), 5);
 
             for (FlowContext ctx : parked) {
                 assertThat(loadSnapshot(ctx))


### PR DESCRIPTION
Fixes the sporadic CI failure in `AbstractSagaRecoveryTck$RestartUnderLoad#parkedFleetSurvivesForceCloseAndResumes:568`.

## The defect is in the oracle, not the engine

The test gated on `completedFlows() >= fleetSize` and then read the snapshot store in the same breath:

```java
awaitCondition(() -> engine.stats().completedFlows() >= expectedCompleted, 15)   // :557
for (FlowContext ctx : parked) { assertThat(loadSnapshot(ctx)).isEmpty(); }      // :564
```

That gate is not a proxy for the reclaim. `CoreFlowRuntime.complete()` does:

```java
completedFlows.increment();                    // :932
progressPublisher.publishProgress(...);        // :933
liveInstances.remove(...);                     // :935
parkedInstances.remove(...);                   // :936
deleteSnapshot(instance, staleLifecycle);      // :939
```

The counter reaches the fleet size while the last instance's row is still in the store, with an event publish sitting inside the window. On a 2-vCPU runner with a 16-instance fleet that is comfortably wide.

**The evidence matched this and not a resurrect.** The reported snapshot was `state=PARKED, currentStep=1, schemaVersion=1` — the original park checkpoint untouched. A resurrecting write would be built from the instance's current state, which by then is past the park step.

## Verified, not inferred

Reproduced deterministically by widening the window — a 50 ms park between the counter and the delete:

| | old assertion | new assertion |
|---|---|---|
| widened window | **fails**, with the exact CI message and snapshot shape | passes |
| unmodified | passes (window too narrow to hit locally) | passes, 4/4 |

The probe was removed before committing; the diff is test-only.

## What changed

The test now awaits the post-condition it actually asserts. The per-instance check is kept **after** the await so a genuine failure still names the offending instance rather than reporting an anonymous timeout.

## What this does not do

It does not weaken the stale-write fence. A checkpoint resurrected *after* the reclaim is a different mechanism — guarded in production by the lifecycle write-fence in `persistSnapshot` (with the reasoning recorded in its comment) and covered by `CoreFlowRuntimeStaleWriteFenceTest`. That guard read as correct and tight when I traced it; nothing here relaxes it.

I did not change `complete()` to increment the counter after the reclaim. That would make the counter imply the reclaim and would also fix the symptom, but it drags production ordering toward the test's expectation — the wrong direction. `completedFlows` promises a count of completed flows; it never promised anything about the store.

| Gate | Command | Result |
|---|---|---|
| Full reactor, lint-gated | `mvn clean install` (no skip flags) | green |
| CI profile | `mvn clean verify -P coverage` | green |
| The Wall | `ExerisArchitectureTest` | 13/13 |
| Subject test, fresh reports | `CommunitySagaRecoveryTckTest` | 4/4 |