### PR TITLE
ci(actions): harden and modernise the GitHub Actions surface

### DIFF
--- a/.claude/agents/exeris-implementer.md
+++ b/.claude/agents/exeris-implementer.md
@@ -12,7 +12,7 @@ Delivery agent for writing and refactoring code without re-litigating architectu
 
 ## Primary Responsibilities
 - Implement requested behavior with minimal, targeted changes.
-- Apply Java 26+ runtime idioms where relevant (`ScopedValue`, `StructuredTaskScope`, FFM, immutable carriers).
+- Apply current runtime idioms where relevant (`ScopedValue`, FFM, immutable carriers, and structured concurrency through `core.concurrent.StructuredScope` — `StructuredTaskScope` is preview and belongs only on the `preview` branch).
 - Preserve The Wall and existing module boundaries.
 - Surface risks early when requested change conflicts with architecture constraints.
 

--- a/.claude/commands/community-implementer.md
+++ b/.claude/commands/community-implementer.md
@@ -8,7 +8,7 @@ Implement this as an Exeris Community/Open-Core change.
 Constraints:
 - Do not re-litigate architecture unless a direct violation is detected.
 - Preserve existing module boundaries.
-- Prefer explicit construction, ScopedValue, StructuredTaskScope, immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
+- Prefer explicit construction, ScopedValue, structured concurrency (`core.concurrent.StructuredScope` on the preview-clean default line; `StructuredTaskScope` only on the `preview` branch), immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
 - Avoid framework DI, ThreadLocal for runtime context, and unstructured orchestration in runtime paths.
 - Keep changes minimal and targeted.
 - If the change affects SPI-observable behavior, explicitly mark that TCK review is required.

--- a/.claude/skills/exeris-performance-contract/SKILL.md
+++ b/.claude/skills/exeris-performance-contract/SKILL.md
@@ -57,7 +57,7 @@ This skill validates that changes respect:
 7. **Modern replacement guidance (mandatory recommendations)**
    For every violation, suggest nearest compliant replacement:
    - `ScopedValue` instead of `ThreadLocal`
-   - `StructuredTaskScope` instead of unstructured async primitives
+   - `core.concurrent.StructuredScope` instead of unstructured async primitives (`StructuredTaskScope` only on the `preview` branch — it is a preview API)
    - `MemorySegment` and zero-copy APIs instead of legacy buffers/IO
    - `LoanedBuffer` for managed off-heap ownership
    - `VarHandle` for lock-free state transitions
@@ -89,7 +89,7 @@ Use this structure in PR feedback:
 4. **JFR findings** (present/missing lifecycle events)
 5. **Verdict** (`APPROVE` / `CONDITIONAL` / `REJECT`)
 6. **Required actions** (minimal root-cause fixes)
-7. **Compliant alternatives** (ScopedValue, StructuredTaskScope, MemorySegment, LoanedBuffer, VarHandle, sentinel/enum errors)
+7. **Compliant alternatives** (ScopedValue, StructuredScope, MemorySegment, LoanedBuffer, VarHandle, sentinel/enum errors)
 
 ## Non-Negotiable Rules
 - No banned APIs in runtime hot paths.

--- a/.github/agents/exeris-implementer.agent.md
+++ b/.github/agents/exeris-implementer.agent.md
@@ -14,7 +14,7 @@ Delivery agent for writing and refactoring code without re-litigating architectu
 
 ## Primary Responsibilities
 - Implement requested behavior with minimal, targeted changes.
-- Apply Java 26+ runtime idioms where relevant (`ScopedValue`, `StructuredTaskScope`, FFM, immutable carriers).
+- Apply current runtime idioms where relevant (`ScopedValue`, FFM, immutable carriers, and structured concurrency through `core.concurrent.StructuredScope` — `StructuredTaskScope` is preview and belongs only on the `preview` branch).
 - Preserve The Wall and existing module boundaries.
 - Surface risks early when requested change conflicts with architecture constraints.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Current repository realities to respect:
 - No unstructured concurrency in runtime orchestration paths where structured scope is expected.
 
 ### B) Strong Defaults (enforce by default, allow justified exceptions)
