### PR TITLE
fix(transport): CAS the drain handle's flag, and make observing zero a commit

### DIFF
--- a/docs/release/v0.11.0-release-notes.md
+++ b/docs/release/v0.11.0-release-notes.md
@@ -65,3 +65,25 @@ binary-incompatible change: code compiled against 0.10.x that constructs the rec
 recompiled. Use the `withSharedScope()` composer rather than the canonical constructor where the axis
 is not being set — the shared-scope key is orthogonal to the isolation strategy, and composing keeps
 call sites insulated from further components on this carrier while it remains `preview`.
+
+## Benchmarking: v0.11 moves the HTTP/1.1 per-request hot path
+
+Numbers measured on 0.10.x and on 0.11.0 are **not comparable without annotation**, and this is stated
+before a measurement campaign rather than after one.
+
+`DrainCoordinator` did not exist when the pre-0.11 figures were taken. It adds two atomic
+read-modify-writes on a shared per-engine counter to the H1 keep-alive loop — `markIdle()` when the
+connection parks on the next request, `markBusy()` when one arrives — so the cost lands **per request**,
+not per connection, and on one cache line shared by every stream the engine is serving. Whether that is
+visible above a given harness's noise floor is a question for a measurement, not for release notes; that
+it changes the path is not.
+
+The concurrency shape settled during this milestone and the final form is what any campaign must
+measure. Both operations are unconditional `getAndAdd` — the seal that closes the drain's commit window
+is expressed as a **negative range** rather than an exact sentinel value precisely so the hot path does
+not need a compare-and-set retry loop, which is the form that degrades under contention. An interim
+version during review did use CAS loops; it is not what ships.
+
+Treat 0.11.0 as a fence in the benchmark record, in the same way individual commits that moved this path
+have been annotated before. A figure carried across it without a note will read as an unexplained
+regression to whoever compares them next — including the person who took them.

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -330,9 +330,15 @@ being dropped by it. On the 60-second deadline the coordinator seals uncondition
 shutdown proceeds regardless, letting a late arrival believe it is protected is worse than closing on it.
 
 **The per-stream handle is not thread-confined.** `StreamWork` reaches protocol code through the
-`STREAM_WORK` `ScopedValue`, and `StructuredTaskScope.fork()` — mandated for concurrency inside
-`runStream()` — inherits `ScopedValue` bindings, so a subtask can report idleness from another thread.
-Both the shared count and the handle's flag are therefore compare-and-set. A double release drops the
+`STREAM_WORK` `ScopedValue` — chosen precisely so it survives down the stack and across a task
+boundary. The reachable route is track-independent and does not rest on `StructuredTaskScope` (which
+the default line must not ship for 1.0 GA): `StreamExecutionBackend`, the seam at which an admitted
+stream's root task is started, is contractually required to preserve `ScopedValue` bindings across
+whatever thread a backend chooses, and its forward consumers — an Enterprise locality-aware backend,
+the post-1.0 DST simulation scheduler — are exactly the ones that run the task on a thread the
+scheduler did not create. On the `preview` artifact `StructuredTaskScope.fork()`'s binding inheritance
+is a second route to the same place. Both the shared count and the handle's flag are therefore
+compare-and-set. A double release drops the
 count below the truth and ends the drain early; a double acquire means it never ends. Neither is
 reachable by anything short of a stress harness, so the guarantee is a property of the type rather than
 an assumption about callers.

--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -316,6 +316,27 @@ When PAQS sheds a stream or the Kernel initiates graceful shutdown:
    looping here, so a handler that completes during the drain can still have its response flushed.
 3. **Teardown** — reactors are woken and joined, then the selector and all remaining channels close.
 
+**Observing zero and committing to teardown are one step.** `DrainCoordinator.sealIfIdle()` is a
+compare-and-set on the busy count, not a read followed by a decision. Read as two steps, a request that
+arrived while the drain was looking flips the count back to one on an engine already past its commit
+point, and phase 3 severs the stream serving it — the failure phase ordering exists to prevent, reached
+from the other side. Asking protocols to check `isDraining()` first does not close it: a request already
+sitting in the socket buffer when the drain began has nobody left to ask.
+
+After the seal, `StreamWork.markBusy()` answers `false` and the protocol layer closes rather than
+serves — `CommunityHttpRequestProcessor` returns from its keep-alive loop. That is the honest reading of
+a connection the peer was already told to close: a request arriving after that is racing teardown, not
+being dropped by it. On the 60-second deadline the coordinator seals unconditionally, because once
+shutdown proceeds regardless, letting a late arrival believe it is protected is worse than closing on it.
+
+**The per-stream handle is not thread-confined.** `StreamWork` reaches protocol code through the
+`STREAM_WORK` `ScopedValue`, and `StructuredTaskScope.fork()` — mandated for concurrency inside
+`runStream()` — inherits `ScopedValue` bindings, so a subtask can report idleness from another thread.
+Both the shared count and the handle's flag are therefore compare-and-set. A double release drops the
+count below the truth and ends the drain early; a double acquire means it never ends. Neither is
+reachable by anything short of a stress harness, so the guarantee is a property of the type rather than
+an assumption about callers.
+
 Until 0.11 the drain ran *after* teardown, which made it inert: handlers were waited on while their
 sockets were already closed, so an in-flight request completed and its response went nowhere. The peer
 observed a connection closed with no reply, and an idempotent client retried into a listener that was

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -156,12 +156,21 @@ public final class CommunityHttpRequestProcessor {
         // Streams are busy by default, so a protocol that cannot tell simply never reaches this.
         markIdle();
         ReadResult readResult;
+        boolean rearmed;
         try {
             readResult = readRequest(codec, stream, handler, state, state.bufferedBytes());
         } finally {
-            markBusy();
+            rearmed = markBusy();
         }
         if (readResult == null) {
+            return false;
+        }
+        if (!rearmed) {
+            // The drain committed to teardown while this connection was parked on the next request,
+            // so this stream is not being waited for. Serving now would race a teardown already in
+            // progress — the failure the drain exists to prevent, reached from the other side. The
+            // peer was told to close on the previous response; a request sent anyway is racing us,
+            // and RFC 9112 §9.6 requires a client to tolerate a persistent connection closing.
             return false;
         }
 
@@ -212,10 +221,13 @@ public final class CommunityHttpRequestProcessor {
         }
     }
 
