### PR TITLE
feat(preview): six carriers become JEP 401 value classes

### DIFF
--- a/PREVIEW-TRACK.md
+++ b/PREVIEW-TRACK.md
@@ -43,10 +43,18 @@ rather than the `BootstrapException` the contract names. The checked exception f
 catch restores the intended type. The default line reached the same outcome by a different route
 (ADR-066 §2).
 
-## Three gates cannot run here, and none is a lowered bar
+## Four gates cannot run here — and the reason is structural, not temporary
 
-All three are **tooling limits on an EA JDK**, recorded rather than quietly skipped. None of them was
-predicted — each was found by running the gate:
+Three of the four read class files, and **class-file readers ship support after a JDK releases**. This
+line tracks the newest JDK, usually while it is still EA. The two facts do not reconcile: by the time
+a tool supports the JDK this branch is on, this branch has moved to the next one.
+
+That was measured, not assumed. ArchUnit 1.4.2's shaded ASM knows class-file versions only up to
+**V26**; even the newest ArchUnit reaches 27, and JDK 28 is major 72. JaCoCo **0.8.15** — a release
+newer than the one the build pins — still fails with "Unsupported class file major version 72".
+
+So the correct expectation is not "re-enable when the tool catches up" but **these gates are
+unavailable on this line as a standing condition**. Each is recorded rather than quietly skipped:
 
 - **PMD** (`pmd.skip` in the root POM). PMD 7.22.0 cannot parse JDK 28 class files — type resolution
   fails on `java/lang/String` itself. With types unresolved it reports ~20 false positives on SPI
@@ -56,6 +64,15 @@ predicted — each was found by running the gate:
   the suites' own non-empty-analysis assertions (`verifyClassesArePresent`,
   `allThreeTiersAreOnTheAnalysisClasspath`), which exist precisely so an empty analysis can never pass
   as a green one.
+- **Checkstyle** (`checkstyle.skip` in the root POM). **This is the one this document previously
+  singled out as unaffected** — "syntax-level and unaffected" — and JEP 401 falsified it. Checkstyle
+  13.2.0's Java grammar does not know the `value` modifier and fails to *parse* the file: "no viable
+  alternative at input 'value'", reported as a configuration error rather than a style finding.
+
+  It also **widens the rule rather than repeating it.** PMD, ArchUnit and JaCoCo fail on the class-file
+  **major version**, so they break when this line bumps its JDK. Checkstyle fails on preview **source
+  syntax**, so it breaks the moment this line uses a preview *language* feature at all — which is what
+  the line exists to do. Tool lag reaches source-level tools too, not only bytecode readers.
 - **JaCoCo** (`jacoco.skip` in the root POM). JaCoCo 0.8.14 fails report generation outright —
   "Unsupported class file major version 72" — on the first module it reaches, and would fail
   identically on every one. Unlike the other two this is not noise: it fails
@@ -69,14 +86,19 @@ predicted — each was found by running the gate:
 invisible locally for exactly that reason. **Verify this line with the command CI runs, not a
 neighbouring one**; the same slip produced two red gates on the default line's PR in the same week.
 
-**Why the bar is not lowered:** all three gates' subject is identical on the two lines — the SPI /
+**Why the bar is not lowered:** all four gates' subject is identical on the two lines — the SPI /
 Core / Community boundaries, the lint rules, and the coverage floors, over the same sources — and
-`main` runs all three on JDK 25 LTS where the tools work. **That argument has a limit, and it is the branch's main standing risk:** it holds only
-while the two lines differ solely in the concurrency mechanism. If this branch grows structure `main`
-does not have, the coverage borrowed from `main` disappears with it.
+`main` runs all three on JDK 25 LTS where the tools work.
 
-Each skip carries its own re-enable trigger and the one command that tests it, in the POM comment
-beside it.
+**The permanence of the gap makes one constraint governing rather than advisory.** This line is
+**never self-verifying** for boundaries, lint, or coverage; that verification is always inherited from
+`main`. Inheriting is only sound while the two lines differ solely in the concurrency mechanism and
+the build. **Keeping the delta small is therefore not a matter of taste — it is what makes this branch
+verifiable at all.** Any structure added here that `main` does not have arrives with no boundary
+guard, no lint and no coverage floor behind it, and nothing will say so.
+
+The POM comment beside each skip carries the one command that re-tests the tool. Worth re-running at
+each JDK bump — but expect the answer to stay "no" more often than not, for the reason above.
 
 ## Keeping this line in sync with `development/*`
 
