### PR TITLE
docs(release): the v0.11 notes did not mention the milestone's headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
 ## [Unreleased]
 
 ### Added
+- **The distributed artifact no longer requires `--enable-preview`, and baselines on JDK 25 LTS**
+  (ADR-066). `--enable-preview` is a whole-compilation and whole-JVM flag whose bytecode is stamped
+  and major-pinned, so a published artifact carrying it forces every consumer's entire build under the
+  same flag and the same exact JDK. As of 0.11.0: 930 distributed classes, class-file major 69, zero
+  preview-stamped, enforced by a CI gate that reads the shipped class files rather than the sources
+  (`tools/preview-bytecode-scan/`). The JDK baseline moves 26 → 25, which is a widening for
+  consumers. A second artifact, `0.11.0-preview`, carries `StructuredTaskScope` on the newest JDK for
+  JVM-controlled deployments.
 - **Flow resume binds to identity, not position** — `FlowSnapshot` gains three components across v0.11:
   `currentStepName` (ADR-062), `definitionVersion` (ADR-064) and `compensationStepNames` (ADR-064
   amendment A5). Each replaces an inference the runtime used to make from a bare index: which step a
@@ -44,6 +52,20 @@ Format follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.
   surfaces it had never described — client retry (ADR-045) and route authorization (ADR-061); and
   the pre-1.0 framing now distinguishes "no consumer under a support contract" from "no consumers",
   and points at the generated record.
+
+- **`EventBus.publishAndAwait` runs handlers on the calling thread**, in subscription order (ADR-066).
+  Handler durations now sum rather than overlap, and a slow handler delays its successors; `publish`
+  is unchanged. This is what preserves the path's `ScopedValue` contract without a preview API — a
+  handler observes every value the publisher bound, including ones the kernel cannot name, which no
+  fork-based GA mechanism can deliver.
+- **Subsystem start runs on the booting thread** in dependency-safe rounds, so a phase takes the sum
+  of its subsystems' start times rather than the longest — once per JVM, and `FOUNDATION` was already
+  sequential. Forking with a rebuilt kernel carrier was implemented and booted the HTTP subsystem with
+  no handler bound, because `HTTP_SERVER_HANDLER` is bound by the application around `boot()`.
+- **A failed subsystem in a parallel phase now throws `BootstrapException`** instead of escaping as
+  the unchecked preview type `StructuredTaskScope.FailedException` — which had also made the
+  orchestrator's own failure-collection path unreachable. Callers catching that preview type should
+  remove it.
 
 ## [0.10.2] — 2026-07-19
 

--- a/docs/release/v0.11.0-release-notes.md
+++ b/docs/release/v0.11.0-release-notes.md
@@ -2,13 +2,82 @@
 
 | | |
 |:--|:--|
-| **Version** | 0.11.0 |
+| **Artifacts** | **`0.11.0`** — the distributable line, and **`0.11.0-preview`** — the preview line |
 | **Date** | _unreleased — milestone in progress_ |
 | **Predecessor** | 0.10.2 |
 | **Framing** | Pre-1.0 / TRL-3. Per-surface semver policy: [`docs/stability-matrix.md`](../stability-matrix.md). |
 
 > **Status.** This file is opened early and deliberately, to carry the compatibility items that must
 > not be discovered at the release cut. It is not the finished notes for the milestone.