-- Prefer `StructuredTaskScope` for orchestration concurrency.
+- Prefer structured orchestration concurrency. On the preview-clean default line that is the kernel's own `core.concurrent.StructuredScope` (fork/join/cancel over virtual threads); `StructuredTaskScope` is a preview API and belongs only on the `preview` branch (ADR-066).
 - Prefer `MemorySegment`, `LoanedBuffer`, and `VarHandle` on runtime hot paths.
 - Prefer JFR-first instrumentation for subsystem lifecycle/failure points (bootstrap, allocation failure, bind/start, state transitions).
 - Prefer expanding TCK coverage when observable SPI behavior changes.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+# Actions are pinned by commit SHA (OpenSSF Scorecard "Pinned-Dependencies"), which makes them
+# immune to a moved tag but also invisible to a human reading the file — nothing about
+# `@3d3c42e5…` says it is three majors behind. Dependabot is what closes that: it rewrites the SHA
+# and the trailing `# vX.Y.Z` comment together, so the pin stays current without anyone auditing
+# eleven refs by hand. Without it, SHA-pinning trades a supply-chain risk for a staleness one.
+#
+# Only the actions ecosystem is enabled. Maven dependency bumps land through the milestone flow
+# with the full reactor and the tagged gates behind them; opening them as individual PRs would put
+# version changes on a path that does not run those gates.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(actions)"
+    labels:
+      - dependencies
+    groups:
+      # One PR for the routine github/actions bumps rather than five. Third-party actions
+      # (Sonar, Pages, claude-code-action) stay ungrouped: those are the ones worth reading
+      # a changelog for before merging.
+      github-owned:
+        patterns:
+          - "actions/*"
+          - "github/*"

--- a/.github/prompts/community-implementer.prompt.md
+++ b/.github/prompts/community-implementer.prompt.md
@@ -9,7 +9,7 @@ Implement this as an Exeris Community/Open-Core change.
 Constraints:
 - Do not re-litigate architecture unless a direct violation is detected.
 - Preserve existing module boundaries.
-- Prefer explicit construction, ScopedValue, StructuredTaskScope, immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
+- Prefer explicit construction, ScopedValue, structured concurrency (`core.concurrent.StructuredScope` on the preview-clean default line; `StructuredTaskScope` only on the `preview` branch), immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
 - Avoid framework DI, ThreadLocal for runtime context, and unstructured orchestration in runtime paths.
 - Keep changes minimal and targeted.
 - If the change affects SPI-observable behavior, explicitly mark that TCK review is required.

--- a/.github/prompts/exeris-community-prompt-pack.md
+++ b/.github/prompts/exeris-community-prompt-pack.md
@@ -25,7 +25,7 @@ Implement this as an Exeris Community/Open-Core change.
 Constraints:
 - Do not re-litigate architecture unless a direct violation is detected.
 - Preserve existing module boundaries.
-- Prefer explicit construction, ScopedValue, StructuredTaskScope, immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
+- Prefer explicit construction, ScopedValue, structured concurrency (`core.concurrent.StructuredScope` on the preview-clean default line; `StructuredTaskScope` only on the `preview` branch), immutable carriers, and zero-copy/off-heap-safe patterns where relevant.
 - Avoid framework DI, ThreadLocal for runtime context, and unstructured orchestration in runtime paths.
 - Keep changes minimal and targeted.
 - If the change affects SPI-observable behavior, explicitly mark that TCK review is required.

--- a/.github/skills/exeris-java26-panama-loom/SKILL.md
+++ b/.github/skills/exeris-java26-panama-loom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exeris-java26-panama-loom
-description: 'Java 26+ runtime PR review for Exeris Kernel. Use for every PR that touches concurrency, memory, native interop, and data carriers to enforce ScopedValue, StructuredTaskScope, Panama FFM, Valhalla readiness, immutable/early construction, and removal of legacy framework idioms.'
+description: 'Runtime PR review for Exeris Kernel. Use for every PR that touches concurrency, memory, native interop, and data carriers to enforce ScopedValue, structured concurrency (track-dependent), Panama FFM, Valhalla readiness, immutable/early construction, and removal of legacy framework idioms.'
 argument-hint: 'PR scope, changed files, and intended Java/runtime impact'
 user-invocable: true
 disable-model-invocation: false
@@ -38,7 +38,7 @@ This skill validates changes against:
    - Flag deep context parameter threading when `ScopedValue` is the cleaner runtime-aligned option.
 
 3. **Structured concurrency discipline**