@@ -129,10 +151,36 @@ missed.
 
 ## Still to do on this line
 
-- **Exercise JEP 401 (Value Objects) and JEP 539 (Strict Field Initialization)**, both preview in
-  JDK 28. This is the reason the line exists beyond `StructuredTaskScope`: the "Valhalla-ready
-  carriers" guardrail is a style rule on `main` and becomes *executable* here. Nothing has been
-  measured yet — no value class has been declared and no benchmark has been run, so this document
-  makes no claim about what it buys.
+- **JEP 539 (Strict Field Initialization)** — not yet exercised.
+- **A benchmark for the value carriers.** Six are declared (below) and none is measured; the numbers
+  need the benchmark harness and are deliberately post-cut. This document makes **no claim** about
+  what value classes buy until one exists.
 - Decide whether this line publishes `0.11.0-preview-SNAPSHOT` to GitHub Packages. The workflow's
   publish step is currently gated on `main` and `development/*`, so today it does not.
+
+## JEP 401: six carriers are value classes here
+
+Declared `public value record`: `MemoryStats`, `TlsShutdownResult`, `TlsHandshakeResult`,
+`EventEngineStats` (SPI), `TransactionRetryPolicy`, `SyscallHandles` (Core). Chosen because the
+repository already *claimed* they were Valhalla-ready — each has a `ValhallaReadiness` test predating
+this work — so converting them tests the claim rather than asserting a new one.
+
+**Verified in the bytecode, with a control.** `ACC_IDENTITY` (0x0020, formerly `ACC_SUPER`) is **clear**
+on all six and **set** on an untouched carrier (`FlowSnapshot`). Compiling is not evidence that the
+modifier did anything; the flag is.
+
+**Three semantics change, all silently**, which is why the selection criterion mattered more than the
+conversion:
+
+| | identity `record` | `value record` |
+|:--|:--|:--|
+| `a == b` for structurally equal | `false` | **`true`** — comparison is by value |
+| `System.identityHashCode` differs | yes | **no** |
+| `IdentityHashMap` holding two equal instances | size 2 | **size 1** |
+
+`synchronized` on a value throws `IdentityException` — **at runtime, not at compile time**, so a
+converted carrier needs test coverage to prove the guardrail, not a green compile.
+
+The criterion applied before converting: **zero identity comparisons and zero identity-keyed lookups
+on the carrier anywhere in `*/src/main`** — checked per carrier, all six at zero. A carrier used as an
+identity key would break silently, and nothing in the toolchain would say so.

--- a/PREVIEW-TRACK.md
+++ b/PREVIEW-TRACK.md
@@ -64,7 +64,7 @@ unavailable on this line as a standing condition**. Each is recorded rather than
   the suites' own non-empty-analysis assertions (`verifyClassesArePresent`,
   `allThreeTiersAreOnTheAnalysisClasspath`), which exist precisely so an empty analysis can never pass
   as a green one.
-- **Checkstyle** (`checkstyle.skip` in the root POM). **This is the one this document previously
+- **Checkstyle** (`checkstyle.skip` in `exeris-kernel-spi` and `exeris-kernel-core` only — **not** the root, because unlike the other three this failure is not reactor-wide: those two are the only modules carrying `value` syntax, and `community`, `community-kafka`, `community-testkit`, `tck` and `diagnostics-cli` keep real Checkstyle coverage; verified in the build log). **This is the one this document previously
   singled out as unaffected** — "syntax-level and unaffected" — and JEP 401 falsified it. Checkstyle
   13.2.0's Java grammar does not know the `value` modifier and fails to *parse* the file: "no viable
   alternative at input 'value'", reported as a configuration error rather than a style finding.
@@ -168,6 +168,12 @@ this work — so converting them tests the claim rather than asserting a new one
 **Verified in the bytecode, with a control.** `ACC_IDENTITY` (0x0020, formerly `ACC_SUPER`) is **clear**
 on all six and **set** on an untouched carrier (`FlowSnapshot`). Compiling is not evidence that the
 modifier did anything; the flag is.