+
+## This milestone ships two artifacts
+
+They carry the **same kernel** — same SPI, same subsystems, same tests — and differ in exactly one
+axis plus the build that follows from it.
+
+| | `0.11.0` | `0.11.0-preview` |
+|:--|:--|:--|
+| **JDK** | **25 LTS** | newest available — JDK 28 EA today |
+| **`--enable-preview`** | **not required, and not imposed on you** | required, by definition |
+| **Structured concurrency** | `StructuredScope` — virtual threads + `ScopedValue`, both GA | `StructuredTaskScope` |
+| **Class-file major** | 69 | 72 |
+| **For** | anything published, and any deployment that does not control its JVM | JVM-controlled deployments, and early access to what the next LTS will carry |
+
+Take `0.11.0` unless you have a reason not to. The preview line exists to absorb JDK API churn ahead
+of the LTS it converges into, not to be the better artifact — see below for what it costs.
+
+## Platform: the distributed artifact no longer requires `--enable-preview` (ADR-066)
+
+**This is the milestone's headline, and it is a compatibility item disguised as a build change.**
+
+`--enable-preview` is not a per-library opt-in. It is a whole-compilation and whole-JVM flag, and the
+bytecode it produces is stamped `minor_version = 0xFFFF` and pinned to one exact class-file major — a
+class built that way will not load on any other JDK **even with the flag**. A published artifact
+carrying that stamp therefore inverts the dependency contract: every consumer would have to build and
+run *their entire application* with the flag, pin to our exact JDK, and accept that all of their own
+code falls under the "may change or disappear next release" preview contract. Many organisations
+forbid preview in production outright.
+
+As of 0.11.0 the distributed artifact carries none of that. Measured at the cut rather than asserted:
+**930 distributed classes, class-file major 69, zero preview-stamped.** A CI gate
+(`tools/preview-bytecode-scan/`) reads the shipped class files and fails the build on any preview
+stamp or on a major above the baseline — bytecode rather than a source grep, because the stamp is what
+a consumer trips over and it survives generated code a grep would miss.
+
+**The JDK baseline moves 26 → 25 LTS**, which for a consumer is a *widening*: anything that ran on 26
+still runs, and LTS-only environments become reachable. Nothing in the kernel used a JDK-26-only API —
+the `26` was never load-bearing.
+
+### Behaviour changes you may observe
+
+Two of the four concurrency sites could not move to a GA fork-based mechanism at all, because their
+contracts require `ScopedValue` bindings the kernel cannot enumerate — an application's own. A
+`ScopedValue.Carrier` can only carry values named in advance, so those two now run **in-thread**:
+
+- **`EventBus.publishAndAwait` runs handlers on the calling thread**, in subscription order. Handler
+  durations therefore **sum** rather than overlap, and a slow handler delays its successors. The
+  method always blocked until all handlers finished; it now does that work instead of delegating it.
+  Callers wanting fan-out have `publish`, which is unchanged. What this preserves is the contract: a
+  handler still observes every scoped value the publisher had bound, including your own — which no
+  fork-based GA mechanism can deliver.
+- **Subsystem start runs on the booting thread**, in dependency-safe rounds. A phase now takes the
+  sum of its subsystems' start times rather than the longest. Paid once per JVM; `FOUNDATION` was
+  already sequential. This was not a preference: forking with a rebuilt kernel carrier was
+  implemented and booted the HTTP subsystem with **no handler bound**, because `HTTP_SERVER_HANDLER`
+  is bound by the *application* around `boot()`.
+- **A failed subsystem in a parallel phase now throws `BootstrapException`.** It previously escaped as
+  `StructuredTaskScope.FailedException`, an unchecked preview type — which also meant the
+  orchestrator's own failure-collection path was unreachable. **If you catch that preview type, remove
+  it**; `BootstrapException` is what the contract always named.
+
+### What the preview line costs
+
+`0.11.0-preview` tracks the newest JDK, usually while it is still EA, and **class-file readers ship
+support after a JDK releases**. Three gates therefore cannot run there: PMD, ArchUnit and JaCoCo all
+fail to parse class-file major 72 — measured, including on releases newer than the ones pinned. Their
+coverage is inherited from the distributed line, which runs all three on JDK 25 where the tools work.
+That inheritance is sound only while the two lines differ solely in the concurrency mechanism and the
+build, which is why the preview line is kept deliberately thin.
 
 ## Compatibility: `spi.flow` — `FlowSnapshot` gains three record components
 


### PR DESCRIPTION
The release notes and the CHANGELOG's `[Unreleased]` block both **predated ADR-066** and carried no trace of it — no "preview-clean", no "JDK 25", no mention that the distributed artifact stops imposing `--enable-preview` on its consumers. That is the item the whole platform-baseline stream existed to produce.

## One document, two artifacts

The milestone ships **`0.11.0`** and **`0.11.0-preview`**. They carry the same kernel and differ on one axis plus the build that follows from it, so the notes say it once in a table rather than forking into a second file.

That is not only tidiness: written this way the file **merges up to the preview line unchanged** instead of becoming a permanent conflict — the same reason the two SPI javadocs were rewritten to be true on both lines in #305.

## Three behaviour changes, stated as changes

The build change is the easy half. These are the half a reader would otherwise meet in production:

- **`publishAndAwait` runs handlers on the calling thread** — durations **sum** rather than overlap, and a slow handler delays its successors. What it buys is the contract: a handler still observes every scoped value the publisher bound, *including the application's own*, which no fork-based GA mechanism can deliver.
- **Subsystem start runs on the booting thread** — a phase costs the sum of its subsystems' start times rather than the longest. Once per JVM; `FOUNDATION` was already sequential.
- **A failed subsystem in a parallel phase now throws `BootstrapException`** instead of the unchecked preview type `StructuredTaskScope.FailedException`. Anyone catching that type **must remove it** — written as an action, not a note.

## The preview line's cost is in the notes too

Three gates (PMD, ArchUnit, JaCoCo) cannot run on an EA JDK, because class-file readers ship support *after* a JDK releases. Their coverage is inherited from the distributed line — sound only while the two lines stay thin apart. A reader choosing between artifacts should see that before choosing, not after.

## Deliberately not done here

`[Unreleased]` is **not** renamed to `[0.11.0]`, and versions are **not** flipped. Both belong to the `release(0.11.0)` PR, which is what fixes the date. This commit is content only, so the release PR stays mechanical.

## Verification

Docs only. 8 relative links resolve; no private party named; the new text is qualified by line wherever the two differ.