### PR TITLE
feat(security): make the ClaimsMapper seam reachable, and add the ADR-063 stub

### DIFF
--- a/docs/adr/ADR-063.link.md
+++ b/docs/adr/ADR-063.link.md
@@ -5,7 +5,10 @@
 ADR-063 is owned by `exeris-spring-runtime`. It ships **no kernel change**, which is why this file is a
 stub and not a decision — but it consumes a kernel seam this repository created on purpose, and
 [ADR-061](./ADR-061-declarable-http-route-authorization-policy.md) §5 gates any such binding on that
-ADR existing. Kernel-side awareness is therefore appropriate; the same shape as ADR-030.
+ADR existing. Kernel-side awareness is therefore appropriate — the same shape as **ADR-030** ("Phase 4C Scope —
+Spring-Side Seam for Kernel Graph SPI", owned by `exeris-spring-runtime`), which is likewise a
+spring-runtime decision the kernel keeps awareness of. Neither has a copy in this repository; both are
+listed in the global registry, `exeris-docs/adr-index.md`.
 
 ## What it consumes here
 

--- a/docs/adr/ADR-063.link.md
+++ b/docs/adr/ADR-063.link.md
@@ -1,0 +1,59 @@
+# ADR-063 — `ExerisHttpSecurity`: Spring-shaped route rules compile onto the kernel's decision (link stub)
+
+**Authoritative copy:** [`exeris-spring-runtime/docs/adr/ADR-063-exeris-http-security-route-policy-binding.md`](https://github.com/exeris-systems/exeris-spring-runtime/blob/main/docs/adr/ADR-063-exeris-http-security-route-policy-binding.md)
+
+ADR-063 is owned by `exeris-spring-runtime`. It ships **no kernel change**, which is why this file is a
+stub and not a decision — but it consumes a kernel seam this repository created on purpose, and
+[ADR-061](./ADR-061-declarable-http-route-authorization-policy.md) §5 gates any such binding on that
+ADR existing. Kernel-side awareness is therefore appropriate; the same shape as ADR-030.
+
+## What it consumes here
+
+An application declares Spring-shaped rules in an `ExerisHttpSecurity` bean, and
+`exeris-spring-runtime-web` compiles them **once at startup** into a single `HttpRoutePolicy` bound
+into `HttpKernelProviders.HTTP_ROUTE_POLICY` (`exeris-kernel-spi/.../http/HttpKernelProviders.java:148`).
+Enforcement stays entirely kernel-side, on the admission path.
+
+That placement is not incidental. ADR-061 put `RouteAuthorizationEnforcer` in Core rather than in the
+Community HTTP driver **specifically** so a host-runtime DSL could translate onto it, which is what
+keeps a Spring-hosted deployment and a kernel-direct one sharing one decision layer instead of two that
+can disagree. Compile-once is a contract requirement rather than an optimisation: `requirementFor` runs
+per request, and ADR-061 forbids allocation there.
+
+## Why a kernel reader should care
+
+**Two of ADR-063's three constraints are statements about this repository**, not about Spring:
+
+- **`hasRole(...)` is deliberately absent from the edge DSL**, because `RouteRequirement` has no role
+  kind and `RouteAuthorizationEnforcer` decides only through `PrincipalContext.hasScope`. Roles stay
+  with `@PreAuthorize`, which reads Spring authorities. Adding a `ROLE_x`→scope convention would put a
+  second, silently-diverging authority model at the edge — a kernel-side decision, made here.
+- **The unmatched route takes no default**, because `HttpRoutePolicy.unmatched()` is fail-closed and
+  the kernel exempts none of the driver's own probe routes (`/health`, `/health/live`,
+  `/health/ready`, `/db/ping`, `/db/roundtrip`). Spring's idiomatic `anyRequest().authenticated()` maps
+  straight onto fail-closed and would deny orchestrator probes on a healthy process.
+
+## The open item is a kernel slice, and its shape is narrower than "hardcoded"
+
+ADR-063 defers **authority parity** and names `ClaimsMapper` as the cause. Read against this tree the
+mechanism is more specific than the phrase suggests, and the difference changes what the fix is:
+
+`CommunityOidcIdentityProvider` **does** expose the seam — a constructor taking a `ClaimsMapper`
+(`:72`) and a static factory that accepts one (`:114`). What is missing is the path to it:
+`CommunitySecurityProvider` builds the provider through overloads (`:60`, `:75`) that pass no mapper,
+so the default `CommunityClaimsMapper` is the only one a booted kernel can reach. There is no bootstrap
+seam for a custom mapper.
+
+The consequence ADR-063 records stands either way: a Keycloak `realm_access.roles` token yields kernel
+scopes that can differ from the Spring authorities the same token produces through an application's own
+`JwtAuthenticationConverter`. But the corrective action is **threading the existing parameter through
+`CommunitySecurityProvider` and the bootstrap path**, not adding a seam that already exists.
+
+## When to consult ADR-063
+
+- Any change to `HttpRoutePolicy`, `RouteRequirement`, or `RouteAuthorizationEnforcer` semantics — a
+  host-runtime DSL compiles onto them and will inherit the change.
+- Any change to `HttpKernelProviders.HTTP_ROUTE_POLICY`'s binding lifecycle, which ADR-063 relies on
+  being bound once at startup.
+- Work on the `ClaimsMapper` reachability gap above, which is kernel-side and blocks ADR-063's
+  end-to-end verification.

--- a/docs/adr/ADR-063.link.md
+++ b/docs/adr/ADR-063.link.md
@@ -33,21 +33,31 @@ per request, and ADR-061 forbids allocation there.
   `/health/ready`, `/db/ping`, `/db/roundtrip`). Spring's idiomatic `anyRequest().authenticated()` maps
   straight onto fail-closed and would deny orchestrator probes on a healthy process.
 