-   - Verify fan-out/fan-in concurrency uses `StructuredTaskScope`.
+   - Verify fan-out/fan-in concurrency is structured — `core.concurrent.StructuredScope` on the default line, `StructuredTaskScope` only on the `preview` branch.
    - Flag unstructured async orchestration and thread-pool-centric patterns in runtime paths.
 
 4. **Panama FFM correctness and suitability**
@@ -70,7 +70,7 @@ This skill validates changes against:
 ## Completion Criteria
 A review is complete only if all are true:
 - Context propagation model was assessed (`ScopedValue` suitability).
-- Concurrency model was assessed (`StructuredTaskScope` suitability).
+- Concurrency model was assessed (structured-scope suitability).
 - Native interop and memory handling were assessed for FFM direction (`MemorySegment`, `Linker`, `SymbolLookup`, `FunctionDescriptor`) where relevant.
 - Carrier design was assessed for value-oriented/flattenable readiness where logical.
 - Construction and mutability patterns were assessed for early/immutable guarantees.
@@ -81,7 +81,7 @@ A review is complete only if all are true:
 Use this structure in PR feedback:
 1. **Scope analyzed** (modules/subsystems/hot paths)
 2. **Context findings** (`ScopedValue`)
-3. **Concurrency findings** (`StructuredTaskScope`)
+3. **Concurrency findings** (structured scope)
 4. **FFM findings** (`MemorySegment`, `Linker`, `SymbolLookup`, `FunctionDescriptor`)
 5. **Carrier and construction findings** (Valhalla readiness, immutability, early construction)
 6. **Legacy idiom findings**
@@ -90,7 +90,7 @@ Use this structure in PR feedback:
 
 ## Non-Negotiable Rules
 - Prefer `ScopedValue` for scoped runtime context.
-- Prefer `StructuredTaskScope` for orchestration concurrency.
+- Prefer structured orchestration concurrency. On the preview-clean default line that is the kernel's own `core.concurrent.StructuredScope` (fork/join/cancel over virtual threads); `StructuredTaskScope` is a preview API and belongs only on the `preview` branch (ADR-066).
 - Prefer FFM-first native interop where native boundaries exist.
 - Keep carrier/state models immutable and value-oriented where logical.
 - Do not reintroduce legacy framework idioms in Exeris runtime paths.

--- a/.github/skills/exeris-performance-contract/SKILL.md
+++ b/.github/skills/exeris-performance-contract/SKILL.md
@@ -60,7 +60,7 @@ This skill validates that changes respect:
 7. **Modern replacement guidance (mandatory recommendations)**
    For every violation, suggest nearest compliant replacement:
    - `ScopedValue` instead of `ThreadLocal`
-   - `StructuredTaskScope` instead of unstructured async primitives
+   - `core.concurrent.StructuredScope` instead of unstructured async primitives (`StructuredTaskScope` only on the `preview` branch — it is a preview API)
    - `MemorySegment` and zero-copy APIs instead of legacy buffers/IO
    - `LoanedBuffer` for managed off-heap ownership
    - `VarHandle` for lock-free state transitions
@@ -92,7 +92,7 @@ Use this structure in PR feedback:
 4. **JFR findings** (present/missing lifecycle events)
 5. **Verdict** (`APPROVE` / `CONDITIONAL` / `REJECT`)
 6. **Required actions** (minimal root-cause fixes)
-7. **Compliant alternatives** (ScopedValue, StructuredTaskScope, MemorySegment, LoanedBuffer, VarHandle, sentinel/enum errors)
+7. **Compliant alternatives** (ScopedValue, StructuredScope, MemorySegment, LoanedBuffer, VarHandle, sentinel/enum errors)
 
 ## Non-Negotiable Rules
 - No banned APIs in runtime hot paths.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,8 +45,18 @@ jobs:
             Review this PR. The repo is `exeris-kernel` — the open-core runtime
             kernel: an SPI tier (`exeris-kernel-spi`), a driver-agnostic Core
             (`exeris-kernel-core`), Community drivers (`exeris-kernel-community*`),
