### PR TITLE
ci(preview): publish SNAPSHOTs from this line, and record the release-coordinate hazard

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -156,7 +156,7 @@ jobs:
       #     SNAPSHOT artifact so downstream consumers (e.g. exeris-spring-runtime) always
       #     pull the latest RC trunk HEAD.
       #
-      # THE PREVIEW LINE PUBLISHES TOO (since v0.11) — but read the coordinate note below before
+      # THE PREVIEW LINE PUBLISHES TOO (since v0.11) — but read the rest of this comment before
       # changing its version. Maven's ComparableVersion sorts an UNKNOWN qualifier AFTER the release:
       # measured, `0.11.0-preview` > `0.11.0` and > `0.10.2`. A release version carrying `-preview`
       # under the same groupId:artifactId would therefore win a `[0.11.0,)` range and `RELEASE`

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -155,8 +155,16 @@ jobs:
       #   * SNAPSHOTs are MUTABLE — every push to an RC trunk overwrites the previous
       #     SNAPSHOT artifact so downstream consumers (e.g. exeris-spring-runtime) always
       #     pull the latest RC trunk HEAD.
+      #
+      # THE PREVIEW LINE PUBLISHES TOO (since v0.11) — but read the coordinate note below before
+      # changing its version. Maven's ComparableVersion sorts an UNKNOWN qualifier AFTER the release:
+      # measured, `0.11.0-preview` > `0.11.0` and > `0.10.2`. A release version carrying `-preview`
+      # under the same groupId:artifactId would therefore win a `[0.11.0,)` range and `RELEASE`
+      # metadata resolution — capturing exactly the consumers who wanted the preview-clean artifact.
+      # This line currently publishes only `-SNAPSHOT`s, where consumption is explicit anyway; the
+      # coordinates for a preview RELEASE are an open decision recorded in PREVIEW-TRACK.md.
       - name: Publish to GitHub Packages
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/development/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/development/'))
         continue-on-error: true
         run: |
           mvn deploy -B -e \

--- a/PREVIEW-TRACK.md
+++ b/PREVIEW-TRACK.md
@@ -155,8 +155,25 @@ missed.
 - **A benchmark for the value carriers.** Six are declared (below) and none is measured; the numbers
   need the benchmark harness and are deliberately post-cut. This document makes **no claim** about
   what value classes buy until one exists.
-- Decide whether this line publishes `0.11.0-preview-SNAPSHOT` to GitHub Packages. The workflow's
-  publish step is currently gated on `main` and `development/*`, so today it does not.
+- **Decide the coordinates for a preview RELEASE, before the cut.** SNAPSHOT publishing is on as of
+  v0.11 (the workflow's publish step now includes this branch), and for SNAPSHOTs the risk below is
+  tolerable because consuming one is always an explicit act. A *release* version is different, and
+  the reason is measured rather than assumed:
+
+  ```
+  ComparableVersion:  0.11.0-preview  >  0.11.0     and  >  0.10.2
+  ```
+
+  Maven sorts an **unknown qualifier after the release**, so `0.11.0-preview` published under the
+  same `groupId:artifactId` would win a `[0.11.0,)` range and `RELEASE` metadata resolution — it
+  would capture precisely the consumers who came for the preview-clean artifact. Publishing it that
+  way is worse than not publishing it at all.
+
+  Three ways out, none yet chosen: a distinct **groupId** (`eu.exeris.preview:*`, so opting in is an
+  explicit coordinate change and the version can stay plain `0.11.0`); a distinct **artifactId**
+  suffix on all eleven modules; or a qualifier Maven sorts *before* the release, which means one of
+  its known set (`alpha`/`beta`/`milestone`/`rc`) and therefore a name that misdescribes what this
+  line is.
 
 ## JEP 401: six carriers are value classes here
 


### PR DESCRIPTION
The publish step was gated on `main` and `development/*` only, so this line built artifacts nobody could consume. It now includes `preview`.

## Scoped to SNAPSHOTs deliberately — the release case is a trap

Measured with Maven's own `ComparableVersion`, not assumed:

```
0.11.0-preview  >  0.11.0
0.11.0-preview  >  0.10.2
```

**Maven sorts an unknown qualifier AFTER the release.** So a published `0.11.0-preview` under the same `groupId:artifactId` would win a `[0.11.0,)` range and `RELEASE` metadata resolution — it would capture **exactly the consumers who came for the preview-clean artifact**, which is the audience this entire milestone exists to serve.

Publishing it that way is worse than not publishing at all.

SNAPSHOTs do not carry that risk in practice: consuming one is always an explicit act, and the two lines' SNAPSHOT versions already differ (`0.11.0-preview-SNAPSHOT` vs `0.11.0-SNAPSHOT`).

## An open decision, surfaced rather than settled

`PREVIEW-TRACK.md` now carries the measurement and three ways out, none chosen here:

- a distinct **groupId** (`eu.exeris.preview:*`) — opting in becomes an explicit coordinate change and the version can stay plain `0.11.0`;
- an **artifactId** suffix on all eleven modules;
- a qualifier from Maven's *known* set (`alpha`/`beta`/`milestone`/`rc`), which sorts before the release but names this line something it is not.

This is a decision owed **before the cut**, not a detail to settle inside a release PR — which is why it is recorded as an open item rather than resolved by picking one here.

## Verification

Workflow YAML parses. No build change: the step's body and every other condition are untouched.