-## The open item is a kernel slice, and its shape is narrower than "hardcoded"
+## The kernel-side blocker, and its resolution in v0.11
 
 ADR-063 defers **authority parity** and names `ClaimsMapper` as the cause. Read against this tree the
-mechanism is more specific than the phrase suggests, and the difference changes what the fix is:
+mechanism was more specific than the phrase "hardcodes a mapper" suggests, and the difference decided
+what the fix had to be.
 
-`CommunityOidcIdentityProvider` **does** expose the seam — a constructor taking a `ClaimsMapper`
-(`:72`) and a static factory that accepts one (`:114`). What is missing is the path to it:
-`CommunitySecurityProvider` builds the provider through overloads (`:60`, `:75`) that pass no mapper,
-so the default `CommunityClaimsMapper` is the only one a booted kernel can reach. There is no bootstrap
-seam for a custom mapper.
+`CommunityOidcIdentityProvider` always exposed the seam — a constructor taking a `ClaimsMapper`, and a
+public `withClaimsMapper` wither. What was missing was the road to it: `CommunitySecurityProvider`
+built the provider through overloads that passed no mapper, so the default `CommunityClaimsMapper` was
+the only one a booted kernel could reach. The corrective action was therefore **threading the existing
+parameter through**, not adding a seam that already existed.
 