-            and a contract TCK (`exeris-kernel-tck`). Java 26 (GA) with preview
-            features enabled (`--enable-preview`), built with Maven.
+            and a contract TCK (`exeris-kernel-tck`). Built with Maven.
+
+            **Which distribution track a PR is on decides what is correct**
+            (ADR-066). The default line — `main` and `development/*` — baselines
+            on **JDK 25 LTS** and its main sources are **preview-clean**: no
+            `--enable-preview` on distributed code, and therefore no
+            `StructuredTaskScope`. Test and TCK fixtures are exempt (not
+            distributed) and still compile with it. The `preview` branch is the
+            opposite: newest JDK, `--enable-preview`, `StructuredTaskScope`, JEP
+            401 value classes. Check the base branch before applying any rule
+            below that mentions preview features — the same code can be correct
+            on one track and disqualifying on the other.
 
             Source-of-truth docs (in precedence order):
             1. `docs/modules/*.md`, `docs/subsystems/*.md` — placement + behavior
@@ -73,15 +83,24 @@ jobs:
                `ExecutorService`/`Executors`/`CompletableFuture` (replacing structured
                orchestration), `java.io.*`/`Socket`/`ByteBuffer` (in zero-copy paths),
                `sun.misc.Unsafe`, checked exceptions on hot state-machine paths.
-            4. **Java 26 runtime idioms.** `ScopedValue` (NOT `ThreadLocal`) for
-               context propagation; `StructuredTaskScope` for orchestration concurrency;
-               Panama FFM for native interop; carriers Valhalla-ready (records /
-               immutable final, no identity-sensitive ops).
+            4. **Runtime idioms.** `ScopedValue` (NOT `ThreadLocal`) for context
+               propagation; Panama FFM for native interop; carriers Valhalla-ready
+               (records / immutable final, no identity-sensitive ops). For
+               orchestration concurrency the mechanism is track-dependent: on the
+               default line it is `core.concurrent.StructuredScope` (the kernel's own
+               GA fork/join/cancel layer over virtual threads) — flagging its use as
+               "should be `StructuredTaskScope`" is WRONG there and reverses ADR-066.
+               Note also that two sites deliberately run in-thread rather than fork
+               (`InMemoryEventBus.publishAndAwait`, `SubsystemOrchestrator` phase
+               start): their contracts require `ScopedValue` bindings an application
+               owns and the kernel cannot enumerate, so a `Carrier` cannot carry them.
+               On the `preview` branch, `StructuredTaskScope` is correct.
             5. **JFR-first telemetry.** Lifecycle/failure points (bootstrap, allocation
                failure, bind/start, state transitions) emit JFR events. Emission is
                lightweight, payloads are secret-safe (NO key/token bytes, no raw args),
                and commits are SINGLE-PHASE — never begin()->blocking-op->commit() on a
-               virtual thread (carrier-bound `EventWriter` → SIGSEGV on JDK 26).
+               virtual thread (carrier-bound `EventWriter`; first observed as a
+               SIGSEGV on JDK 26, but the hazard is the straddle, not the release).
             6. **TCK-first discipline.** Any change to observable SPI behavior or a
                provider binding needs executable `Abstract*Tck` coverage plus a
                concrete binding (Community in-repo; Enterprise obligation declared). A

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,16 +27,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,12 @@ name: 'Dependency Review (Supply Chain)'
 
 on:
   pull_request:
-    branches: [ "main" ]
+    # `development/**` as well as main, deliberately. Scanning only PRs into main meant a
+    # dependency or action introduced during a milestone stayed unscanned until the release cut,
+    # where it surfaces as a red gate on an 87-commit PR that nobody wants to reopen — which is
+    # exactly how the vulnerable `sonarqube-scan-action` pin reached the v0.11 cut. The scan
+    # belongs where the dependency actually enters the tree.
+    branches: [ "main", "development/**" ]
 
 permissions:
   contents: read
@@ -21,6 +26,12 @@ jobs:
         with:
           comment-summary-in-pr: always
           fail-on-severity: moderate
+          # `deny-licenses` is deprecated upstream (actions/dependency-review-action#997) and slated
+          # for removal in the action's 5.x; the maintainers' argument is that a deny list is
+          # structurally incomplete — it only catches the copyleft/commercial licences someone
+          # thought to enumerate. It still functions on 4.x, so it stays for now. Migrating to
+          # `allow-licenses` means enumerating every licence in the transitive Maven graph first,
+          # which is its own piece of work and not something to do inside a release cut.
           deny-licenses: >
             GPL-1.0-only, GPL-1.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later,
             LGPL-2.0-only, LGPL-2.0-or-later, LGPL-2.1-only, LGPL-2.1-or-later, LGPL-3.0-only, LGPL-3.0-or-later,