-    private static void markBusy() {
-        if (TransportScopes.STREAM_WORK.isBound()) {
-            TransportScopes.STREAM_WORK.get().markBusy();
-        }
+    /**
+     * @return {@code false} only when the drain has committed to teardown; unbound means no drain
+     *         coordinator is in play at all, which must not close connections
+     */
+    private static boolean markBusy() {
+        return !TransportScopes.STREAM_WORK.isBound()
+                || TransportScopes.STREAM_WORK.get().markBusy();
     }
 
     private static boolean isDraining() {

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -177,10 +177,19 @@ public final class DrainCoordinator {
      * <h2>Why this is not thread-confined</h2>
      * <p>An earlier version declared the flag confined to the stream's own thread and left it a plain
      * field. The mechanism contradicted the declaration: the handle reaches protocol code only through
-     * {@link eu.exeris.kernel.core.transport.TransportScopes#STREAM_WORK}, a {@code ScopedValue}, and
-     * {@code PaqsScheduler} mandates {@code StructuredTaskScope} for concurrency inside
-     * {@code runStream()} — whose {@code fork()} inherits {@code ScopedValue} bindings. Any subtask
-     * written to that mandate can read the handle and call these methods from another thread.
+     * {@link eu.exeris.kernel.core.transport.TransportScopes#STREAM_WORK}, a {@code ScopedValue} —
+     * chosen precisely so it survives down the stack and across a task boundary. A parameter or a field
+     * would have expressed confinement; this expresses the opposite.
+     *
+     * <p>The reachable route does not depend on {@code StructuredTaskScope}, and saying so matters
+     * because the two distribution tracks disagree about it: the {@code preview} artifact keeps STS
+     * (whose {@code fork()} inherits {@code ScopedValue} bindings), while the default line must stay
+     * preview-clean for 1.0 GA. What holds on <em>both</em> is {@link StreamExecutionBackend}: the PAQS
+     * seam at which an admitted stream's root task is started, contractually required to preserve
+     * {@code ScopedValue} bindings across whatever thread a backend chooses
+     * ({@code AbstractPaqsSchedulerTck#customExecutionBackendPreservesScopedValueBindings}). Its
+     * forward consumers are the ones that run the task somewhere the scheduler did not create — an
+     * Enterprise locality-aware backend, and the post-1.0 DST simulation scheduler.
      *
      * <p>Both failure modes destroy what this class is for. Two threads observing {@code busy == true}
      * in {@link #markIdle()} both release, the count falls below the truth, the drain finishes early

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -167,8 +167,29 @@ public final class DrainCoordinator {
         return (boolean) DRAINING.getAcquire(this);
     }
 
+    /**
+     * Returns one count, unless the coordinator is sealed.
+     *
+     * <p>Symmetric with {@link #tryAcquire()} and for the same reason: the sentinel must not be
+     * arithmetic on. {@link #sealNow()} discards whatever was in flight, so a handler that finishes
+     * after the deadline still calls this — and {@code SEALED} is {@code Integer.MIN_VALUE}, so an
+     * unguarded decrement wraps it to {@code Integer.MAX_VALUE}. That is no longer the sentinel, so
+     * {@code tryAcquire} starts handing out counts again and a stream can report itself busy during
+     * teardown: the failure this class exists to prevent, reopened through the forced path.
+     *
+     * <p>Once sealed the count is not a count, so declining to touch it is the whole contract — the
+     * handle's flag and the owner's count are deliberately allowed to disagree from that point on.
+     */
     private void release() {
-        BUSY_STREAMS.getAndAdd(this, -1);
+        while (true) {
+            int current = (int) BUSY_STREAMS.getAcquire(this);
+            if (current == SEALED) {
+                return;
+            }
+            if (BUSY_STREAMS.compareAndSet(this, current, current - 1)) {
+                return;
+            }
+        }
     }
 
     /**
@@ -199,9 +220,16 @@ public final class DrainCoordinator {
      * neither is visible to ArchUnit or PMD, so the guarantee has to be a property of the type.
      *
      * <h2>Invariant</h2>
-     * <p>This handle holds exactly {@code busy ? 1 : 0} counts on the owner. Every transition of the
-     * flag is a compare-and-set paired with exactly one counter operation, and the loser of a
-     * concurrent {@link #markBusy()} returns the count it took rather than leaving it stranded.
+     * <p>Until the owner is sealed, this handle holds exactly {@code busy ? 1 : 0} counts on it. Every
+     * transition of the flag is a compare-and-set paired with exactly one counter operation, and the
+     * loser of a concurrent {@link #markBusy()} returns the count it took rather than leaving it
+     * stranded.
+     *
+     * <p>Sealing ends that correspondence deliberately: {@link #sealNow()} discards the counts of
+     * streams still in flight, so a handle can be {@code busy} while the owner holds nothing for it.
+     * From then on the flag describes only this stream's own view, and every counter operation is a
+     * no-op — which is why {@link #release()} refuses to decrement a sealed count rather than
+     * subtracting from a sentinel.
      */
     public static final class StreamWork implements AutoCloseable {
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -57,8 +57,25 @@ import java.lang.invoke.VarHandle;
  */
 public final class DrainCoordinator {
 
-    /** Count value meaning "the drain committed to teardown"; no further count may be taken. */
-    private static final int SEALED = Integer.MIN_VALUE;
+    /**
+     * Seal marker: <b>any negative count means sealed</b>, and this is the value the seal writes.
+     *
+     * <p>A range rather than one exact value, so the hot path can stay on {@code getAndAdd}. A single
+     * sentinel forces every mutator into a read-then-compare-and-set loop, because a blind increment
+     * or decrement would step off the exact value — and on the H1 keep-alive path
+     * {@link StreamWork#markIdle()} and {@link StreamWork#markBusy()} run <em>per request</em> against
+     * one per-engine counter, so that is the difference between an unconditional {@code lock xadd} and
+     * a loop that retries under contention. With up to {@code maxConnections} streams on a handful of
+     * carriers hammering one cache line, retry behaviour is exactly what degrades.
+     *
+     * <p>Half of {@link Integer#MIN_VALUE} rather than {@code MIN_VALUE} itself, so the marker has
+     * roughly a billion of headroom in both directions. Nothing realistic approaches it: post-seal
+     * decrements are bounded by the streams that were in flight, and transient increments by the
+     * acquires racing the seal — both bounded by the connection ceiling, which is orders of magnitude
+     * below the margin. The old exact sentinel had the opposite property: it sat one decrement away
+     * from wrapping to {@link Integer#MAX_VALUE}.
+     */
+    private static final int SEALED = Integer.MIN_VALUE / 2;
 
     private static final VarHandle BUSY_STREAMS;
     private static final VarHandle DRAINING;
@@ -102,7 +119,10 @@ public final class DrainCoordinator {
      */
     public int busyStreams() {
         int count = (int) BUSY_STREAMS.getAcquire(this);
-        return count == SEALED ? 0 : count;
+        // Negative means sealed, not "equal to the marker": post-seal releases drive it further down,
+        // and a transient acquire nudges it up. Comparing for equality would report a sealed
+        // coordinator as carrying a billion live streams.
+        return count < 0 ? 0 : count;
     }
 
     /**
@@ -136,15 +156,14 @@ public final class DrainCoordinator {
      * @return {@code true} if a count was taken and must later be released
      */
     private boolean tryAcquire() {
-        while (true) {
-            int current = (int) BUSY_STREAMS.getAcquire(this);
-            if (current == SEALED) {
-                return false;
-            }
-            if (BUSY_STREAMS.compareAndSet(this, current, current + 1)) {
-                return true;
-            }
+        int previous = (int) BUSY_STREAMS.getAndAdd(this, 1);
+        if (previous < 0) {
+            // Sealed. Take the count back; the marker's headroom absorbs the round trip, and this
+            // branch is only reachable after teardown has committed.
+            BUSY_STREAMS.getAndAdd(this, -1);
+            return false;
         }
+        return true;
     }
 
     /**
@@ -170,26 +189,17 @@ public final class DrainCoordinator {
     /**
      * Returns one count, unless the coordinator is sealed.
      *
-     * <p>Symmetric with {@link #tryAcquire()} and for the same reason: the sentinel must not be
-     * arithmetic on. {@link #sealNow()} discards whatever was in flight, so a handler that finishes
-     * after the deadline still calls this — and {@code SEALED} is {@code Integer.MIN_VALUE}, so an
-     * unguarded decrement wraps it to {@code Integer.MAX_VALUE}. That is no longer the sentinel, so
-     * {@code tryAcquire} starts handing out counts again and a stream can report itself busy during
-     * teardown: the failure this class exists to prevent, reopened through the forced path.
+     * <p>Unconditional, and safe only because {@link #SEALED} marks a <em>range</em>. {@link #sealNow()}
+     * discards whatever was in flight, so a handler that finishes after the deadline still calls this;
+     * the decrement drives the marker further negative, which still reads as sealed. An exact sentinel
+     * at {@link Integer#MIN_VALUE} sat one decrement from wrapping to {@link Integer#MAX_VALUE} —
+     * no longer sealed, so acquisition resumed and a stream could report itself busy during teardown.
      *
-     * <p>Once sealed the count is not a count, so declining to touch it is the whole contract — the
-     * handle's flag and the owner's count are deliberately allowed to disagree from that point on.
+     * <p>Once sealed the count is not a count, and the handle's flag and the owner's count are
+     * deliberately allowed to disagree from that point on.
      */
     private void release() {
-        while (true) {
-            int current = (int) BUSY_STREAMS.getAcquire(this);
-            if (current == SEALED) {
-                return;
-            }
-            if (BUSY_STREAMS.compareAndSet(this, current, current - 1)) {
-                return;
-            }
-        }
+        BUSY_STREAMS.getAndAdd(this, -1);
     }
 
     /**

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -49,9 +49,10 @@ import java.lang.invoke.VarHandle;
  *
  * <h2>Allocation</h2>
  * <p>One shared instance per engine plus one {@link StreamWork} handle per stream — the same order as
- * the Virtual Thread PAQS already spawns per stream, and nothing per request. Both the shared count and
- * the per-handle flag are compare-and-set; see {@link StreamWork} for why the handle cannot rely on
- * thread confinement.
+ * the Virtual Thread PAQS already spawns per stream, and nothing per request. The per-handle flag is
+ * compare-and-set — see {@link StreamWork} for why it cannot rely on thread confinement — while the
+ * shared count takes plain {@code getAndAdd} on the per-request path and compare-and-set only in
+ * {@link #sealIfIdle()}, which runs once per drain.
  *
  * @since 0.11.0
  */
@@ -150,8 +151,10 @@ public final class DrainCoordinator {
     /**
      * Takes one count unless sealed.
      *
-     * <p>CAS loop rather than {@code getAndAdd}, because the sentinel must not be arithmetic on: a
-     * blind increment past {@link #SEALED} produces a count that is neither sealed nor true.
+     * <p>Add first, then inspect what was there — not read-then-compare-and-set. This runs per request
+     * on the H1 keep-alive path, so the difference is an unconditional {@code getAndAdd} against a loop
+     * that retries under contention. It is only available because {@link #SEALED} marks a range: the
+     * speculative {@code +1} on a sealed count lands harmlessly inside it and is taken straight back.
      *
      * @return {@code true} if a count was taken and must later be released
      */
@@ -237,9 +240,10 @@ public final class DrainCoordinator {
      *
      * <p>Sealing ends that correspondence deliberately: {@link #sealNow()} discards the counts of
      * streams still in flight, so a handle can be {@code busy} while the owner holds nothing for it.
-     * From then on the flag describes only this stream's own view, and every counter operation is a
-     * no-op — which is why {@link #release()} refuses to decrement a sealed count rather than
-     * subtracting from a sentinel.
+     * From then on the flag describes only this stream's own view, and the counter's value carries no
+     * meaning to restore — which is why {@link #release()} may decrement it unconditionally. The
+     * marker is a range, so a post-seal decrement lands further inside it (see {@link #SEALED}); it is
+     * not a value a mutator has to steer around.
      */
     public static final class StreamWork implements AutoCloseable {
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -34,14 +34,31 @@ import java.lang.invoke.VarHandle;
  * its response — which is the exact regression graceful shutdown exists to prevent. Defaulting to busy
  * costs an unparticipating protocol a wait; defaulting to idle costs it its response.
  *
+ * <h2>Sealing — why observing zero is not enough</h2>
+ * <p>The busy count reaching zero and the shutdown proceeding to teardown must be one step. Read as
+ * two, a request that arrived while the drain was looking flips the count back to one on an engine
+ * already committed to tearing down, and the stream serving it is severed. That window is not closable
+ * by asking protocols to check {@link #isDraining()} first — a request already sitting in the socket
+ * buffer when the drain began has nobody left to ask, and the same reasoning that makes busy the
+ * default applies here: a protocol that does not participate must not be able to silently re-arm.
+ *
+ * <p>So {@link #sealIfIdle()} is a compare-and-set on the count itself. Once it succeeds no further
+ * count may be taken, {@link StreamWork#markBusy()} answers {@code false}, and the protocol layer is
+ * expected to close rather than serve. That is the honest reading of a connection we have already told
+ * the peer to close: a request arriving after that is racing our teardown, not being dropped by it.
+ *
  * <h2>Allocation</h2>
  * <p>One shared instance per engine plus one {@link StreamWork} handle per stream — the same order as
- * the Virtual Thread PAQS already spawns per stream, and nothing per request. The handle's own flag is
- * confined to its stream's thread, so only the shared counter is atomic.
+ * the Virtual Thread PAQS already spawns per stream, and nothing per request. Both the shared count and
+ * the per-handle flag are compare-and-set; see {@link StreamWork} for why the handle cannot rely on
+ * thread confinement.
  *
  * @since 0.11.0
  */
 public final class DrainCoordinator {
+
+    /** Count value meaning "the drain committed to teardown"; no further count may be taken. */
+    private static final int SEALED = Integer.MIN_VALUE;
 
     private static final VarHandle BUSY_STREAMS;
     private static final VarHandle DRAINING;
@@ -67,20 +84,67 @@ public final class DrainCoordinator {
      *
      * <p>Called by {@link PaqsScheduler} for every admitted stream, before the handler runs.
      *
+     * <p>After {@link #sealIfIdle()} has succeeded this returns a handle that holds no count. The
+     * handler still runs — {@code close()} does not stop admission, so a connection accepted moments
+     * earlier is entitled to what it can get — but it cannot extend a shutdown already past its commit
+     * point, and its {@link StreamWork#markBusy()} answers {@code false}.
+     *
      * @return the handle the protocol layer uses to report idleness; must be closed on stream exit
      */
     public StreamWork registerStream() {
-        BUSY_STREAMS.getAndAdd(this, 1);
-        return new StreamWork(this);
+        return new StreamWork(this, tryAcquire());
     }
 
     /**
      * Returns how many streams are currently being served.
      *
-     * @return the busy count; {@code 0} means shutdown may proceed to teardown
+     * @return the busy count, or {@code 0} once sealed; {@code 0} means teardown may proceed
      */
     public int busyStreams() {
-        return (int) BUSY_STREAMS.getAcquire(this);
+        int count = (int) BUSY_STREAMS.getAcquire(this);
+        return count == SEALED ? 0 : count;
+    }
+
+    /**
+     * Commits to teardown if — and atomically with observing that — nothing is being served.
+     *
+     * <p>The atomicity is the whole point. {@code busyStreams() == 0} followed by teardown is two
+     * steps, and a stream re-arming between them is served by a handler the next step severs.
+     *
+     * @return {@code true} if the count was zero and is now sealed; {@code false} if work is in flight
+     */
+    public boolean sealIfIdle() {
+        return BUSY_STREAMS.compareAndSet(this, 0, SEALED);
+    }
+
+    /**
+     * Seals unconditionally, discarding whatever is still in flight.
+     *
+     * <p>For the drain deadline only: once shutdown has decided to proceed regardless, letting streams
+     * keep taking counts serves nothing and lets a late arrival believe it is protected.
+     */
+    public void sealNow() {
+        BUSY_STREAMS.setVolatile(this, SEALED);
+    }
+
+    /**
+     * Takes one count unless sealed.
+     *
+     * <p>CAS loop rather than {@code getAndAdd}, because the sentinel must not be arithmetic on: a
+     * blind increment past {@link #SEALED} produces a count that is neither sealed nor true.
+     *
+     * @return {@code true} if a count was taken and must later be released
+     */
+    private boolean tryAcquire() {
+        while (true) {
+            int current = (int) BUSY_STREAMS.getAcquire(this);
+            if (current == SEALED) {
+                return false;
+            }
+            if (BUSY_STREAMS.compareAndSet(this, current, current + 1)) {
+                return true;
+            }
+        }
     }
 
     /**
@@ -110,32 +174,77 @@ public final class DrainCoordinator {
     /**
      * One stream's contribution to the busy count.
      *
-     * <p>The flag is confined to the stream's own thread — the protocol loop that reports it is the
-     * only caller — so the handle needs no synchronisation of its own.
+     * <h2>Why this is not thread-confined</h2>
+     * <p>An earlier version declared the flag confined to the stream's own thread and left it a plain
+     * field. The mechanism contradicted the declaration: the handle reaches protocol code only through
+     * {@link eu.exeris.kernel.core.transport.TransportScopes#STREAM_WORK}, a {@code ScopedValue}, and
+     * {@code PaqsScheduler} mandates {@code StructuredTaskScope} for concurrency inside
+     * {@code runStream()} — whose {@code fork()} inherits {@code ScopedValue} bindings. Any subtask
+     * written to that mandate can read the handle and call these methods from another thread.
+     *
+     * <p>Both failure modes destroy what this class is for. Two threads observing {@code busy == true}
+     * in {@link #markIdle()} both release, the count falls below the truth, the drain finishes early
+     * and teardown severs a handler mid-response — the exact regression graceful shutdown exists to
+     * prevent. Two observing {@code busy == false} in {@link #markBusy()} both take a count, and the
+     * drain never reaches zero. Neither is reachable by any test that is not a stress harness, and
+     * neither is visible to ArchUnit or PMD, so the guarantee has to be a property of the type.
+     *
+     * <h2>Invariant</h2>
+     * <p>This handle holds exactly {@code busy ? 1 : 0} counts on the owner. Every transition of the
+     * flag is a compare-and-set paired with exactly one counter operation, and the loser of a
+     * concurrent {@link #markBusy()} returns the count it took rather than leaving it stranded.
      */
     public static final class StreamWork implements AutoCloseable {
 
-        private final DrainCoordinator owner;
-        private boolean busy = true;
+        private static final VarHandle BUSY;
 
-        private StreamWork(DrainCoordinator owner) {
+        static {
+            try {
+                BUSY = MethodHandles.lookup().findVarHandle(StreamWork.class, "busy", boolean.class);
+            } catch (ReflectiveOperationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        private final DrainCoordinator owner;
+
+        /** Written only through {@link #BUSY}; the plain reads below are the fast paths. */
+        private volatile boolean busy;
+
+        private StreamWork(DrainCoordinator owner, boolean busy) {
             this.owner = owner;
+            this.busy = busy;
         }
 
         /** Reports that this stream is between units of work and must not hold shutdown open. */
         public void markIdle() {
-            if (busy) {
-                busy = false;
+            if (BUSY.compareAndSet(this, true, false)) {
                 owner.release();
             }
         }
 
-        /** Reports that this stream has work in flight again. */
-        public void markBusy() {
-            if (!busy) {
-                busy = true;
-                BUSY_STREAMS.getAndAdd(owner, 1);
+        /**
+         * Reports that this stream has work in flight again.
+         *
+         * <p>The count is taken <em>before</em> the flag is set, never the other way round. Setting the
+         * flag first and reverting on failure would expose a window where a concurrent
+         * {@link #markIdle()} sees {@code busy == true} and releases a count this handle never took.
+         *
+         * @return {@code false} if the drain has already committed to teardown, in which case the
+         *         protocol layer must close rather than serve — the stream will not be waited for
+         */
+        public boolean markBusy() {
+            if (busy) {
+                return true;
             }
+            if (!owner.tryAcquire()) {
+                return false;
+            }
+            if (!BUSY.compareAndSet(this, false, true)) {
+                // Another markBusy won; it already holds the one count this handle is entitled to.
+                owner.release();
+            }
+            return true;
         }
 
         /** Releases this stream's contribution; idempotent with {@link #markIdle()}. */

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -54,8 +54,15 @@ import java.util.function.Function;
  * (NIO selectors, io_uring rings) — none of which own a shared scope. A long-lived STS is
  * therefore architecturally incompatible with the multi-carrier ingress model.
  * {@code Thread.ofVirtual().start()} is the sole deliberate exception to the STS mandate.
- * All concurrent operations <em>within</em> {@code runStream()} MUST use
- * {@code StructuredTaskScope}.
+ *
+ * <p><b>Track-dependent, and this class carries no {@code StructuredTaskScope} import on either.</b>
+ * The sentence this paragraph replaced said concurrency inside {@code runStream()} MUST use
+ * {@code StructuredTaskScope}. On the default line that mandates the one preview dependency 1.0 GA must
+ * not ship — see ROADMAP §"Platform Baseline for 1.0 GA", which records the same staleness in
+ * {@code ExerisArchitectureTest.noExecutorsAnywhere}'s reason text. Read it per track: the
+ * {@code preview} artifact keeps {@code StructuredTaskScope}; the default line uses virtual threads
+ * plus explicit {@code ScopedValue} rebind at the {@link StreamExecutionBackend} seam, both GA.
+ * Either way structured lifetime is the requirement, not a specific class.
  *
  * <h2>ScopedValue Bindings (JEP 506)</h2>
  * <p>Before invoking the {@link StreamHandler}, the PAQS binds:

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -251,7 +251,11 @@ public final class PaqsScheduler implements AutoCloseable {
         // Waits on streams being SERVED, not on streams being OPEN. A stream is busy from the moment
         // it starts and only a protocol that knows it is between requests reports otherwise, so a raw
         // handler still gets the full drain while an idle keep-alive connection stops holding it.
-        while (drainCoordinator.busyStreams() > 0) {
+        // sealIfIdle() rather than busyStreams() == 0: observing zero and committing to teardown must
+        // be one step. Read as two, a request that arrived while the loop was looking flips the count
+        // back to one on an engine already past its commit point, and teardown severs the stream
+        // serving it. After the seal a re-arm is refused and the protocol layer closes instead.
+        while (!drainCoordinator.sealIfIdle()) {
             if (System.nanoTime() >= deadlineNanos) {
                 int remaining = drainCoordinator.busyStreams();
                 if (remaining > 0) {
@@ -260,6 +264,9 @@ public final class PaqsScheduler implements AutoCloseable {
                                     + " streams to finish; proceeding with shutdown",
                             remaining);
                 }
+                // Seal anyway. Shutdown has decided to proceed, so letting streams keep taking counts
+                // serves nothing and lets a late arrival believe it is protected when it is not.
+                drainCoordinator.sealNow();
                 break;
             }
             if (spins < SPIN_THRESHOLD) {

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
@@ -242,15 +242,48 @@ class DrainCoordinatorTest {
         @DisplayName("sealNow discards work in flight, for the drain deadline only")
         void sealNowDiscardsInFlightWork() {
             DrainCoordinator coordinator = new DrainCoordinator();
-            DrainCoordinator.StreamWork work = coordinator.registerStream();
+            coordinator.registerStream();
 
             coordinator.sealNow();
 
             assertThat(coordinator.busyStreams()).isZero();
-            assertThat(work.markBusy())
+            // Asserted through a FRESH handle. Asking the already-busy one whether it may re-arm
+            // answers from its own flag before the coordinator is ever consulted, so it would pass
+            // against no seal at all.
+            assertThat(coordinator.registerStream().markBusy())
                     .as("once shutdown proceeds regardless, letting a late arrival believe it is "
                             + "protected is worse than telling it to close")
-                    .isTrue();
+                    .isFalse();
+        }
+
+        /**
+         * The forced seal is the one path where a handle outlives its count, and the sentinel is a
+         * number.
+         *
+         * <p>{@code SEALED} is {@code Integer.MIN_VALUE}. A handler still running when the deadline
+         * fires finishes afterwards and releases; an unguarded decrement wraps the sentinel to
+         * {@code Integer.MAX_VALUE}, which is no longer the sentinel — so the coordinator resumes
+         * handing out counts, and a stream can report itself busy in the middle of teardown. That is
+         * the failure this class exists to prevent, reopened through the path that exists for it.
+         *
+         * <p>Deterministic, not an interleaving: it fires on every timed-out drain with work in flight.
+         */
+        @Test
+        @DisplayName("a stream released after a forced seal does not corrupt the sentinel")
+        void releaseAfterForcedSealDoesNotCorruptTheCount() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork inFlight = coordinator.registerStream();
+
+            coordinator.sealNow();
+            inFlight.close();
+
+            assertThat(coordinator.busyStreams())
+                    .as("a wrapped sentinel reads as a huge live count, so shutdown would believe "
+                            + "work appeared out of nowhere at the moment it stopped waiting")
+                    .isZero();
+            assertThat(coordinator.registerStream().markBusy())
+                    .as("and the seal must survive the release that followed it")
+                    .isFalse();
         }
     }
 

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
@@ -178,4 +178,180 @@ class DrainCoordinatorTest {
                     .isEqualTo(1);
         }
     }
+
+    @Nested
+    @DisplayName("Sealing — observing zero and committing must be one step")
+    class Sealing {
+
+        @Test
+        @DisplayName("an idle coordinator seals")
+        void idleCoordinatorSeals() {
+            assertThat(new DrainCoordinator().sealIfIdle()).isTrue();
+        }
+
+        @Test
+        @DisplayName("a coordinator with work in flight refuses to seal")
+        void busyCoordinatorDoesNotSeal() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            coordinator.registerStream();
+
+            assertThat(coordinator.sealIfIdle())
+                    .as("sealing while a stream is served is the commit that severs it")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("after sealing, a parked stream cannot re-arm")
+        void sealedCoordinatorRefusesReArm() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork work = coordinator.registerStream();
+            work.markIdle();
+
+            assertThat(coordinator.sealIfIdle()).isTrue();
+
+            assertThat(work.markBusy())
+                    .as("this is the window the drain loop could not close by reading the count: a "
+                            + "request arriving after the commit must be told to close, not served "
+                            + "by a handler the teardown is about to sever")
+                    .isFalse();
+            assertThat(coordinator.busyStreams())
+                    .as("and a refused re-arm must not leave a count behind either")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("a stream registered after the seal holds no count")
+        void streamRegisteredAfterSealHoldsNoCount() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            assertThat(coordinator.sealIfIdle()).isTrue();
+
+            DrainCoordinator.StreamWork late = coordinator.registerStream();
+
+            assertThat(coordinator.busyStreams())
+                    .as("close() does not stop admission, so a connection can still arrive — but it "
+                            + "cannot extend a shutdown already past its commit point")
+                    .isZero();
+            assertThat(late.markBusy()).isFalse();
+            late.close();
+            assertThat(coordinator.busyStreams())
+                    .as("and closing a handle that never took a count must not decrement")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("sealNow discards work in flight, for the drain deadline only")
+        void sealNowDiscardsInFlightWork() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+            coordinator.sealNow();
+
+            assertThat(coordinator.busyStreams()).isZero();
+            assertThat(work.markBusy())
+                    .as("once shutdown proceeds regardless, letting a late arrival believe it is "
+                            + "protected is worse than telling it to close")
+                    .isTrue();
+        }
+    }
+
+    /**
+     * The handle is reachable from more than its own thread, so its flag is a compare-and-set.
+     *
+     * <p>These cannot prove the absence of a race — that needs a stress harness, and jcstress is not
+     * wired into this repo. What they do prove is that the previous shape was wrong: reverting the flag
+     * to a non-volatile field with read-modify-write fails <em>all three</em> of these, observed rather
+     * than assumed (the double-acquire case reported a count of 3 against an expected 1). A green run
+     * here is evidence the arithmetic holds under contention, not a proof that it always will; that
+     * distinction is written down rather than left for a reader to assume the stronger claim.
+     */
+    @Nested
+    @DisplayName("Handle concurrency")
+    class HandleConcurrency {
+
+        private static final int THREADS = 8;
+        private static final int ROUNDS = 2_000;
+
+        @Test
+        @DisplayName("concurrent markIdle() releases the count once, never once per caller")
+        void concurrentMarkIdleNeverDoubleReleases() throws InterruptedException {
+            for (int round = 0; round < ROUNDS; round++) {
+                DrainCoordinator coordinator = new DrainCoordinator();
+                DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+                raceOn(work::markIdle);
+
+                assertThat(coordinator.busyStreams())
+                        .as("a double release drops the count below the truth, so the drain finishes "
+                                + "early and teardown severs a handler still writing its response")
+                        .isZero();
+            }
+        }
+
+        @Test
+        @DisplayName("concurrent markBusy() takes the count once, never once per caller")
+        void concurrentMarkBusyNeverDoubleAcquires() throws InterruptedException {
+            for (int round = 0; round < ROUNDS; round++) {
+                DrainCoordinator coordinator = new DrainCoordinator();
+                DrainCoordinator.StreamWork work = coordinator.registerStream();
+                work.markIdle();
+
+                raceOn(work::markBusy);
+
+                assertThat(coordinator.busyStreams())
+                        .as("a double acquire leaves a count nothing will ever release, so the drain "
+                                + "burns its full deadline — issue #282's symptom by another route")
+                        .isEqualTo(1);
+            }
+        }
+
+        @Test
+        @DisplayName("interleaved markIdle()/markBusy() leaves the count matching the flag")
+        void interleavedTransitionsPreserveTheInvariant() throws InterruptedException {
+            for (int round = 0; round < ROUNDS; round++) {
+                DrainCoordinator coordinator = new DrainCoordinator();
+                DrainCoordinator.StreamWork work = coordinator.registerStream();
+
+                raceOn(index -> {
+                    if (index % 2 == 0) {
+                        work.markIdle();
+                    } else {
+                        work.markBusy();
+                    }
+                });
+
+                // Whichever transition landed last, the handle holds 0 or 1 — never 2, never -1.
+                work.markIdle();
+                assertThat(coordinator.busyStreams())
+                        .as("the invariant is that a handle holds exactly busy ? 1 : 0 counts; any "
+                                + "other value means a transition and its counter operation came apart")
+                        .isZero();
+            }
+        }
+
+        private void raceOn(Runnable action) throws InterruptedException {
+            raceOn(_ -> action.run());
+        }
+
+        private void raceOn(java.util.function.IntConsumer action) throws InterruptedException {
+            java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+            Thread[] threads = new Thread[THREADS];
+            for (int i = 0; i < THREADS; i++) {
+                int index = i;
+                threads[i] = Thread.ofVirtual().unstarted(() -> {
+                    try {
+                        start.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    action.accept(index);
+                });
+                threads[i].start();
+            }
+            start.countDown();
+            for (Thread thread : threads) {
+                thread.join();
+            }
+        }
+    }
 }

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
@@ -260,16 +260,20 @@ class DrainCoordinatorTest {
         }
 
         /**
-         * The forced seal is the one path where a handle outlives its count, and the sentinel is a
-         * number.
+         * The forced seal is the one path where a handle outlives its count, and the marker is a number.
          *
-         * <p>{@code SEALED} is {@code Integer.MIN_VALUE}. A handler still running when the deadline
-         * fires finishes afterwards and releases; an unguarded decrement wraps the sentinel to
-         * {@code Integer.MAX_VALUE}, which is no longer the sentinel — so the coordinator resumes
-         * handing out counts, and a stream can report itself busy in the middle of teardown. That is
-         * the failure this class exists to prevent, reopened through the path that exists for it.
+         * <p>A handler still running when the deadline fires finishes afterwards and releases, and
+         * {@code release()} decrements unconditionally. That is safe only because the seal marks a
+         * <em>range</em>: the decrement lands further inside it. Pin an exact marker instead — the
+         * shape this suite was first written against, at {@code Integer.MIN_VALUE} — and one decrement
+         * wraps it to {@code Integer.MAX_VALUE}, which reads as neither sealed nor a plausible count.
+         * The coordinator resumes handing out counts and a stream can report itself busy in the middle
+         * of teardown: the failure this class exists to prevent, reopened through the path that exists
+         * for it.
          *
          * <p>Deterministic, not an interleaving: it fires on every timed-out drain with work in flight.
+         * The single-release case is kept alongside {@link #sealSurvivesRepeatedPostSealReleases()}
+         * because it is the minimal one — if the range property breaks, this is what fails first.
          */
         @Test
         @DisplayName("a stream released after a forced seal does not corrupt the sentinel")

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinatorTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -283,6 +286,36 @@ class DrainCoordinatorTest {
                     .isZero();
             assertThat(coordinator.registerStream().markBusy())
                     .as("and the seal must survive the release that followed it")
+                    .isFalse();
+        }
+
+        /**
+         * The marker is a range, and the headroom is the reason the hot path can stay on
+         * {@code getAndAdd}.
+         *
+         * <p>Post-seal releases drive the count further negative, so the claim being pinned is that a
+         * realistic number of them cannot walk it back across zero. The streams must be registered
+         * <em>before</em> the seal to hold a count at all — one registered after holds none, so its
+         * {@code close()} is a no-op and would exercise nothing. Asserting a single release proves only
+         * the first step.
+         */
+        @Test
+        @DisplayName("the seal survives far more post-seal releases than any ceiling permits")
+        void sealSurvivesRepeatedPostSealReleases() {
+            DrainCoordinator coordinator = new DrainCoordinator();
+            List<DrainCoordinator.StreamWork> inFlight = new ArrayList<>();
+            for (int i = 0; i < 10_000; i++) {
+                inFlight.add(coordinator.registerStream());
+            }
+
+            coordinator.sealNow();
+            inFlight.forEach(DrainCoordinator.StreamWork::close);
+
+            assertThat(coordinator.busyStreams())
+                    .as("a marker one step from wrapping reports a sealed engine as fully loaded")
+                    .isZero();
+            assertThat(coordinator.registerStream().markBusy())
+                    .as("and admission must still be closed after all of it")
                     .isFalse();
         }
     }


### PR DESCRIPTION
Two defects in the graceful-drain machinery from #284, found reading the code rather than by a failure. Both are latent today and both destroy exactly what the class exists to guarantee.

## 1. The handle claimed thread confinement; the mechanism guarantees the opposite

`StreamWork`'s flag was a plain `boolean`, its Javadoc saying *"confined to the stream's own thread — the protocol loop that reports it is the only caller"*.

But the handle reaches protocol code **only** through `TransportScopes.STREAM_WORK`, a `ScopedValue` — `CommunityHttpRequestProcessor` never receives it as a parameter. And `PaqsScheduler` mandates, two screens above the binding site, that *"all concurrent operations within `runStream()` MUST use `StructuredTaskScope`"* — whose `fork()` inherits `ScopedValue` bindings. Any subtask written to that mandate can read the handle and call `markIdle()`/`markBusy()` from another thread. `ScopedValue` is chosen precisely for down-stack visibility and fork inheritance; a parameter or a field would have expressed confinement without the door.

Both races are fatal to the purpose:

| Interleaving | Result |
|---|---|
| two threads see `busy == true` in `markIdle()` | double release → count below the truth → drain ends early → **teardown severs a handler mid-response** |
| two threads see `busy == false` in `markBusy()` | double acquire → count never reaches zero → full 60s deadline, i.e. #282's symptom |

The flag is now compare-and-set, so idempotence is a property of the type rather than an assumption about callers. One uncontended CAS per transition on a per-stream handle — noise against the `getAndAdd` on the shared counter that already happens.

Ordering detail worth flagging for review: `markBusy()` takes the count **before** setting the flag. The reverse needs an optimistic set plus a revert on failure, which opens a window where a concurrent `markIdle()` observes `busy == true` and releases a count this handle never took.

## 2. Observing zero was not the same as committing to teardown

The loop was `while (drainCoordinator.busyStreams() > 0)`, and `markBusy()` did not consult `draining` at all. An idle keep-alive stream has `busy == false`; a request arriving after the loop's last read and before teardown flips 0 → 1 on an engine already tearing down.

The existing protection is cooperative — protocols read `isDraining()` and stop extending, and the H1 codec answers `Connection: close`. That covers a codec that checks. It does not cover a request already sitting in the socket buffer when the drain began, nor a protocol that does not read the flag. The same reasoning that makes *busy* the default applies one level up: a protocol that does not participate must not be able to silently re-arm.

**Checking the flag inside `markBusy()` would not have fixed it** — read `!sealed`, loop seals, increment lands after the commit. So the count and the commit move together: `sealIfIdle()` is a CAS to a sentinel, the drain loop spins on *that* rather than on a read, and `markBusy()` answers `false` once sealed. The H1 loop returns instead of serving — the honest reading of a connection whose peer was already told to close; RFC 9112 §9.6 requires a client to tolerate a persistent connection closing. On the deadline the coordinator seals unconditionally, since once shutdown proceeds regardless, letting a late arrival believe it is protected is worse than closing on it.

This was **not** a deliberate best-effort decision — the window was simply not considered when #284 was written. It is now stated in `transport.md` either way.

## Verification

`DrainCoordinatorTest` 11 → 19 cases: 5 on sealing, 3 on handle concurrency.

The concurrency cases were verified against the *previous* shape rather than assumed adequate — reverting the flag to a plain field with read-modify-write fails **all three**, the double-acquire case reporting a count of 3 against an expected 1. They cannot prove the absence of a race (that needs jcstress, not wired into this repo) and the test Javadoc says so rather than letting a green run read as proof.

- `mvn clean install` — full reactor, no skip flags, so lint-gated. It surfaced two real findings on the way (a Checkstyle declaration-order break and a PMD `UnnecessaryWarningSuppression`, the latter correct — the flag *is* read directly).
- `ExerisArchitectureTest` — 13 rules.
- `stress` gate on `exeris-kernel-community` — 4 tests.
- Drain coverage specifically: `CommunityNativeTcpCarrierTckTest` (incl. `GracefulDrain`) + `CommunityHttpDrainIntegrationTest`, 12 tests.

One flake to record rather than bury: the first full build failed `CommunityConnectionRefusalTest.refusalIsCountedAndRecorded` (empty JFR event list, 0.025 s). Re-run 3× in isolation and twice as a full build: green every time. It is also not mechanically reachable from this change — the recording is stopped *before* `engine.stop()`, so the drain is not on that assertion's path. Recorded because this test family has been flaky on CI before, not because it is attributed to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