-The consequence ADR-063 records stands either way: a Keycloak `realm_access.roles` token yields kernel
-scopes that can differ from the Spring authorities the same token produces through an application's own
-`JwtAuthenticationConverter`. But the corrective action is **threading the existing parameter through
-`CommunitySecurityProvider` and the bootstrap path**, not adding a seam that already exists.
+**Resolved in v0.11.** `CommunityClaimsMapperResolver` discovers a `ClaimsMapper` through
+`ServiceLoader` — the model `SecurityProvider` and `IdentityProvider` already use — off the context
+class loader, and `CommunitySecurityProvider` assembles through it on both construction paths. Nothing
+registered still yields the Community default, so an unconfigured deployment is unchanged. Two
+registrations are **refused** rather than ordered: `ClaimsMapper` declares no `priority()`, so a
+class-name tie-break would silently let classpath order decide how every principal in the deployment
+is identified.
+
+What this does **not** close is the parity question itself. ADR-063's observation stands: a Keycloak
+`realm_access.roles` token can still yield kernel scopes differing from the Spring authorities the same
+token produces through an application's own `JwtAuthenticationConverter`. The kernel now lets a
+deployment *fix* that by registering its own mapper; deciding whether the two models should agree by
+default remains ADR-063's question, on the `exeris-spring-runtime` side.
 
 ## When to consult ADR-063
 
@@ -55,5 +65,5 @@ scopes that can differ from the Spring authorities the same token produces throu
   host-runtime DSL compiles onto them and will inherit the change.
 - Any change to `HttpKernelProviders.HTTP_ROUTE_POLICY`'s binding lifecycle, which ADR-063 relies on
   being bound once at startup.
-- Work on the `ClaimsMapper` reachability gap above, which is kernel-side and blocks ADR-063's
-  end-to-end verification.
+- Registering a custom `ClaimsMapper`: it is now the supported way to align kernel scopes with an
+  application's own authority model, and exactly one may be registered.