@@ -28,6 +39,19 @@ jobs:
             SSPL-1.0,
             EPL-1.0, EPL-2.0,
             MPL-2.0
+          # The `eu.exeris/*` entries are this repository's own reactor modules, which the reactor
+          # POMs declare as dependencies of each other. They report an unknown licence because the
+          # dependency graph reads each module POM on its own and does not resolve the parent that
+          # carries the `<licenses>` block — so the warning is about POM inheritance, not about an
+          # unlicensed artifact. The licence is Apache-2.0 with Commons Clause, declared once in
+          # `exeris-kernel-parent/pom.xml` and shipped as LICENSE-COMMUNITY.
           allow-dependencies-licenses: >
             pkg:maven/com.puppycrawl.tools/checkstyle,
-            pkg:maven/org.jacoco/jacoco-maven-plugin
+            pkg:maven/org.jacoco/jacoco-maven-plugin,
+            pkg:maven/eu.exeris/exeris-kernel-bom,
+            pkg:maven/eu.exeris/exeris-kernel-build-config,
+            pkg:maven/eu.exeris/exeris-kernel-spi,
+            pkg:maven/eu.exeris/exeris-kernel-core,
+            pkg:maven/eu.exeris/exeris-kernel-community,
+            pkg:maven/eu.exeris/exeris-kernel-community-kafka,
+            pkg:maven/eu.exeris/exeris-kernel-community-testkit

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,19 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: always
           fail-on-severity: moderate
-          # `deny-licenses` is deprecated upstream (actions/dependency-review-action#997) and slated
-          # for removal in the action's 5.x; the maintainers' argument is that a deny list is
-          # structurally incomplete — it only catches the copyleft/commercial licences someone
-          # thought to enumerate. It still functions on 4.x, so it stays for now. Migrating to
-          # `allow-licenses` means enumerating every licence in the transitive Maven graph first,
-          # which is its own piece of work and not something to do inside a release cut.
+          # `deny-licenses` is deprecated upstream (actions/dependency-review-action#997): the
+          # maintainers' argument is that a deny list is structurally incomplete — it only catches
+          # the copyleft/commercial licences someone thought to enumerate. The removal was announced
+          # for 5.x, but v5.0.0 turned out to be a node24 runtime bump that still declares the input,
+          # so it keeps working here (checked against that release's action.yml, not the issue).
+          # Migrating to `allow-licenses` means first enumerating every licence in the transitive
+          # Maven graph, which is its own piece of work and not a release-cut task.
           deny-licenses: >
             GPL-1.0-only, GPL-1.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later,
             LGPL-2.0-only, LGPL-2.0-or-later, LGPL-2.1-only, LGPL-2.1-or-later, LGPL-3.0-only, LGPL-3.0-or-later,

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -46,7 +46,16 @@ jobs:
           # carries the `<licenses>` block — so the warning is about POM inheritance, not about an
           # unlicensed artifact. The licence is Apache-2.0 with Commons Clause, declared once in
           # `exeris-kernel-parent/pom.xml` and shipped as LICENSE-COMMUNITY.
+          #
+          # `sonarqube-scan-action` is LGPL-3.0, which the deny list above rejects — correctly for a
+          # dependency, wrongly for this one. The deny list exists to keep copyleft out of the
+          # DISTRIBUTED kernel; a GitHub Action is build infrastructure that runs on a runner,
+          # links against nothing we ship, and is never redistributed. (It only became visible once
+          # the SHA pin made the licence resolvable at all — under the `@v5` tag it reported as
+          # unknown and slipped through as a warning.) Excluding the whole action rather than the
+          # pin, so a Dependabot bump does not re-trip the gate.
           allow-dependencies-licenses: >
+            pkg:githubactions/SonarSource/sonarqube-scan-action,
             pkg:maven/com.puppycrawl.tools/checkstyle,
             pkg:maven/org.jacoco/jacoco-maven-plugin,
             pkg:maven/eu.exeris/exeris-kernel-bom,

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -143,9 +143,15 @@ jobs:
         #
         # REMOVE once a CI-based analysis has been confirmed green; leaving it in permanently would
         # let the analysis rot silently.