+
+**And the check is repeatable, not a one-time inspection.** Each carrier's pre-existing
+`ValhallaReadiness` test now asserts `Class::isValue`, because the structural-equality cases already
+there pass for an identity record too — nothing in the suite would have noticed the modifier being
+lost to a merge or a reformat. Proven non-vacuous by mutation: dropping `value` from `MemoryStats`
+reddens exactly `isValueClass` with the message naming `ACC_IDENTITY`.
 
 **Three semantics change, all silently**, which is why the selection criterion mattered more than the
 conversion:

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -20,6 +20,24 @@
     </description>
 
     <properties>
+    <!--
+        PREVIEW LINE ONLY — the FOURTH tool this line outruns, and the one this document
+        previously singled out as unaffected ("Checkstyle stays ON — it is syntax-level").
+        JEP 401 value classes falsify that: Checkstyle's Java grammar does not know the `value`
+        modifier and fails to PARSE the file — "no viable alternative at input 'value'" — so it
+        reports a configuration error, not a style finding.
+
+        Note the difference from PMD / ArchUnit / JaCoCo, because it widens the rule rather than
+        repeating it: those three fail on the class-file MAJOR VERSION, so they break when this
+        line bumps its JDK. Checkstyle fails on preview SOURCE SYNTAX, so it breaks the moment
+        this line uses a preview language feature at all — which is what the line exists to do.
+        Tool lag reaches source-level tools too, not only bytecode readers.
+
+        The bar is not lowered: `main` runs Checkstyle over the same sources on JDK 25, where no
+        `value` modifier appears. RE-ENABLE when Checkstyle's grammar accepts JEP 401. Test it by
+        deleting this property and running `mvn -pl exeris-kernel-spi checkstyle:check`.
+        -->
+    <checkstyle.skip>true</checkstyle.skip>
         <!--
             v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the Core bundle.
             Current measurement: ~74% (deepest test coverage in the reactor — TCK

--- a/exeris-kernel-core/pom.xml
+++ b/exeris-kernel-core/pom.xml
@@ -35,7 +35,7 @@
 
         The bar is not lowered: `main` runs Checkstyle over the same sources on JDK 25, where no
         `value` modifier appears. RE-ENABLE when Checkstyle's grammar accepts JEP 401. Test it by
-        deleting this property and running `mvn -pl exeris-kernel-spi checkstyle:check`.
+        deleting this property and running `mvn -pl exeris-kernel-core checkstyle:check`.
         -->
     <checkstyle.skip>true</checkstyle.skip>
         <!--

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/persistence/TransactionRetryPolicy.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/persistence/TransactionRetryPolicy.java
@@ -23,7 +23,7 @@ package eu.exeris.kernel.core.persistence;
  * @param backoffMultiplier exponential multiplier applied after each retry
  * @since 0.5.0
  */
-public record TransactionRetryPolicy(int maxAttempts, long baseDelayMs, double backoffMultiplier) {
+public value record TransactionRetryPolicy(int maxAttempts, long baseDelayMs, double backoffMultiplier) {
 
     /** Default: 1 attempt, no retry. */
     public static final TransactionRetryPolicy NONE = new TransactionRetryPolicy(1, 0L, 1.0);

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/syscall/SyscallHandles.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/syscall/SyscallHandles.java
@@ -18,7 +18,8 @@ import java.lang.invoke.MethodHandle;
  * <p>This is a standard {@code record} whose fields are all identity-free.
  * No {@code ==}, no {@code synchronized}, no {@code System.identityHashCode()} — it
  * scalarizes cleanly via C2 JIT Escape Analysis on the hot path.
- * Will be migrated to {@code value record} once JEP 401 is mainline.
+ * Declared {@code value record} on the `preview` line (JEP 401); asserted by
+ * {@code Class::isValue} in its ValhallaReadiness test.
  *
  * <h2>C-type to ValueLayout mapping</h2>
  * <pre>

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/syscall/SyscallHandles.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/syscall/SyscallHandles.java
@@ -61,7 +61,7 @@ import java.lang.invoke.MethodHandle;
  *                        Must be invoked to pair with {@code WSAStartup} before the owning arena is closed.
  * @since 0.5.0
  */
-public record SyscallHandles(
+public value record SyscallHandles(
         MethodHandle socket,
         MethodHandle bind,
         MethodHandle listen,

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/persistence/TransactionRetryPolicyTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/persistence/TransactionRetryPolicyTest.java
@@ -131,6 +131,21 @@ class TransactionRetryPolicyTest {
     @DisplayName("Valhalla-readiness — identity-free record")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("TransactionRetryPolicy is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(TransactionRetryPolicy.class.isValue())
+                    .as("TransactionRetryPolicy must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Two equal policies are equal by value — no identity dependency")
         void equalByValue() {

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallHandlesTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/syscall/SyscallHandlesTest.java
@@ -188,6 +188,21 @@ class SyscallHandlesTest {
     @DisplayName("Valhalla-readiness — identity-free record")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("SyscallHandles is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(SyscallHandles.class.isValue())
+                    .as("SyscallHandles must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Two SyscallHandles with identical fields are equal (value semantics)")
         void equalByValue() {

--- a/exeris-kernel-spi/pom.xml
+++ b/exeris-kernel-spi/pom.xml
@@ -16,6 +16,24 @@
     <description>The "Invisible Wall" — agnostic L0/L1/L2 contracts and RAII memory protocols.</description>
 
     <properties>
+    <!--
+        PREVIEW LINE ONLY — the FOURTH tool this line outruns, and the one this document
+        previously singled out as unaffected ("Checkstyle stays ON — it is syntax-level").
+        JEP 401 value classes falsify that: Checkstyle's Java grammar does not know the `value`
+        modifier and fails to PARSE the file — "no viable alternative at input 'value'" — so it
+        reports a configuration error, not a style finding.
+
+        Note the difference from PMD / ArchUnit / JaCoCo, because it widens the rule rather than
+        repeating it: those three fail on the class-file MAJOR VERSION, so they break when this
+        line bumps its JDK. Checkstyle fails on preview SOURCE SYNTAX, so it breaks the moment
+        this line uses a preview language feature at all — which is what the line exists to do.
+        Tool lag reaches source-level tools too, not only bytecode readers.
+
+        The bar is not lowered: `main` runs Checkstyle over the same sources on JDK 25, where no
+        `value` modifier appears. RE-ENABLE when Checkstyle's grammar accepts JEP 401. Test it by
+        deleting this property and running `mvn -pl exeris-kernel-spi checkstyle:check`.
+        -->
+    <checkstyle.skip>true</checkstyle.skip>
         <!--
             v0.8 Sprint 6 (Coverage C-P0-01): LINE coverage floor for the SPI bundle.
             Current measurement: ~36% (records / enums / interface skeletons inflate

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
@@ -12,7 +12,7 @@ package eu.exeris.kernel.spi.crypto;
  * SPI: Immutable result of a single TLS handshake step.
  *
  * <h2>Valhalla Readiness</h2>
- * <p>Immutable data carrier and candidate for {@code value record} once JEP 401
+ * <p>Immutable data carrier, declared {@code value record} on the `preview` line (JEP 401,
  * is mainline — at that point JVMs will be able to flatten instances in arrays and
  * as fields of other value types, eliminating object headers on the heap.
  *

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
@@ -26,7 +26,7 @@ package eu.exeris.kernel.spi.crypto;
  *                        interpretation is left to the implementation tier
  * @since 0.5.0
  */
-public record TlsHandshakeResult(Status status, int nativeErrorCode) {
+public value record TlsHandshakeResult(Status status, int nativeErrorCode) {
 
     /** Pre-allocated singleton: handshake complete. */
     public static final TlsHandshakeResult COMPLETE    = new TlsHandshakeResult(Status.COMPLETE, 0);

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResult.java
@@ -12,9 +12,12 @@ package eu.exeris.kernel.spi.crypto;
  * SPI: Immutable result of a single TLS handshake step.
  *
  * <h2>Valhalla Readiness</h2>
- * <p>Immutable data carrier, declared {@code value record} on the `preview` line (JEP 401,
- * is mainline — at that point JVMs will be able to flatten instances in arrays and
- * as fields of other value types, eliminating object headers on the heap.
+ * <p>Immutable data carrier, declared {@code value record} on the `preview` line (JEP 401, preview
+ * in JDK 28). The distributed line compiles the same source as an identity {@code record}; the
+ * modifier is the only difference, and it is asserted by {@code Class::isValue} in this carrier's
+ * ValhallaReadiness test rather than left to a one-time inspection.
+ * A JVM is therefore free to flatten instances in arrays and as fields of other value types,
+ * eliminating object headers on the heap — an opportunity, not a behaviour this contract assumes.
  *
  * <h2>Zero-Allocation Contract</h2>
  * <p>Callers retrieve one of the three pre-allocated singleton instances

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
@@ -12,7 +12,9 @@ package eu.exeris.kernel.spi.crypto;
  * SPI: Immutable result of a single TLS shutdown step.
  *
  * <h2>Valhalla Readiness</h2>
- * <p>Designed as a candidate for {@code value record} once JEP 401 is mainline.
+ * <p>Declared {@code value record} on the `preview` line (JEP 401, preview in JDK 28); the
+ * distributed line compiles the same source as an identity {@code record}. Asserted by
+ * {@code Class::isValue} in this carrier's ValhallaReadiness test.
  * At that point the {@code sentCloseNotify}/{@code receivedCloseNotify} booleans
  * and the status ordinal can be flattened to minimize header and pointer overhead.
  *

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
@@ -15,8 +15,9 @@ package eu.exeris.kernel.spi.crypto;
  * <p>Declared {@code value record} on the `preview` line (JEP 401, preview in JDK 28); the
  * distributed line compiles the same source as an identity {@code record}. Asserted by
  * {@code Class::isValue} in this carrier's ValhallaReadiness test.
- * At that point the {@code sentCloseNotify}/{@code receivedCloseNotify} booleans
- * and the status ordinal can be flattened to minimize header and pointer overhead.
+ * The {@code sentCloseNotify}/{@code receivedCloseNotify} booleans and the status ordinal are
+ * therefore flattenable, saving header and pointer overhead where a JVM chooses to do so — an
+ * opportunity, not a behaviour this contract assumes.
  *
  * <h2>Zero-Allocation Contract</h2>
  * <p>{@link #COMPLETE} and {@link #ERROR} are pre-allocated singletons.

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/crypto/TlsShutdownResult.java
@@ -25,7 +25,7 @@ package eu.exeris.kernel.spi.crypto;
  * @param receivedCloseNotify whether the peer's close-notify has been received
  * @since 0.5.0
  */
-public record TlsShutdownResult(Status status,
+public value record TlsShutdownResult(Status status,
                                 boolean sentCloseNotify,
                                 boolean receivedCloseNotify) {
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventEngineStats.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventEngineStats.java
@@ -30,7 +30,7 @@ package eu.exeris.kernel.spi.events;
  * @since 0.5.0
  * @see EventEngine#stats()
  */
-public record EventEngineStats(
+public value record EventEngineStats(
         long publishedTotal,
         long processedTotal,
         long failedTotal,

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventEngineStats.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventEngineStats.java
@@ -14,10 +14,11 @@ package eu.exeris.kernel.spi.events;
  * <h2>JFR-First</h2>
  * <p>This record is the data carrier for the {@code EventEngineStatsEvent} JFR event.
  * All fields are primitives — low-allocation snapshot (zero-allocation ready for
- * {@code value record} migration once JEP 401 is mainline).
+ * {@code value record} on the `preview` line).
  *
  * <h2>Valhalla Readiness</h2>
- * <p>All fields are primitives. No identity operations. Ready for {@code value record} migration.
+ * <p>All fields are primitives. No identity operations. Declared {@code value record} on the
+ * `preview` line (JEP 401); asserted by {@code Class::isValue} in its ValhallaReadiness test.
  *
  * @param publishedTotal    total number of events published since engine start
  * @param processedTotal    total number of events processed (dispatched to handlers)

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/memory/MemoryStats.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/memory/MemoryStats.java
@@ -14,8 +14,10 @@ import java.util.Objects;
  * Immutable snapshot of {@link MemoryAllocator} diagnostics.
  *
  * <h2>Valhalla Readiness</h2>
- * <p>This is a primitive-only {@code record} structured so it can be migrated to a
- * {@code value record} (JEP 401) once Valhalla is available in the target toolchain.
+ * <p>Primitive-only, and declared {@code value record} on the `preview` line (JEP 401, preview in
+ * JDK 28). The distributed line compiles the same source as an identity {@code record}; the
+ * modifier is the only difference, and it is asserted by {@code Class::isValue} in this carrier's
+ * ValhallaReadiness test rather than left to a one-time inspection.
  * Arrays of {@code MemoryStats} are therefore expected to benefit from header elimination
  * and heap flattening on future JVMs, but no such behaviour is assumed or required today.
  *

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/memory/MemoryStats.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/memory/MemoryStats.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * @see MemoryAllocator#stats()
  * @since 0.5.0
  */
-public record MemoryStats(
+public value record MemoryStats(
         long totalBytes,
         long allocatedBytes,
         long freeBytes,

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResultTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/crypto/TlsHandshakeResultTest.java
@@ -89,6 +89,21 @@ class TlsHandshakeResultTest {
     @DisplayName("Valhalla-readiness: value record semantics")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("TlsHandshakeResult is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(TlsHandshakeResult.class.isValue())
+                    .as("TlsHandshakeResult must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Equal records satisfy structural equals()")
         void structuralEquality() {

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/crypto/TlsShutdownResultTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/crypto/TlsShutdownResultTest.java
@@ -97,6 +97,21 @@ class TlsShutdownResultTest {
     @DisplayName("Valhalla-readiness")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("TlsShutdownResult is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(TlsShutdownResult.class.isValue())
+                    .as("TlsShutdownResult must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Equal partial results satisfy structural equals()")
         void equalPartials() {

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/events/EventEngineStatsTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/events/EventEngineStatsTest.java
@@ -143,6 +143,21 @@ class EventEngineStatsTest {
     @DisplayName("Valhalla-readiness — structural equals/hashCode")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("EventEngineStats is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(EventEngineStats.class.isValue())
+                    .as("EventEngineStats must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Two structurally equal EventEngineStats are equal")
         void structuralEquality() {

--- a/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/memory/MemoryStatsTest.java
+++ b/exeris-kernel-spi/src/test/java/eu/exeris/kernel/spi/memory/MemoryStatsTest.java
@@ -192,6 +192,21 @@ class MemoryStatsTest {
     @DisplayName("4. Valhalla-readiness — structural equals/hashCode, no identity ops")
     class ValhallaReadiness {
 
+        /**
+         * The {@code value} modifier is the only difference between this carrier on the two
+         * distribution lines, and nothing else in the suite would notice if it were lost to a merge
+         * or a reformat — the structural equality cases below pass for an identity record too. This
+         * asserts the modifier itself, so the bytecode check that first proved it is repeatable
+         * rather than a one-time inspection.
+         */
+        @Test
+        @DisplayName("MemoryStats is a value class on the preview line (JEP 401)")
+        void isValueClass() {
+            assertThat(MemoryStats.class.isValue())
+                    .as("MemoryStats must carry the value modifier; ACC_IDENTITY must be clear")
+                    .isTrue();
+        }
+
         @Test
         @DisplayName("Two structurally equal MemoryStats are equals()")
         void equalityByStructure() {

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,25 @@
             `mvn -P coverage -pl exeris-kernel-build-config verify`.
         -->
         <jacoco.skip>true</jacoco.skip>
+
+        <!--
+            PREVIEW LINE ONLY — the FOURTH tool this line outruns, and the one this document
+            previously singled out as unaffected ("Checkstyle stays ON — it is syntax-level").
+            JEP 401 value classes falsify that: Checkstyle's Java grammar does not know the `value`
+            modifier and fails to PARSE the file — "no viable alternative at input 'value'" — so it
+            reports a configuration error, not a style finding.
+
+            Note the difference from PMD / ArchUnit / JaCoCo, because it widens the rule rather than
+            repeating it: those three fail on the class-file MAJOR VERSION, so they break when this
+            line bumps its JDK. Checkstyle fails on preview SOURCE SYNTAX, so it breaks the moment
+            this line uses a preview language feature at all — which is what the line exists to do.
+            Tool lag reaches source-level tools too, not only bytecode readers.
+
+            The bar is not lowered: `main` runs Checkstyle over the same sources on JDK 25, where no
+            `value` modifier appears. RE-ENABLE when Checkstyle's grammar accepts JEP 401. Test it by
+            deleting this property and running `mvn -pl exeris-kernel-spi checkstyle:check`.
+        -->
+        <checkstyle.skip>true</checkstyle.skip>
         <coverage.argLine/>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -70,24 +70,6 @@
         -->
         <jacoco.skip>true</jacoco.skip>
 
-        <!--
-            PREVIEW LINE ONLY — the FOURTH tool this line outruns, and the one this document
-            previously singled out as unaffected ("Checkstyle stays ON — it is syntax-level").
-            JEP 401 value classes falsify that: Checkstyle's Java grammar does not know the `value`
-            modifier and fails to PARSE the file — "no viable alternative at input 'value'" — so it
-            reports a configuration error, not a style finding.
-
-            Note the difference from PMD / ArchUnit / JaCoCo, because it widens the rule rather than
-            repeating it: those three fail on the class-file MAJOR VERSION, so they break when this
-            line bumps its JDK. Checkstyle fails on preview SOURCE SYNTAX, so it breaks the moment
-            this line uses a preview language feature at all — which is what the line exists to do.
-            Tool lag reaches source-level tools too, not only bytecode readers.
-
-            The bar is not lowered: `main` runs Checkstyle over the same sources on JDK 25, where no
-            `value` modifier appears. RE-ENABLE when Checkstyle's grammar accepts JEP 401. Test it by
-            deleting this property and running `mvn -pl exeris-kernel-spi checkstyle:check`.
-        -->
-        <checkstyle.skip>true</checkstyle.skip>
         <coverage.argLine/>
 
         <!--


### PR DESCRIPTION
The reason this line exists beyond `StructuredTaskScope`. Six carriers are now `public value record`: `MemoryStats`, `TlsShutdownResult`, `TlsHandshakeResult`, `EventEngineStats` (SPI), `TransactionRetryPolicy`, `SyscallHandles` (Core).

**Chosen to test a claim, not to assert one.** Each already had a `ValhallaReadiness` test predating this work — the repository has been claiming its carriers are Valhalla-ready for milestones. Converting exactly those turns the claim into a measurement. **It held**: 4123 tests green, no behavioural test touched.

## Verified in the bytecode, with a control

Compiling proves only that the modifier parsed.

| class | `ACC_IDENTITY` (0x0020) |
|---|---|
| `MemoryStats`, `TlsShutdownResult`, `EventEngineStats` | **clear → value class** |
| `FlowSnapshot` (untouched control) | set → identity class |

## Three semantics change, all silently

Measured on JDK 28 **before** converting anything:

| | identity `record` | `value record` |
|:--|:--|:--|
| `a == b` for structurally equal | `false` | **`true`** — by value |
| `System.identityHashCode` differs | yes | **no** |
| `IdentityHashMap` with two equal instances | size 2 | **size 1** |

`synchronized` on a value throws `IdentityException` **at runtime, not compile time**.

So **the selection criterion mattered more than the conversion**: zero identity comparisons and zero identity-keyed lookups on the carrier anywhere in `*/src/main` — checked per carrier, all six at zero. A carrier used as an identity key would have broken silently with nothing in the toolchain to say so.

## A fourth gate falls — and it widens the rule

**Checkstyle**, which `PREVIEW-TRACK.md` explicitly singled out as *unaffected* ("syntax-level"). Its grammar does not know the `value` modifier and fails to **parse**: `no viable alternative at input 'value'` — a configuration error, not a style finding.

The distinction matters: PMD, ArchUnit and JaCoCo fail on the class-file **major version**, so they break when this line bumps its JDK. Checkstyle fails on preview **source syntax**, so it breaks the moment this line uses a preview *language* feature at all — which is what the line is for. **Tool lag reaches source-level tools too, not only bytecode readers.**

## Recovers an orphaned commit

`fed750ea` — "the tooling gap is structural, not a wait for a release" — was pushed to `chore/preview-track-baseline` **29 minutes after #303 merged it**. It went to a dead branch and never reached `preview`: the most load-bearing conclusion of that session, silently absent for hours. Cherry-picked here. *Verify by tree, not by having pushed.*

## No benchmark, and that is deliberate

Six carriers declared, **none measured**. That needs the harness and is post-cut, so this PR makes **no claim** about what value classes buy.

## Verification

```
mvn clean verify -B -e -P coverage -Dexeris.tck.transport.drainTimeoutSeconds=30   (JDK 28-ea+10)
  -> BUILD SUCCESS, 4123 tests
```
The delta sweep recorded in `PREVIEW-TRACK.md` comes back clean on this branch.