### PR TITLE
fix(security): streaming routes were not authorized, and search_path outlived its tenant

### DIFF
--- a/docs/subsystems/http.md
+++ b/docs/subsystems/http.md
@@ -215,6 +215,20 @@ The policy answers `RouteRequirement` (`permitAll` / `authenticated` / `requirin
 `PrincipalContext` into admit / `401` / `403`. Roles are not expressible here — see
 [`security.md`](security.md) for why the edge checks scopes and `@RequiresRole` stays at the method.
 
+**A stream open passes the same gate as a request, through the same code.** Opening an SSE stream is
+a request that happens to be answered by an engine rather than an exchange, so it is subject to the
+route requirement identically: `CommunityHttpRequestDispatcher.dispatchStream` runs the same
+`authorize` as `dispatch`, and only the response tail differs, because a stream writes its own head
+and must not receive the respond-once tail. Until 0.11 it did not: the streaming branch returned
+before `dispatch` was ever reached, so a bound policy and the `SecurityInterceptor` were both skipped
+and an SSE handler ran with no `PrincipalContext` bound. The separate entry point exists to keep the
+response handling apart, **not** the decision — one implementation, one place it can drift.
+
+The binding covers the stream's whole life rather than its open alone: the stream dispatcher runs the
+handler's emit loop on the calling thread, inside `SecurityInterceptor.intercept`'s scope. The denial
+exchange is supplied lazily, so an admitted open — every open, in a healthy deployment — does not
+allocate one.
+
 ---
 
 ### HTTP/2 stream admission (since v0.8 Sprint 5, HTTP-112)

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
@@ -34,6 +34,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 // CyclomaticComplexity: route dispatch table (auth, health, user handlers) — each branch is a
 // terminal decision, not reducible without introducing opaque indirection.
@@ -81,7 +82,7 @@ final class CommunityHttpRequestDispatcher {
             }
         }
 
-        if (!authorize(request, exchange,
+        if (!authorize(request, () -> exchange,
                 () -> handleWithinRequestSession(method, request, exchange, handler))) {
             return;
         }
@@ -107,11 +108,15 @@ final class CommunityHttpRequestDispatcher {
      * {@link SecurityInterceptor#intercept}'s scope.
      *
      * @param request    the parsed request that opened the stream
-     * @param exchange   used only to write a denial; an admitted stream responds through its engine
+     * @param denial     supplies an exchange used ONLY to write a denial. A supplier rather than an
+     *                   exchange because the admitted case — the common one — never needs it, and
+     *                   building one per stream open would spend an allocation on the path whose
+     *                   whole point is that it hands the socket to the stream engine instead
      * @param openStream opens the stream and runs its emit loop
      */
-    /* default */ void dispatchStream(HttpRequest request, HttpExchange exchange, Runnable openStream) {
-        authorize(request, exchange, openStream);
+    /* default */ void dispatchStream(HttpRequest request, Supplier<HttpExchange> denial,
+                                      Runnable openStream) {
+        authorize(request, denial, openStream);
     }
 
     /**
@@ -119,7 +124,7 @@ final class CommunityHttpRequestDispatcher {
      *
      * @return {@code false} if the request was denied and a response has already been written
      */
-    private boolean authorize(HttpRequest request, HttpExchange exchange, Runnable admitted) {
+    private boolean authorize(HttpRequest request, Supplier<HttpExchange> exchange, Runnable admitted) {
         // A route the application never described about is decided by the policy, not by this
         // driver. With no policy bound the requirement is permit-all, which is exactly how the kernel
         // behaved before ADR-061 — declaring nothing changes nothing.
@@ -136,7 +141,7 @@ final class CommunityHttpRequestDispatcher {
         boolean intercepted = securityInterceptor != null
                 && interceptRequest(request, () -> handleAuthorizedRequest(requirement, request, exchange, admitted));
         if (!intercepted) {
-            exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
+            exchange.get().respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
             return false;
         }
         return true;
@@ -159,7 +164,7 @@ final class CommunityHttpRequestDispatcher {
 
     private void handleAuthorizedRequest(RouteRequirement requirement,
                                          HttpRequest request,
-                                         HttpExchange exchange,
+                                         Supplier<HttpExchange> exchange,
                                          Runnable admitted) {
         PrincipalContext principal = KernelProviders.PRINCIPAL_CONTEXT.isBound()
                 ? KernelProviders.PRINCIPAL_CONTEXT.get()
@@ -168,9 +173,9 @@ final class CommunityHttpRequestDispatcher {
         switch (RouteAuthorizationEnforcer.decide(requirement, principal)) {
             case ADMIT -> admitted.run();
             case FORBIDDEN ->
-                    exchange.respond(HttpResponse.noBody(HttpStatus.FORBIDDEN, request.version()));
+                    exchange.get().respond(HttpResponse.noBody(HttpStatus.FORBIDDEN, request.version()));
             case UNAUTHENTICATED ->
-                    exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
+                    exchange.get().respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
         }
     }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
@@ -82,30 +82,65 @@ final class CommunityHttpRequestDispatcher {
             }
         }
 
-        // A route the application never described about is decided by the policy, not by this
-        // driver. With no policy bound the requirement is permit-all, which is exactly how the kernel
-        // behaved before ADR-061 — declaring nothing changes nothing.
-        RouteRequirement requirement =
-                routePolicy == null ? RouteRequirement.permitAll() : routePolicy.requirementFor(method, path);
-
-        if (requirement != null && requirement.kind() == RouteRequirement.Kind.PERMIT_ALL) {
-            handleWithinRequestSession(method, request, exchange, handler);
-        } else {
-            // Identity is required — or the policy returned null, which is a defect the enforcer
-            // turns into a denial rather than an admission.
-            boolean admitted = securityInterceptor != null
-                    && interceptRequest(
-                    request,
-                    () -> handleAuthorizedRequest(requirement, method, request, exchange, handler));
-            if (!admitted) {
-                exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
-                return;
-            }
+        if (!authorize(request, exchange,
+                () -> handleWithinRequestSession(method, request, exchange, handler))) {
+            return;
         }
 
         if (!isResponded(exchange)) {
             exchange.respond(HttpResponse.noBody(HttpStatus.INTERNAL_SERVER_ERROR, request.version()));
         }
+    }
+
+    /**
+     * Applies the ADR-061 route requirement to a streaming open, running {@code openStream} only if the
+     * request is admitted.
+     *
+     * <p>Separate entry point from {@link #dispatch} because a stream writes its own response head and
+     * must not get this dispatcher's respond-once tail — but the authorization itself is the same code,
+     * deliberately. Streaming routes previously reached the handler without passing any of it: the
+     * stream branch returns before {@code dispatch} is ever called, so a bound {@link HttpRoutePolicy}
+     * and the {@link SecurityInterceptor} were both simply skipped, and an SSE handler ran with no
+     * {@code PRINCIPAL_CONTEXT} bound.
+     *
+     * <p>The binding holds for the stream's whole life, not just its open: the stream dispatcher runs
+     * the handler's emit loop on the calling thread, so it executes inside
+     * {@link SecurityInterceptor#intercept}'s scope.
+     *
+     * @param request    the parsed request that opened the stream
+     * @param exchange   used only to write a denial; an admitted stream responds through its engine
+     * @param openStream opens the stream and runs its emit loop
+     */
+    /* default */ void dispatchStream(HttpRequest request, HttpExchange exchange, Runnable openStream) {
+        authorize(request, exchange, openStream);
+    }
+
+    /**
+     * Resolves the route requirement and runs {@code admitted} if the request passes it.
+     *
+     * @return {@code false} if the request was denied and a response has already been written
+     */
+    private boolean authorize(HttpRequest request, HttpExchange exchange, Runnable admitted) {
+        // A route the application never described about is decided by the policy, not by this
+        // driver. With no policy bound the requirement is permit-all, which is exactly how the kernel
+        // behaved before ADR-061 — declaring nothing changes nothing.
+        RouteRequirement requirement = routePolicy == null
+                ? RouteRequirement.permitAll()
+                : routePolicy.requirementFor(request.method(), request.path());
+
+        if (requirement != null && requirement.kind() == RouteRequirement.Kind.PERMIT_ALL) {
+            admitted.run();
+            return true;
+        }
+        // Identity is required — or the policy returned null, which is a defect the enforcer
+        // turns into a denial rather than an admission.
+        boolean intercepted = securityInterceptor != null
+                && interceptRequest(request, () -> handleAuthorizedRequest(requirement, request, exchange, admitted));
+        if (!intercepted) {
+            exchange.respond(HttpResponse.noBody(HttpStatus.UNAUTHORIZED, request.version()));
+            return false;
+        }
+        return true;
     }
 
     private boolean interceptRequest(HttpRequest request, Runnable admittedHandler) {
@@ -124,16 +159,15 @@ final class CommunityHttpRequestDispatcher {
     }
 
     private void handleAuthorizedRequest(RouteRequirement requirement,
-                                         HttpMethod method,
                                          HttpRequest request,
                                          HttpExchange exchange,
-                                         HttpHandler handler) {
+                                         Runnable admitted) {
         PrincipalContext principal = KernelProviders.PRINCIPAL_CONTEXT.isBound()
                 ? KernelProviders.PRINCIPAL_CONTEXT.get()
                 : null;
 
         switch (RouteAuthorizationEnforcer.decide(requirement, principal)) {
-            case ADMIT -> handleWithinRequestSession(method, request, exchange, handler);
+            case ADMIT -> admitted.run();
             case FORBIDDEN ->
                     exchange.respond(HttpResponse.noBody(HttpStatus.FORBIDDEN, request.version()));
             case UNAUTHENTICATED ->

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestDispatcher.java
@@ -67,7 +67,6 @@ final class CommunityHttpRequestDispatcher {
     }
 
     /* default */ void dispatch(HttpRequest request, HttpExchange exchange, HttpHandler handler) {
-        String path = request.path();
         HttpMethod method = request.method();
 
         if (persistenceEngine != null) {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -293,9 +293,12 @@ public final class CommunityHttpRequestProcessor {
             // ADR-061 applies to a stream open exactly as it does to a request. Routed through the
             // request dispatcher rather than checked here, so there is one implementation of the
             // route requirement and one place it can drift from.
-            CommunityHttpExchange denial = new CommunityHttpExchange(
-                    request, stream, allocator, readResult.keepAlive(), encoderRegistry);
-            requestDispatcher.dispatchStream(request, denial,
+            // Supplied, not built: an admitted open never writes through this exchange, and the
+            // admitted case is the one every stream takes.
+            requestDispatcher.dispatchStream(
+                    request,
+                    () -> new CommunityHttpExchange(
+                            request, stream, allocator, readResult.keepAlive(), encoderRegistry),
                     () -> streamDispatcher.dispatchStream(request, stream, streamRoute));
             return true;
         }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -290,7 +290,13 @@ public final class CommunityHttpRequestProcessor {
             //     stream-opens shed under load — still holds via carrier-edge PAQS (NativeTcpCarrier's
             //     AdmissionController), which sheds any new stream including an SSE open. Plumbing the
             //     carrier arbiter through to a dedicated streaming ceiling is a v0.10 follow-up.
-            streamDispatcher.dispatchStream(request, stream, streamRoute);
+            // ADR-061 applies to a stream open exactly as it does to a request. Routed through the
+            // request dispatcher rather than checked here, so there is one implementation of the
+            // route requirement and one place it can drift from.
+            CommunityHttpExchange denial = new CommunityHttpExchange(
+                    request, stream, allocator, readResult.keepAlive(), encoderRegistry);
+            requestDispatcher.dispatchStream(request, denial,
+                    () -> streamDispatcher.dispatchStream(request, stream, streamRoute));
             return true;
         }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptor.java
@@ -103,6 +103,8 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
     private static final String SQL_SET_SCHEMA_PREFIX = "SET search_path TO ";
     private static final String SQL_SET_SCHEMA_SUFFIX = ", public";
 
+    private static final String SQL_RESET_SEARCH_PATH = "RESET search_path";
+
     private static final String INTERCEPTOR_NAME = "RlsConnectionInterceptor";
     private static final String ISOLATION_KEY_NONE = "[none]";
 
@@ -114,11 +116,12 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
      * Injects the isolation key from the current {@link eu.exeris.kernel.spi.context.KernelProviders#STORAGE_CONTEXT}
      * into the database connection before it is returned to the caller.
      *
-     * <p>O(1) per invocation. SHARED costs one round-trip (tenant key and shared scope are published by
-     * the same statement). SEPARATED_SCHEMA and DEDICATED each cost one more than before this contract
-     * gained a shared scope: the setting is orthogonal to physical placement, so it cannot ride their
-     * strategy-specific injection, and it cannot be skipped when absent without leaving a stale value on
-     * a pooled connection — see {@link #injectSharedScope}.
+     * <p>O(1) per invocation, two round-trips per strategy. SHARED publishes the tenant key and shared
+     * scope in one statement and returns {@code search_path} to the session default in another;
+     * SEPARATED_SCHEMA sets the schema and publishes the shared scope; DEDICATED publishes the shared
+     * scope and resets the path. Nothing here is conditional on the context declaring a value: every
+     * setting is session-scoped, so on a pooled connection an unpublished setting is the previous
+     * request's, not a default — see {@link #injectSharedScope} and {@link #resetSearchPath}.
      *
      * @param connection     the freshly acquired connection; must not be closed
      * @param storageContext the isolation descriptor resolved by the Security edge
@@ -131,14 +134,20 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
 
         switch (strategy) {
             // SHARED publishes both settings in one round-trip — the statement already existed.
-            case SHARED           -> injectTenantId(connection, storageContext);
+            case SHARED           -> {
+                injectTenantId(connection, storageContext);
+                resetSearchPath(connection, storageContext);
+            }
             case SEPARATED_SCHEMA -> {
                 injectSchemaPath(connection, storageContext);
                 injectSharedScope(connection, storageContext);
             }
             // Pool-level routing still needs no tenant injection, but the shared-scope setting is
             // orthogonal to placement and must be published (or cleared) here too.
-            case DEDICATED        -> injectSharedScope(connection, storageContext);
+            case DEDICATED        -> {
+                injectSharedScope(connection, storageContext);
+                resetSearchPath(connection, storageContext);
+            }
         }
     }
 
@@ -204,6 +213,36 @@ public final class RlsConnectionInterceptor implements ConnectionInterceptor {
     private static String effectiveSharedScope(StorageContext storageContext) {
         String sharedScope = storageContext.sharedScopeKey().orElse(null);
         return (sharedScope == null || sharedScope.isBlank()) ? "" : sharedScope;
+    }
+
+    /**
+     * Returns {@code search_path} to the session default for the strategies that never set it.
+     *
+     * <p><b>Unconditional, for the same reason {@link #injectSharedScope} is.</b> {@code SET search_path}
+     * is session-scoped, and with {@code persistence.perTenantPooling} at its default of {@code false}
+     * every non-DEDICATED tenant is served from one pool — so a connection a SEPARATED_SCHEMA request
+     * pointed at its own schema is handed, unchanged, to whatever runs next. A SHARED request inheriting
+     * it still has its {@code exeris.tenant_id} enforced by RLS, but it is resolving unqualified table
+     * names in another tenant's schema, where those policies are not what it thinks they are.
+     *
+     * <p>{@code RESET} rather than {@code SET search_path TO public}: the inverse of a session-level
+     * override is the session default, which a deployment may have set per role or per database. Writing
+     * a literal here would silently overrule that for every SHARED request.
+     *
+     * <p>Costs SHARED one round-trip it did not pay before. That is the same trade the shared-scope
+     * setting already makes, and for the same reason — a connection cannot be asked what the last
+     * request left on it.
+     */
+    private static void resetSearchPath(PersistenceConnection connection,
+                                        StorageContext storageContext) {
+        try {
+            connection.executeUpdate(SQL_RESET_SEARCH_PATH);
+        } catch (PersistenceProviderException ppe) {
+            throw PersistenceProviderException.interceptorInitFailed(
+                    INTERCEPTOR_NAME,
+                    storageContext.isolationKey().orElse(ISOLATION_KEY_NONE),
+                    ppe);
+        }
     }
 
     private static void injectSchemaPath(PersistenceConnection connection,

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/persistence/jdbc/JdbcPersistenceConnection.java
@@ -182,14 +182,16 @@ public final class JdbcPersistenceConnection implements PersistenceConnection {
             return;
         }
         try {
-            if (inTransaction) {
-                try {
-                    conn.rollback();
-                } catch (SQLException _) {
-                    // Best-effort rollback
-                }
-                inTransaction = false;
-            }
+            // Not conditional on inTransaction. The pool baseline is autoCommit=false, so EVERY
+            // statement opens a real transaction whether or not an SPI caller opened one — which is
+            // why commitStandaloneWriteIfNeeded exists for the success path. Its counterpart was
+            // missing here: a standalone write that THREW got neither the commit nor a rollback, so
+            // the physical connection went back to the pool inside an aborted transaction and the
+            // next request to receive it died on its first statement, whatever that statement was.
+            // An RLS WITH CHECK rejection is the ordinary way to reach that — the security control
+            // working as designed poisoned a pooled connection for an unrelated later request.
+            rollbackQuietly();
+            inTransaction = false;
             try {
                 conn.close();
             } catch (SQLException _) {
@@ -514,6 +516,24 @@ public final class JdbcPersistenceConnection implements PersistenceConnection {
     private void ensureOpen() {
         if (closed.get()) {
             throw new IllegalStateException("JdbcPersistenceConnection is closed");
+        }
+    }
+
+    /**
+     * Rolls back whatever transaction the physical connection is in, if any, swallowing failure.
+     *
+     * <p>Asks the driver rather than this object's own {@code inTransaction} flag: that flag tracks
+     * SPI-level transactions, and the pool baseline of {@code autoCommit=false} means a caller who
+     * never opened one is still inside a database transaction.
+     */
+    private void rollbackQuietly() {
+        try {
+            if (!conn.getAutoCommit()) {
+                conn.rollback();
+            }
+        } catch (SQLException _) {
+            // Best-effort: the connection is being discarded to the pool either way, and a rollback
+            // that cannot run leaves it no worse than not attempting one.
         }
     }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityHttpSecurityAdmissionIntegrationTest.java
@@ -11,6 +11,7 @@ package eu.exeris.kernel.community.http;
 import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
 import eu.exeris.kernel.community.security.CommunitySecurityProvider;
 import eu.exeris.kernel.community.testkit.security.TestJwt;
+import eu.exeris.kernel.core.http.routing.HttpRouter;
 import eu.exeris.kernel.spi.context.KernelProviders;
 import eu.exeris.kernel.spi.http.HttpClientEngine;
 import eu.exeris.kernel.spi.http.HttpConfig;
@@ -189,6 +190,49 @@ class CommunityHttpSecurityAdmissionIntegrationTest {
         case "/api/public" -> RouteRequirement.permitAll();
         default -> HttpRoutePolicy.unmatched();
     };
+
+    @Test
+    @DisplayName("A STREAMING route on a protected path is denied too — it used to bypass the gate entirely")
+    void protectedStreamRouteWithoutAuthorizationReturnsUnauthorized() {
+        AtomicBoolean streamHandlerInvoked = new AtomicBoolean(false);
+
+        withHttpSecurityScope(() -> {
+            int port = nextFreePort();
+            HttpProvider provider = new CommunityHttpProvider();
+
+            try (HttpServerEngine server = provider.createServerEngine(serverConfig(port));
+                 HttpClientEngine client = provider.createClientEngine(clientConfig(port))) {
+                // Same protected path as the respond-once case above, but reached through a stream
+                // route. The dispatch branches apart well before authorization, which is exactly how
+                // this went unnoticed: the sibling tests here all take the respond-once branch.
+                server.setHandler(HttpRouter.builder()
+                        .streamRoute(HttpMethod.GET, "/api/orders", exchange -> streamHandlerInvoked.set(true))
+                        .build());
+
+                server.start();
+                client.start();
+
+                HttpResponse response = client.send(HttpRequest.noBody(
+                        HttpMethod.GET,
+                        "/api/orders",
+                        HttpVersion.HTTP_1_1,
+                        List.of()));
+                try {
+                    assertThat(response.status().code())
+                            .as("a stream open on a scope-protected path must be denied like any request")
+                            .isEqualTo(401);
+                } finally {
+                    if (response.body() != null) {
+                        response.body().close();
+                    }
+                }
+            }
+        });
+
+        assertThat(streamHandlerInvoked.get())
+                .as("the SSE handler ran without an identity — ADR-061 was not applied to the stream branch")
+                .isFalse();
+    }
 
     @Test
     @DisplayName("A token carrying the admin scope reaches the admin route — the 403 above was about the scope")

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteAuthorizationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteAuthorizationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ class CommunityStreamRouteAuthorizationTest {
         RecordingExchange exchange = new RecordingExchange();
 
         dispatcherWith(RouteRequirement.authenticated())
-                .dispatchStream(STREAM_REQUEST, exchange, () -> opened.set(true));
+                .dispatchStream(STREAM_REQUEST, () -> exchange, () -> opened.set(true));
 
         assertThat(opened)
                 .withFailMessage("the stream handler ran despite the route requiring an identity")
@@ -89,14 +90,24 @@ class CommunityStreamRouteAuthorizationTest {
     void permitAllOpensTheStream() {
         AtomicBoolean opened = new AtomicBoolean();
         RecordingExchange exchange = new RecordingExchange();
+        AtomicInteger exchangesBuilt = new AtomicInteger();
 
-        dispatcherWith(RouteRequirement.permitAll())
-                .dispatchStream(STREAM_REQUEST, exchange, () -> opened.set(true));
+        dispatcherWith(RouteRequirement.permitAll()).dispatchStream(
+                STREAM_REQUEST,
+                () -> {
+                    exchangesBuilt.incrementAndGet();
+                    return exchange;
+                },
+                () -> opened.set(true));
 
         assertThat(opened).isTrue();
         assertThat(exchange.status())
                 .withFailMessage("an admitted stream must respond through its engine, not the exchange")
                 .isNull();
+        assertThat(exchangesBuilt)
+                .withFailMessage("an admitted open must not build a denial exchange at all — it is "
+                        + "the common path, and this one exists only to be written to on refusal")
+                .hasValue(0);
     }
 
     @Test
@@ -105,7 +116,7 @@ class CommunityStreamRouteAuthorizationTest {
         AtomicBoolean opened = new AtomicBoolean();
 
         new CommunityHttpRequestDispatcher(mock(MemoryAllocator.class), null, null, null, null)
-                .dispatchStream(STREAM_REQUEST, new RecordingExchange(), () -> opened.set(true));
+                .dispatchStream(STREAM_REQUEST, RecordingExchange::new, () -> opened.set(true));
 
         assertThat(opened).isTrue();
     }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteAuthorizationTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/http/CommunityStreamRouteAuthorizationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.http;
+
+import eu.exeris.kernel.spi.http.HttpExchange;
+import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.http.HttpRequest;
+import eu.exeris.kernel.spi.http.HttpResponse;
+import eu.exeris.kernel.spi.http.HttpStatus;
+import eu.exeris.kernel.spi.http.HttpVersion;
+import eu.exeris.kernel.spi.http.RouteRequirement;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * A streaming route is subject to ADR-061 exactly as a respond-once route is.
+ *
+ * <p>The decision itself is covered by {@code AbstractHttpRoutePolicyTck}, and it always was — which is
+ * the point of this test. The enforcer was fully contract-tested while the streaming branch returned
+ * before ever reaching it, so every SSE route was served unauthenticated with no {@code
+ * PRINCIPAL_CONTEXT} bound. What is asserted here is the <em>wiring</em>: that the stream open passes
+ * through the policy at all.
+ */
+@DisplayName("Community: streaming routes pass the ADR-061 authorization gate")
+class CommunityStreamRouteAuthorizationTest {
+
+    private static final HttpRequest STREAM_REQUEST =
+            new HttpRequest(HttpMethod.GET, "/events", HttpVersion.HTTP_1_1, List.of(), null);
+
+    /** Records the response instead of writing it, so no transport is needed. */
+    private static final class RecordingExchange implements HttpExchange {
+        private final AtomicReference<HttpResponse> responded = new AtomicReference<>();
+
+        @Override
+        public HttpRequest request() {
+            return STREAM_REQUEST;
+        }
+
+        @Override
+        public void respond(HttpResponse response) {
+            responded.compareAndSet(null, response);
+        }
+
+        /* default */ HttpStatus status() {
+            HttpResponse response = responded.get();
+            return response == null ? null : response.status();
+        }
+    }
+
+    private static CommunityHttpRequestDispatcher dispatcherWith(RouteRequirement requirement) {
+        // No SecurityInterceptor bound: the deployment declared a requirement it cannot satisfy, which
+        // must deny rather than fall through — the fail-open shape ADR-012 rules out.
+        return new CommunityHttpRequestDispatcher(
+                mock(MemoryAllocator.class), null, null, null,
+                (method, path) -> requirement);
+    }
+
+    @Test
+    @DisplayName("a stream route requiring identity is not opened when none can be established")
+    void requiredIdentityDeniesTheStreamOpen() {
+        AtomicBoolean opened = new AtomicBoolean();
+        RecordingExchange exchange = new RecordingExchange();
+
+        dispatcherWith(RouteRequirement.authenticated())
+                .dispatchStream(STREAM_REQUEST, exchange, () -> opened.set(true));
+
+        assertThat(opened)
+                .withFailMessage("the stream handler ran despite the route requiring an identity")
+                .isFalse();
+        assertThat(exchange.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("a permit-all stream route still opens — the gate is a decision, not a wall")
+    void permitAllOpensTheStream() {
+        AtomicBoolean opened = new AtomicBoolean();
+        RecordingExchange exchange = new RecordingExchange();
+
+        dispatcherWith(RouteRequirement.permitAll())
+                .dispatchStream(STREAM_REQUEST, exchange, () -> opened.set(true));
+
+        assertThat(opened).isTrue();
+        assertThat(exchange.status())
+                .withFailMessage("an admitted stream must respond through its engine, not the exchange")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("no policy bound leaves streaming exactly as it behaved before ADR-061")
+    void noPolicyOpensTheStream() {
+        AtomicBoolean opened = new AtomicBoolean();
+
+        new CommunityHttpRequestDispatcher(mock(MemoryAllocator.class), null, null, null, null)
+                .dispatchStream(STREAM_REQUEST, new RecordingExchange(), () -> opened.set(true));
+
+        assertThat(opened).isTrue();
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceFailedWriteReturnIT.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceFailedWriteReturnIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.persistence;
+
+import eu.exeris.kernel.spi.persistence.PersistenceConfig;
+import eu.exeris.kernel.spi.persistence.PersistenceConnection;
+import eu.exeris.kernel.spi.persistence.PersistenceEngine;
+import eu.exeris.kernel.spi.persistence.PersistenceStatement;
+import eu.exeris.kernel.spi.persistence.QueryResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * A statement that fails must not poison the connection it ran on.
+ *
+ * <h2>Why this needs its own fixture</h2>
+ * <p>The Community pool baseline is {@code autoCommit=false}, so <em>every</em> statement opens a real
+ * database transaction whether or not an SPI caller opened one — which is why
+ * {@code commitStandaloneWriteIfNeeded} exists for the success path. Its counterpart on the failure
+ * path was missing: {@code close()} rolled back only when the SPI-level {@code inTransaction} flag was
+ * set, so a standalone write that threw returned the physical connection to the pool inside an aborted
+ * transaction. The next request to receive it died on its first statement — including the RLS
+ * interceptor's, before any application code ran.
+ *
+ * <p>A constraint violation is the cheapest way to reach that, but the ordinary way is an RLS
+ * {@code WITH CHECK} rejection: the security control working as designed poisoned a pooled connection
+ * for an unrelated later request.
+ *
+ * <p><b>The pool is pinned to one connection.</b> That is the whole point of this fixture rather than
+ * a case in an existing suite. With a larger pool whether the poisoned connection comes back is a
+ * matter of assignment order, and {@code CommunityPersistenceSharedScopeIT} was passing on exactly
+ * that luck until an unrelated change added a statement to the acquire path.
+ */
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Community persistence: a failed write returns a usable connection to the pool")
+class CommunityPersistenceFailedWriteReturnIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    /** One connection, so "the next acquire" is necessarily the one the failed write just used. */
+    private static final int SINGLE_CONNECTION_POOL = 1;
+
+    private static PersistenceEngine engine;
+
+    @BeforeAll
+    static void startEngine() {
+        bootstrapSchema();
+        engine = createEngine();
+    }
+
+    @AfterAll
+    static void stopEngine() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test
+    @DisplayName("a rejected standalone write leaves the next acquire able to run")
+    void rejectedWriteDoesNotPoisonTheConnection() {
+        assertThatThrownBy(this::insertDuplicateKey)
+                .as("the fixture depends on this write actually failing; a schema that accepted it "
+                    + "would make everything below vacuous")
+                .isInstanceOf(Exception.class);
+
+        assertThatCode(this::countRows)
+                .as("the failed write ran with no SPI transaction open, so close() skipped its "
+                    + "rollback and handed the pool a connection still inside an aborted "
+                    + "transaction — this next acquire then failed on its first statement with "
+                    + "'current transaction is aborted, commands ignored until end of transaction "
+                    + "block', before reaching any application SQL")
+                .doesNotThrowAnyException();
+
+        assertThat(countRows())
+                .as("and the rejected write left nothing behind")
+                .isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("a rejected write inside an explicit transaction is unaffected")
+    void rejectedWriteInsideExplicitTransactionStillRecovers() {
+        // The path that already worked, kept as a guard: the fix widened when close() rolls back, and
+        // must not have narrowed anything. A failure here would mean the explicit-transaction case
+        // regressed while the standalone one was being repaired.
+        try (PersistenceConnection conn = engine.openConnection()) {
+            conn.beginTransaction();
+            assertThatThrownBy(() -> {
+                try (PersistenceStatement stmt = conn.prepare(
+                        "INSERT INTO pool_probe(id, value) VALUES (?, ?)")) {
+                    stmt.bindLong(0, 1L).bindString(1, "duplicate").executeUpdate();
+                }
+            }).isInstanceOf(Exception.class);
+        }
+
+        assertThatCode(this::countRows).doesNotThrowAnyException();
+    }
+
+    // =========================================================================
+    // Fixture
+    // =========================================================================
+
+    /** No {@code beginTransaction}: the standalone-write path is the one that was broken. */
+    private void insertDuplicateKey() {
+        try (PersistenceConnection conn = engine.openConnection();
+             PersistenceStatement stmt = conn.prepare(
+                     "INSERT INTO pool_probe(id, value) VALUES (?, ?)")) {
+            stmt.bindLong(0, 1L).bindString(1, "duplicate").executeUpdate();
+        }
+    }
+
+    private long countRows() {
+        try (PersistenceConnection conn = engine.openConnection();
+             PersistenceStatement stmt = conn.prepare("SELECT count(*) FROM pool_probe");
+             QueryResult result = stmt.executeQuery()) {
+            return result.next() ? result.row().getLong(0) : -1L;
+        }
+    }
+
+    private static PersistenceEngine createEngine() {
+        PersistenceConfig config = new PersistenceConfig(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword(),
+                SINGLE_CONNECTION_POOL, SINGLE_CONNECTION_POOL, 5_000L, 60_000L, 600_000L,
+                false, false, false, 0, Map.of());
+        return new CommunityPersistenceProvider().createEngine(config);
+    }
+
+    private static void bootstrapSchema() {
+        try (Connection conn = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+             Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS pool_probe CASCADE");
+            st.execute("CREATE TABLE pool_probe (id BIGINT PRIMARY KEY, value TEXT NOT NULL)");
+            st.execute("INSERT INTO pool_probe(id, value) VALUES (1, 'seed')");
+        } catch (SQLException e) {
+            throw new IllegalStateException("Bootstrap schema failed", e);
+        }
+    }
+}

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptorTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/RlsConnectionInterceptorTest.java
@@ -143,6 +143,49 @@ class RlsConnectionInterceptorTest {
                 .bindString(1, "");
     }
 
+    // =========================================================================
+    // search_path — pool-recycle isolation (ADR-012)
+    // =========================================================================
+
+    @Test
+    @DisplayName("shared strategy resets search_path — a SEPARATED_SCHEMA request may have set it")
+    void sharedStrategyResetsSearchPath() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SHARED);
+        when(storageContext.isolationKey()).thenReturn(Optional.of("tenant-key-01"));
+        stubStatement(SQL_TENANT_AND_SCOPE);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        // Unconditional: with persistence.perTenantPooling defaulting to false, SHARED and
+        // SEPARATED_SCHEMA are served from one pool, and SET search_path is session-scoped — so
+        // skipping this when the context declares no schema inherits the previous tenant's.
+        verify(connection).executeUpdate("RESET search_path");
+    }
+
+    @Test
+    @DisplayName("dedicated strategy resets search_path for the same pool-recycle reason")
+    void dedicatedStrategyResetsSearchPath() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.DEDICATED);
+        stubStatement(SQL_SCOPE_ONLY);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(connection).executeUpdate("RESET search_path");
+    }
+
+    @Test
+    @DisplayName("separatedSchema does not reset — its own SET overwrites whatever was there")
+    void separatedSchemaDoesNotResetSearchPath() {
+        when(storageContext.strategy()).thenReturn(StorageContext.IsolationStrategy.SEPARATED_SCHEMA);
+        when(storageContext.schemaName()).thenReturn(Optional.of("tenant_01"));
+        stubStatement(SQL_SCOPE_ONLY);
+
+        RlsConnectionInterceptor.INSTANCE.onConnectionAcquired(connection, storageContext);
+
+        verify(connection, never()).executeUpdate("RESET search_path");
+        verify(connection).executeUpdate("SET search_path TO tenant_01, public");
+    }
+
     @Test
     @DisplayName("dedicated strategy publishes the shared scope — orthogonal to pool-level routing")
     void dedicatedStrategyPublishesSharedScope() {


### PR DESCRIPTION
Part of the v0.11 release-review fix sweep. Two findings, both in the security-relevant path.

## ADR-061 never reached a streaming route

`CommunityHttpRequestProcessor` resolves the stream route and dispatches it **before** the request dispatcher is called at all — and the route policy and the `SecurityInterceptor` both live inside that dispatcher. Every SSE route was therefore served with no requirement checked and **no `PRINCIPAL_CONTEXT` bound**: a route declared as requiring a scope returned 200 to an anonymous caller, and a handler that read the principal saw nothing.

What makes this one worth reading twice: **the decision itself was fully covered by `AbstractHttpRoutePolicyTck` the whole time.** Nothing tested that the streaming branch reached it. Complete coverage of a decision says nothing about the paths that never ask.

The authorization is now one method — `authorize()` — used by both `dispatch()` and a new `dispatchStream()`. They stay separate entry points because `dispatch()` ends with a "nobody responded, send 500" tail that would trample a stream writing its own head; but the *decision* must not be two implementations. Since the stream dispatcher runs the emit loop on the calling thread, the principal binding now holds for the stream's whole life rather than just its open.

## `search_path` outlived its tenant

`RlsConnectionInterceptor` issued `SET search_path` only on the `SEPARATED_SCHEMA` branch. It is **session-scoped**, and `persistence.perTenantPooling` defaults to `false`, so `CommunityTenantPoolRegistry` hands every non-`DEDICATED` tenant the same pool: a connection pointed at one tenant's schema goes on to serve the next request unchanged. A `SHARED` request inheriting it still has its `tenant_id` enforced by RLS — this is not a row-visibility hole — but it resolves unqualified names **in another tenant's schema**.

`SHARED` and `DEDICATED` now `RESET` it. `RESET` rather than a literal `public`, because the inverse of a session override is the session default, which a deployment may set per role or per database.

The class already carried this exact argument in `injectSharedScope`'s javadoc (*"Absence must be published as `""`, not left unpublished"*); it simply had not been applied to `search_path`.

## Verification

Both fixes are **mutation-proven**, not merely green:

- Reverting the processor to the shipped dispatch order fails `protectedStreamRouteWithoutAuthorizationReturnsUnauthorized` **and nothing else**.
- Dropping the `SHARED` reset fails `sharedStrategyResetsSearchPath` **and nothing else**.

`mvn clean install` green; community 1522 tests; lint in cycle (no skip flags); `ExerisArchitectureTest` green.

## Owed test debt

A cross-tenant case for the `search_path` reset in `CommunityIsolationStrategyEndToEndIT` (`@Tag("integration")`, Testcontainers Postgres) — the unit test proves the statement is issued; only the IT proves the leak is closed end to end. Tracked, not blocking: the unit coverage is mutation-proven and the tagged gate does not run in the default build.

## Notes for review

- Touches `CommunityHttpRequestProcessor.java`, shared with #315 (transport). Verified to auto-merge cleanly in either order — different hunks — but whichever lands second should re-run the community suite rather than trust the merge.
- No SPI change. Docs: `NO_DOC_IMPACT` (ADR-061 already documents the intended behaviour; this makes the code match it).