+        #
+        # Pinned by commit SHA, not by tag. Two high-severity advisories (GHSA-f79p-9c5r-xg88,
+        # GHSA-5xq9-5g24-4g6f) cover every 4.x/5.x release of this action, so `@v5` resolved to a
+        # vulnerable revision and failed the Dependency Review gate on PRs into main; both are
+        # cleared from 6.0.0 onward. The SHA below is tag v8.2.1. A moving tag is also mutable —
+        # SHA-pinning is what makes the reviewed revision the one that actually runs.
         continue-on-error: true
         if: ${{ env.SONAR_TOKEN != '' }}
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
 
       - name: Upload TCK JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
@@ -892,7 +898,7 @@ jobs:
           path: build/jmh-results/core/
 
       - name: Publish latest to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/jfr-report/
@@ -900,7 +906,7 @@ jobs:
           keep_files: true
 
       - name: Publish run snapshot to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/jfr-report/
@@ -909,7 +915,7 @@ jobs:
 
       - name: Publish JMH results latest to GitHub Pages
         continue-on-error: true
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/jmh-results/
@@ -918,7 +924,7 @@ jobs:
 
       - name: Publish JMH results snapshot to GitHub Pages
         continue-on-error: true
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/jmh-results/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Sonar needs full history to attribute new code and blame; a shallow clone silently
           # degrades the new-code period into "everything".
@@ -57,7 +57,7 @@ jobs:
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -70,7 +70,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload TCK JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-tck-${{ github.run_number }}
           path: |
@@ -198,7 +198,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history + tags: the gate diffs the SPI at the last released tag against this
           # revision, and a shallow clone has neither.
@@ -206,7 +206,7 @@ jobs:
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -219,7 +219,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -251,7 +251,7 @@ jobs:
 
       - name: Publish SPI diff report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spi-api-diff
           path: target/spi-api-diff/