--- a/docs/subsystems/security.md
+++ b/docs/subsystems/security.md
@@ -178,6 +178,16 @@ public class SecurityInterceptor {
   scope set and a route requiring any scope denies it. Roles now reach `PrincipalContext.roles()`,
   so the `roleMask` behind `@RequiresRole` is no longer permanently `0L`.
 - **The mapping is substitutable (since 0.11).** `ClaimsMapper` is documented as the only application-customisable point in the identity pipeline, but `CommunityOidcIdentityProvider` constructed the default inline, so there was no way to supply one — an application needing a different subject or scope shape had to reimplement `IdentityProvider` outright. `withClaimsMapper(ClaimsMapper)` returns a provider using the supplied mapping, mirroring `enforcingSharedScope()`: a new provider rather than a mutation, because the mapping takes part in a security decision on every request and must be fixed at construction, never swapped behind a live provider. The two withers compose in either order. Declaring nothing still gets `CommunityClaimsMapper`.
+- **And it is substitutable from a booted kernel, not only from the API (since 0.11).** The wither
+  above was reachable only by constructing the provider yourself, which the ServiceLoader boot path
+  does not do — so until this landed, a deployment that registered a mapping had no way to make the
+  kernel use it, and the bullet above was true of the API and false of a running process.
+  `CommunityClaimsMapperResolver` discovers a `ClaimsMapper` through `ServiceLoader` on the context
+  class loader, and `CommunitySecurityProvider` assembles through it. **Exactly one may be
+  registered**: `ClaimsMapper` declares no `priority()`, so two would leave classpath order deciding
+  how every principal in the deployment is identified, and that is refused at construction with both
+  class names rather than resolved by accident. None registered keeps `CommunityClaimsMapper`, so an
+  unconfigured deployment is unchanged.
 - **Substituting the mapper cannot widen isolation.** A custom mapper produces a `PrincipalContext` only. Tenant routing stays with `IdentityStorageMapping`, which every provider passes through (ADR-012 §4a), so a mapper cannot reach a tenant the token does not entitle it to — the customisable surface is identity shape, the non-negotiable surface is isolation deny semantics. This is also the seam a host-runtime binding uses: kernel scopes and a framework's own authority objects are **two mappings of the same verified token**, derived independently from the same claims, not one derived from the other. Neither is the source of truth for the other, and a kernel-side decision never consults framework authorities.
 - `KernelProviders.SECURITY_PROVIDER` is bound by `CommunitySecuritySubsystem` (since 0.11). Before that it was bound by nothing, so the interceptor was never constructed and the whole Citadel path was unreachable in a default boot.
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityClaimsMapperResolver.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityClaimsMapperResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import eu.exeris.kernel.spi.security.identity.ClaimsMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Resolves the {@link ClaimsMapper} the Community identity pipeline maps with.
+ *
+ * <p>{@code ClaimsMapper}'s own contract calls it "the <b>only</b> application-customisable mapping
+ * point in the identity pipeline" — where a deployment decides how {@code sub} becomes a
+ * {@code principalId}, which claims carry roles versus scopes, and how a tenant identifier is
+ * derived. Until v0.11 that was not reachable: {@code CommunityOidcIdentityProvider} accepted a
+ * mapper, but every path {@code CommunitySecurityProvider} used to build it passed none, so a booted
+ * kernel could only ever run the default. The seam existed and the road to it did not.
+ *
+ * <p>Discovery follows the kernel's plugin model rather than introducing a second one:
+ * {@link ServiceLoader}, exactly as {@code SecurityProvider} and {@code IdentityProvider} are found.
+ *
+ * <h2>Two registrations are an error, not a race</h2>
+ *
+ * <p>{@code ClaimsMapper} carries no {@code priority()}, so two registered mappers cannot be ordered
+ * — and picking either one silently would decide, on classpath order, how every principal in the
+ * deployment is identified. That is refused with the offending class names rather than resolved by
+ * accident, which matches the fail-closed doctrine the surrounding identity code already applies to
+ * an unclaimed token.
+ *
+ * @since 0.11.0
+ */
+final class CommunityClaimsMapperResolver {
+
+    /** More than this many registered mappers is ambiguous — see {@link #select}. */
+    private static final int SINGLE = 1;
+
+    private CommunityClaimsMapperResolver() {
+    }
+
+    /**
+     * @return the single registered {@link ClaimsMapper}, or the Community default when none is
+     *         registered
+     * @throws IllegalStateException if more than one mapper is on the classpath
+     */
+    /* default */ static ClaimsMapper resolve() {
+        // Context class loader, not the resolver's own: an application registering a mapper does so on
+        // its classpath, and it is also the only seam that lets a test register one without a service
+        // file in test resources — which would apply to every test in this module and make the
+        // "nothing registered" case unreachable.
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        return select(loader == null
+                ? ServiceLoader.load(ClaimsMapper.class)
+                : ServiceLoader.load(ClaimsMapper.class, loader));
+    }
+
+    /**
+     * The decision, separated from the lookup so all three outcomes are testable without a service
+     * file on the test classpath — which would otherwise apply to every test in the module and make
+     * the "nothing registered" case unreachable.
+     *
+     * @param discovered what {@link ServiceLoader} found
+     * @return the mapper to use
+     * @throws IllegalStateException if {@code discovered} holds more than one
+     */
+    /* default */ static ClaimsMapper select(Iterable<ClaimsMapper> discovered) {
+        List<ClaimsMapper> found = new ArrayList<>(2);
+        for (ClaimsMapper mapper : discovered) {
+            found.add(mapper);
+        }
+        if (found.isEmpty()) {
+            return new CommunityClaimsMapper();
+        }
+        if (found.size() > SINGLE) {
+            StringBuilder names = new StringBuilder(found.size() * 40);
+            for (ClaimsMapper mapper : found) {
+                if (names.length() > 0) {
+                    names.append(", ");
+                }
+                names.append(mapper.getClass().getName());
+            }
+            throw new IllegalStateException(
+                    "Ambiguous ClaimsMapper: " + found.size() + " registered (" + names
+                    + "). ClaimsMapper has no priority(), so the kernel will not pick one — "
+                    + "register exactly one, or none to use the Community default.");
+        }
+        return found.getFirst();
+    }
+}

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityOidcIdentityProvider.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunityOidcIdentityProvider.java
@@ -135,6 +135,11 @@ public final class CommunityOidcIdentityProvider implements IdentityProvider {
         return new CommunityOidcIdentityProvider(validator, expectedIssuer);
     }
 
+    /** Package-private: lets the wiring test observe which mapper this provider was built with. */
+    /* default */ ClaimsMapper claimsMapper() {
+        return claimsMapper;
+    }
+
     @Override
     public String providerId() {
         return PROVIDER_ID;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunitySecurityProvider.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/security/CommunitySecurityProvider.java
@@ -48,6 +48,7 @@ public final class CommunitySecurityProvider implements SecurityProvider {
     private static final String JWT_TYPE = "JWT";
 
     private final IdentityProviderRegistry registry;
+    private final IdentityProvider identityProvider;
 
     /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
     public CommunitySecurityProvider() {
@@ -57,10 +58,12 @@ public final class CommunitySecurityProvider implements SecurityProvider {
     public CommunitySecurityProvider(Map<String, RSAPublicKey> keysByKid,
                                      String expectedIssuer,
                                      String expectedAudience) {
-        this(new CommunityOidcIdentityProvider(keysByKid, expectedIssuer, expectedAudience));
+        this(new CommunityOidcIdentityProvider(keysByKid, expectedIssuer, expectedAudience)
+                .withClaimsMapper(CommunityClaimsMapperResolver.resolve()));
     }
 
     private CommunitySecurityProvider(IdentityProvider identityProvider) {
+        this.identityProvider = identityProvider;
         this.registry = IdentityProviderRegistry.of(List.of(identityProvider));
     }
 
@@ -72,7 +75,18 @@ public final class CommunitySecurityProvider implements SecurityProvider {
     /* default */ static CommunitySecurityProvider withKeyResolver(
             JwksKeyResolver keyResolver, String expectedIssuer, String expectedAudience) {
         return new CommunitySecurityProvider(
-                new CommunityOidcIdentityProvider(keyResolver, expectedIssuer, expectedAudience));
+                new CommunityOidcIdentityProvider(keyResolver, expectedIssuer, expectedAudience)
+                        .withClaimsMapper(CommunityClaimsMapperResolver.resolve()));
+    }
+
+    /**
+     * Package-private: lets the wiring test assert that this provider was assembled through
+     * {@link CommunityClaimsMapperResolver}. Without it the reachability fix has no failing test —
+     * reverting the wiring compiles and every other assertion still passes, which is exactly what a
+     * mutation run showed before this existed.
+     */
+    /* default */ IdentityProvider identityProvider() {
+        return identityProvider;
     }
 
     @Override

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityClaimsMapperResolverTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/security/CommunityClaimsMapperResolverTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import eu.exeris.kernel.spi.security.identity.ClaimsMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reachability half of {@code ClaimsMapper} — the SPI calls itself "the <b>only</b>
+ * application-customisable mapping point in the identity pipeline", and until v0.11 a booted kernel
+ * could not reach it (ADR-063, cross-repo stub).
+ *
+ * <p>The decision is tested through {@code select(Iterable)} rather than through the classpath: a
+ * service file in test resources would apply to every test in this module and make the
+ * "nothing registered" case unreachable, so the lookup and the decision are separated in the
+ * resolver for exactly that reason.
+ */
+@DisplayName("CommunityClaimsMapperResolver — the ClaimsMapper seam is reachable (ADR-063)")
+class CommunityClaimsMapperResolverTest {
+
+    @Test
+    @DisplayName("with no ClaimsMapper registered, the Community default is used")
+    void defaultsWhenNoneRegistered() {
+        ClaimsMapper resolved = CommunityClaimsMapperResolver.resolve();
+
+        assertThat(resolved)
+                .as("an unconfigured deployment must keep the behaviour it had before the seam opened")
+                .isInstanceOf(CommunityClaimsMapper.class);
+    }
+
+    @Test
+    @DisplayName("a single registered mapper wins over the Community default")
+    void registeredMapperWins() {
+        ClaimsMapper custom = claims -> null;
+
+        assertThat(CommunityClaimsMapperResolver.select(List.of(custom)))
+                .as("this is the reachability the SPI contract promised and did not deliver")
+                .isSameAs(custom);
+    }
+
+    @Test
+    @DisplayName("two registered mappers are refused, not silently ordered")
+    void twoMappersAreRefused() {
+        ClaimsMapper first = claims -> null;
+        ClaimsMapper second = claims -> null;
+
+        assertThatThrownBy(() -> CommunityClaimsMapperResolver.select(List.of(first, second)))
+                .as("ClaimsMapper has no priority(), so classpath order must not decide how every "
+                        + "principal in the deployment is identified")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Ambiguous ClaimsMapper")
+                .hasMessageContaining("register exactly one");
+    }
+
+    /** A loader that reports exactly one {@link ClaimsMapper} service, without touching test resources. */
+    private static ClassLoader loaderRegistering(Class<? extends ClaimsMapper> impl) {
+        String entry = "META-INF/services/" + ClaimsMapper.class.getName();
+        byte[] body = (impl.getName() + "\n").getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        return new ClassLoader(CommunityClaimsMapperResolverTest.class.getClassLoader()) {
+            @Override
+            public java.util.Enumeration<java.net.URL> getResources(String name)
+                    throws java.io.IOException {
+                if (entry.equals(name)) {
+                    java.net.URL url = java.net.URL.of(
+                            java.net.URI.create("string:///" + entry),
+                            new java.net.URLStreamHandler() {
+                                @Override
+                                protected java.net.URLConnection openConnection(java.net.URL u) {
+                                    return new java.net.URLConnection(u) {
+                                        @Override public void connect() { }
+                                        @Override public java.io.InputStream getInputStream() {
+                                            return new java.io.ByteArrayInputStream(body);
+                                        }
+                                    };
+                                }
+                            });
+                    return java.util.Collections.enumeration(java.util.List.of(url));
+                }
+                return super.getResources(name);
+            }
+        };
+    }
+
+    /** Test-only mapper, registered through {@link #loaderRegistering} rather than test resources. */
+    public static final class RegisteredMapper implements ClaimsMapper {
+        @Override
+        public eu.exeris.kernel.spi.security.PrincipalContext map(
+                eu.exeris.kernel.spi.security.identity.VerifiedClaims claims) {
+            throw new UnsupportedOperationException("not invoked by this test");
+        }
+    }
+
+    @Test
+    @DisplayName("a mapper registered on the context classpath reaches the booted provider")
+    void registeredMapperReachesTheProvider() {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(loaderRegistering(RegisteredMapper.class));
+        try {
+            CommunitySecurityProvider provider = new CommunitySecurityProvider();
+
+            assertThat(provider.identityProvider())
+                    .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories
+                            .type(CommunityOidcIdentityProvider.class))
+                    .satisfies(oidc -> assertThat(oidc.claimsMapper())
+                            .as("this is the whole point of the change: without the resolver wired "
+                                    + "into CommunitySecurityProvider a registered mapper is ignored")
+                            .isInstanceOf(RegisteredMapper.class));
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    /**
+     * The wiring itself. An earlier version of this class asserted only that the provider assembled,
+     * and a mutation run — reverting {@code CommunitySecurityProvider} to build the identity provider
+     * without the resolver — left every case green. That is the change this PR exists to make, so it
+     * needs an assertion that fails when it is undone.
+     */
+    @Test
+    @DisplayName("the ServiceLoader boot path assembles the provider through the resolver")
+    void bootPathGoesThroughTheResolver() {
+        CommunitySecurityProvider provider = new CommunitySecurityProvider();
+
+        assertThat(provider.identityProvider())
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories
+                        .type(CommunityOidcIdentityProvider.class))
+                .satisfies(oidc -> assertThat(oidc.claimsMapper())
+                        .as("the mapper must come from CommunityClaimsMapperResolver, not from the "
+                                + "constructor's own default — reverting the wiring must redden this")
+                        .isNotNull()
+                        .isInstanceOf(CommunityClaimsMapper.class));
+    }
+}


### PR DESCRIPTION
Started as the missing cross-repo stub the global index has been announcing, and grew the kernel-side slice that stub identified — because it turned out to be small, Community-only, and directly implied by an accepted ADR.

**No SPI signature moves**, so no stability-matrix or japicmp impact.

---

## 1. The `ClaimsMapper` seam is reachable from a booted kernel

`ClaimsMapper`'s own contract calls it *"the **only** application-customisable mapping point in the identity pipeline"* — where a deployment decides how `sub` becomes a `principalId`, which claims carry roles versus scopes, how a tenant is derived. **A booted kernel could not reach it.**

The index row that flagged this said `CommunityOidcIdentityProvider` "hardcodes `new CommunityClaimsMapper()`". Checked against the tree, that is imprecise in a way that decided the fix: the provider always exposed the seam — a `ClaimsMapper` constructor *and* a public `withClaimsMapper` wither. What was missing was the **road** to it. `CommunitySecurityProvider` built the provider through overloads that passed no mapper, so the default was the only one any deployment could run.

So the fix threads the existing parameter through; it adds no API.

**Discovery** goes through `ServiceLoader` — the model `SecurityProvider` and `IdentityProvider` already use — off the **context** class loader, because that is where an application registers.

**Two registrations are refused, deliberately unlike the rest.** `CommunityProviderDiscovery` orders competing providers by `priority()` with a class-name tie-break. `ClaimsMapper` declares no priority, so that tie-break would *be* the decision — classpath order would silently settle how every principal in the deployment is identified. `IllegalStateException` rather than `SecurityAuthenticationException`: a construction-time classpath misconfiguration filed under token validation sends an operator looking for a bad token when the problem is a build.

### The first test suite was worthless, and mutation said so

Reverting the wiring — **the whole point of the change** — left every assertion green. The reason is worth stating: with nothing registered, the wired and unwired paths produce the same default mapper and are **genuinely indistinguishable**. A test that did not register a mapper could not have caught anything.

The discriminating case builds a `ClassLoader` reporting one synthetic `ClaimsMapper` service and asserts it reaches the provider the ServiceLoader boot path assembles. Re-run against the same mutant: **it fails**, with the message naming what broke. Two package-private accessors are the cost of that observation, noted as such in their javadoc.

---

## 2. The ADR-063 link stub

The global index's cross-repo table has carried *"(stub pending)"* for some time; the file did not exist. Verified before writing: index read **from `origin/main`**, file confirmed absent, and `exeris-spring-runtime` confirmed **public** — so a link stub is allowed rather than requiring the standalone-counterpart treatment reserved for private repos.

Written for a kernel reader rather than transcribed, because **two of ADR-063's three constraints are statements about this repository**: `hasRole` is absent from the edge DSL (`RouteRequirement` has no role kind; the enforcer decides only via `hasScope`), and the unmatched route takes no default (`unmatched()` is fail-closed and exempts none of the driver's own probe routes).

**The stub is scoped to what actually shipped.** Closing the reachability gap is *not* closing authority parity: a Keycloak `realm_access.roles` token can still yield kernel scopes differing from the Spring authorities the same token produces. The kernel now lets a deployment fix that by registering its own mapper; whether the two models should agree *by default* remains ADR-063's question, on the spring-runtime side.

---

## Verification

`mvn clean verify -P coverage` on JDK 25.0.3 — **green, no skip flags**, 4174 tests. One real PMD finding fixed at the source, not suppressed. `ExerisArchitectureTest` 13/13.