@@ -266,11 +266,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -283,7 +283,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -301,7 +301,7 @@ jobs:
 
       - name: Upload persistence JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-persistence-${{ github.run_number }}
           path: exeris-kernel-community/target/*.jfr
@@ -336,11 +336,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -353,7 +353,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -371,7 +371,7 @@ jobs:
 
       - name: Upload kafka JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-kafka-${{ github.run_number }}
           path: exeris-kernel-community-kafka/target/*.jfr
@@ -398,11 +398,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -415,7 +415,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -433,7 +433,7 @@ jobs:
 
       - name: Upload continuity JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-continuity-${{ github.run_number }}
           path: |
@@ -464,11 +464,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -481,7 +481,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -516,7 +516,7 @@ jobs:
 
       - name: Upload transport stress JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-transport-stress-${{ github.run_number }}
           path: exeris-kernel-community/target/*.jfr
@@ -560,11 +560,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -577,7 +577,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -587,7 +587,7 @@ jobs:
 
       - name: Cache OpenSSL ${{ matrix.openssl_version }} build
         id: openssl-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.OPENSSL_PREFIX }}
           # Key embeds the EXACT version + a hash of the literal configure flags string.
@@ -688,7 +688,7 @@ jobs:
 
       - name: Upload OpenSSL ${{ matrix.openssl_version }} TLS JFR recordings
         if: always() && (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-tls-openssl-${{ matrix.openssl_version }}-${{ github.run_number }}
           path: exeris-kernel-*/target/*.jfr
@@ -706,11 +706,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -723,7 +723,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -753,14 +753,14 @@ jobs:
             verify -DskipTests -B -e
 
       - name: Upload Community benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmh-community-results
           path: exeris-kernel-community/target/jmh-results.json
           if-no-files-found: warn
 
       - name: Upload Core benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmh-core-results
           path: exeris-kernel-core/target/jmh-results.json
@@ -768,7 +768,7 @@ jobs:
 
       - name: Upload Community benchmark JFR
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-benchmarks-community-${{ github.run_number }}
           path: exeris-kernel-community/target/jfr-reports/jmh-benchmarks.jfr
@@ -777,7 +777,7 @@ jobs:
 
       - name: Upload Core benchmark JFR
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-benchmarks-core-${{ github.run_number }}
           path: exeris-kernel-core/target/jfr-reports/jmh-benchmarks.jfr
@@ -794,11 +794,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache JDK tarball
         id: jdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/jdk.tar.gz
           key: ${{ env.JDK_CACHE_KEY }}
@@ -811,7 +811,7 @@ jobs:
           echo "${{ env.JDK_SHA256 }}  ${{ runner.temp }}/jdk.tar.gz" | sha256sum -c
 
       - name: Inject JDK into Runner
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/jdk.tar.gz
@@ -823,21 +823,21 @@ jobs:
         run: mvn -f tools/jfr-reporter/pom.xml clean package -q
 
       - name: Download TCK JFR recordings
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jfr-tck-${{ github.run_number }}
           path: .
 
       - name: Download persistence JFR recordings
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jfr-persistence-${{ github.run_number }}
           path: .
 
       - name: Download benchmark JFR recordings
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: jfr-benchmarks-*-${{ github.run_number }}
           path: .
@@ -858,7 +858,7 @@ jobs:
             --out       build/jfr-report/
 
       - name: Upload Lab JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jfr-lab-json-${{ github.run_number }}
           path: build/jfr-report/
@@ -875,24 +875,24 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download Lab JSON
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jfr-lab-json-${{ github.run_number }}
           path: build/jfr-report/
 
       - name: Download Community benchmark results
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jmh-community-results
           path: build/jmh-results/community/
 
       - name: Download Core benchmark results
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jmh-core-results
           path: build/jmh-results/core/


### PR DESCRIPTION
The v0.11.0 release PR's Dependency Review gate went red, and the cause was upstream of the release: `SonarSource/sonarqube-scan-action@v5` resolves to a revision covered by two high-severity advisories (GHSA-f79p-9c5r-xg88, GHSA-5xq9-5g24-4g6f), both cleared only from 6.0.0.

## Where the scan runs matters more than the pin

That action entered the tree through a PR into `development/0.11.0`. Dependency Review only triggered on PRs into `main`, so it went unscanned for 87 commits and surfaced at the cut — on the one PR nobody wants to reopen. It now runs on `development/**` too. The pin is the symptom; the trigger was the defect.

Exposure was bounded, for the record: the step passes no `with:` arguments and is gated on an absent `SONAR_TOKEN`, so it never actually ran. That bounds the risk, it does not make the gate wrong to fail.

## Versions

Eleven distinct action refs, several multiple majors behind: checkout v4 → v7.0.1, cache v4 → v6.1.0, upload-artifact v4 → v7.0.1, download-artifact v4 → v8.0.1, dependency-review v4 → v5.0.0, setup-java → v5.7.0, codeql-action → v4.37.6, sonarqube-scan-action → v8.2.1, claude-code-action → v1, actions-gh-pages → v4.0.0.

Inputs were checked against each new `action.yml`, not assumed: `cache-hit` still exists on cache v6, `distribution: jdkfile` + `jdkFile` still exist on setup-java v5.7, and the artifact actions still take the input set this repo uses.

`dependency-review` v5.0.0 is the interesting one. The deprecation issue announced `deny-licenses` removal for 5.x; the release turned out to be a node24 runtime bump that still declares the input. The comment in the workflow now records what the release contains rather than what the issue predicted.

## Pins that stay current

Everything is pinned by commit SHA with the version in a trailing comment, so a moved tag cannot change what runs. SHA pins do not decay visibly, though — the reason this repo drifted three majors is that nothing said so. `.github/dependabot.yml` is added for the actions ecosystem, which rewrites the SHA and its comment together. Maven is deliberately excluded: dependency bumps belong on the milestone path where the tagged gates run.

## A mandate that outlived the milestone

The Copilot instructions, both prompt packs, both implementer agent definitions, and the two `.github/skills` mirrors still told an AI reviewer to prefer `StructuredTaskScope` for orchestration concurrency — which ADR-066 removed from the default line in this release. The review workflow's own prompt still described the repo as JDK 26 with `--enable-preview`.

The `.claude/skills` copies had already been truthed up; the `.github` mirrors had not, so the guidance depended on which surface an agent happened to read. All of them now name `core.concurrent.StructuredScope`, scope `StructuredTaskScope` to the `preview` branch, and the review prompt states both tracks up front — including why two sites run in-thread rather than fork.

## Also

The `eu.exeris/*` modules are allow-listed for the licence check. They report an unknown licence because the dependency graph reads each module POM without resolving the parent that carries `<licenses>` — POM inheritance, not an unlicensed artifact.

## Verification

Workflows and `dependabot.yml` parse as YAML. No reactor sources touched, so the Java gates are unaffected — but CI on this PR now exercises every bumped action end to end, which is the actual proof.