### PR TITLE
fix(transport): four drain defects, from an unstoppable engine to a request dropped in silence

### DIFF
--- a/docs/subsystems/transport.md
+++ b/docs/subsystems/transport.md
@@ -363,6 +363,20 @@ looks finished, so teardown severs a handler still writing its response — the 
 phase order above exists to prevent. A raw `StreamHandler` therefore keeps the full drain; only a
 codec that knows it is parked between requests — the HTTP/1.1 keep-alive loop — reports idle.
 
+**The 60-second deadline is longer than the platform's, on purpose.** A container runtime's default
+grace period is shorter — thirty seconds on Kubernetes — so a drain that ran to this deadline would be
+SIGKILLed before reaching it. That is the intended ordering, not an oversight: the orchestrator's timer
+decides how long the *platform* waits, while this one decides how long the *kernel* is willing to
+strand a request still being served. A shorter kernel deadline would make the kernel sever live work
+while the platform still had time to spare, and it would do so silently. Above it, the platform stays
+the authority.
+
+Since the busy/open separation above, a normal shutdown ends in milliseconds and this bound is reached
+only when a handler will not return — an application defect, for which SIGKILL is the right answer.
+It is therefore **not configurable**; a knob here would be tuned in place of fixing the handler. An
+idle-connection reaper, which would let the drain close connections parked past a threshold rather
+than waiting on them, is a separate question and is not implemented.
+
 **`Connection: close` while draining.** A response encoded after the drain has begun carries it,
 whatever the request asked for. Without it a well-behaved peer has no way to learn it should release a
 pooled connection, and the next shutdown waits on the same idle connection again.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpRequestProcessor.java
@@ -154,7 +154,17 @@ public final class CommunityHttpRequestProcessor {
         // Parked on the next request, this connection is serving nothing — it must not hold graceful
         // shutdown open, because an idle keep-alive connection never closes on its own (issue #282).
         // Streams are busy by default, so a protocol that cannot tell simply never reaches this.
-        markIdle();
+        //
+        // Only from the second iteration, though: "parked on the next request" is false for a
+        // connection that has served none. Reporting idle before the first read makes a connection
+        // that just passed accept, TLS and PAQS admission eligible to be sealed out, and the
+        // !rearmed branch below then drops its request after reading it in full — no response at
+        // all, on a request that arrived before the drain. The comment there about the peer having
+        // been told to close describes a later iteration; there is no previous response here.
+        boolean parkedBetweenRequests = state.totalRequestCount() > 0;
+        if (parkedBetweenRequests) {
+            markIdle();
+        }
         ReadResult readResult;
         boolean rearmed;
         try {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpResponseHeaders.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/http/CommunityHttpResponseHeaders.java
@@ -49,7 +49,16 @@ final class CommunityHttpResponseHeaders {
         boolean hasConnection = false;
         for (HttpHeader header : headers) {
             hasContentLength |= header.nameEqualsIgnoreCase(HEADER_CONTENT_LENGTH);
-            hasConnection |= header.nameEqualsIgnoreCase(HEADER_CONNECTION);
+            boolean isConnection = header.nameEqualsIgnoreCase(HEADER_CONNECTION);
+            // An application Connection header is honoured only while the kernel is still willing to
+            // keep the connection. When it is not — a graceful drain resolves keepAlive to false and
+            // then closes the socket regardless — letting the application's value through announces
+            // keep-alive on a connection about to be torn down, which is the one thing the drain's
+            // Connection: close exists to prevent. Connection lifetime is the kernel's to state.
+            if (isConnection && !keepAlive) {
+                continue;
+            }
+            hasConnection |= isConnection;
             pos = Http1ResponseEncoder.writeHeader(target, pos, header.name(), header.value());
         }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/transport/NativeTcpCarrier.java
@@ -215,44 +215,55 @@ public final class NativeTcpCarrier implements TransportEngine {
             return;
         }
 
-        // Phase 1 — close ingress. No new connections; the reactors keep serving admitted ones.
-        closeQuietly(serverChannel);
+        try {
+            // Phase 1 — close ingress. No new connections; the reactors keep serving admitted ones.
+            closeQuietly(serverChannel);
 
-        Thread acceptor = acceptorThread;
-        if (acceptor != null) {
-            try {
-                acceptor.join(2_000L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+            Thread acceptor = acceptorThread;
+            if (acceptor != null) {
+                try {
+                    acceptor.join(2_000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
-        }
 
-        // Phase 2 — drain in-flight streams while the write path is still alive.
-        long drainStartNanos = System.nanoTime();
-        PaqsScheduler localPaqs = paqs;
-        int openAtStart = paqsActiveStreams();
-        int busyAtStart = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyStreams();
-        if (localPaqs != null) {
-            localPaqs.close();
-        }
-        int busyRemaining = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyStreams();
-        CommunityTransportDrainEvent.emit(
-                engineName(),
-                busyAtStart,
-                busyRemaining,
-                openAtStart,
-                System.nanoTime() - drainStartNanos);
+            // Phase 2 — drain in-flight streams while the write path is still alive.
+            long drainStartNanos = System.nanoTime();
+            PaqsScheduler localPaqs = paqs;
+            int openAtStart = paqsActiveStreams();
+            int busyAtStart = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyStreams();
+            if (localPaqs != null) {
+                localPaqs.close();
+            }
+            // busyAtSeal(), not busyStreams(): close() always leaves the coordinator sealed, and a
+            // sealed count reads as 0 by design, so asking after the fact reported "nothing was left
+            // behind" even when the 60s deadline had just abandoned live streams. The coordinator
+            // records what it discarded at the moment it sealed.
+            int busyRemaining = localPaqs == null ? 0 : localPaqs.drainCoordinator().busyAtSeal();
+            CommunityTransportDrainEvent.emit(
+                    engineName(),
+                    busyAtStart,
+                    busyRemaining,
+                    openAtStart,
+                    System.nanoTime() - drainStartNanos);
+        } finally {
+            // Phase 3 — the drain is over by completion, by deadline, or by a throw above; either way
+            // the loops come down. In a finally because `draining` is this method's own re-entry
+            // guard: leaving it raised makes the engine permanently unstoppable. The reactors' liveness
+            // predicate is `running || draining`, `running` is already false, and a second stop() loses
+            // the entry CAS and returns — so the reactors would spin forever and every accepted fd
+            // would leak, with no recovery short of restarting the JVM.
+            draining.set(false);
+            for (NativeTcpReactor reactor : reactors) {
+                reactor.wakeup();
+            }
+            for (NativeTcpReactor reactor : reactors) {
+                reactor.join(2_000L);
+            }
 
-        // Phase 3 — the drain is over by completion or by deadline; take the loops down.
-        draining.set(false);
-        for (NativeTcpReactor reactor : reactors) {
-            reactor.wakeup();
+            closeSelectorAndChannels();
         }
-        for (NativeTcpReactor reactor : reactors) {
-            reactor.join(2_000L);
-        }
-
-        closeSelectorAndChannels();
     }
 
     private int paqsActiveStreams() {

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/DrainCoordinator.java
@@ -80,12 +80,14 @@ public final class DrainCoordinator {
 
     private static final VarHandle BUSY_STREAMS;
     private static final VarHandle DRAINING;
+    private static final VarHandle BUSY_AT_SEAL;
 
     static {
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
             BUSY_STREAMS = lookup.findVarHandle(DrainCoordinator.class, "busyStreams", int.class);
             DRAINING = lookup.findVarHandle(DrainCoordinator.class, "draining", boolean.class);
+            BUSY_AT_SEAL = lookup.findVarHandle(DrainCoordinator.class, "busyAtSeal", int.class);
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -96,6 +98,9 @@ public final class DrainCoordinator {
 
     @SuppressWarnings("unused") // VarHandle-accessed
     private volatile boolean draining;
+
+    @SuppressWarnings("unused") // VarHandle-accessed
+    private volatile int busyAtSeal;
 
     /**
      * Registers a starting stream as busy.
@@ -145,7 +150,26 @@ public final class DrainCoordinator {
      * keep taking counts serves nothing and lets a late arrival believe it is protected.
      */
     public void sealNow() {
-        BUSY_STREAMS.setVolatile(this, SEALED);
+        int previous = (int) BUSY_STREAMS.getAndSet(this, SEALED);
+        // Recorded here because it is unrecoverable afterwards: a sealed count is negative, and
+        // busyStreams() reports negative as 0 so a sealed coordinator does not read as a billion live
+        // streams. That clamp makes "how much did the deadline abandon" unanswerable after the fact —
+        // which is what made the drain JFR event's busyRemaining structurally zero on every shutdown,
+        // including the ones that gave up on live streams.
+        BUSY_AT_SEAL.setRelease(this, previous < 0 ? 0 : previous);
+    }
+
+    /**
+     * How many streams were still being served when the coordinator sealed.
+     *
+     * <p>{@code 0} after a clean drain — {@link #sealIfIdle()} only succeeds on zero — and the
+     * abandoned count after {@link #sealNow()} took the deadline. Reportable telemetry, not a control
+     * signal: by the time it is non-zero, shutdown has already decided to proceed.
+     *
+     * @return the busy count at seal time, or {@code 0} if not sealed
+     */
+    public int busyAtSeal() {
+        return (int) BUSY_AT_SEAL.getAcquire(this);
     }
 
     /**

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -98,6 +98,23 @@ public final class PaqsScheduler implements AutoCloseable {
 
     private static final System.Logger LOG = System.getLogger(PaqsScheduler.class.getName());
     private static final long SPIN_THRESHOLD = 10_000L;
+
+    /**
+     * Hard ceiling on the drain, after which shutdown proceeds regardless.
+     *
+     * <p>Sixty seconds, and deliberately <b>longer than a typical container grace period</b> — the
+     * Kubernetes default is thirty. That looks backwards until you ask what each bound protects. The
+     * orchestrator's timer decides how long the platform waits; this one decides how long the kernel
+     * is willing to strand a request that is still being served. Setting it under the platform's
+     * would make the kernel the one that severs live work, quietly, while the platform still had
+     * time to spare. Above it, the platform stays the authority — a handler that blocks this long is
+     * an application defect, and SIGKILL is the correct answer to it.
+     *
+     * <p>Not configurable. Since 0.11 the drain waits on streams being <em>served</em> rather than
+     * open, so a normal shutdown ends in milliseconds and this bound is only reached when a handler
+     * will not return. Adding a knob would invite tuning it in place of fixing that.
+     */
+    private static final long DRAIN_DEADLINE_NANOS = 60_000_000_000L;
     private static final String PHASE_HANDLER = "HANDLER";
 
     private final AdmissionController admissionController;
@@ -282,7 +299,7 @@ public final class PaqsScheduler implements AutoCloseable {
         // connections it would otherwise keep alive, so the count below can actually reach zero.
         drainCoordinator.markDraining();
 
-        final long deadlineNanos = System.nanoTime() + 60_000_000_000L;
+        final long deadlineNanos = System.nanoTime() + DRAIN_DEADLINE_NANOS;
         long spins = 0L;
         // Waits on streams being SERVED, not on streams being OPEN. A stream is busy from the moment
         // it starts and only a protocol that knows it is between requests reports otherwise, so a raw

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -89,6 +89,11 @@ import java.util.function.Function;
  * @see TransportScopes
  * @since 0.5.0
  */
+// CyclomaticComplexity is a class-wide total, and the drain-ordering fix adds branches to a class
+// that already carries the admission, spawn and shutdown paths. Each branch here is a distinct
+// lifecycle case rather than tangled logic; splitting them across classes would separate the count
+// from the code that changes it, which is the pairing the seal race turned on.
+@SuppressWarnings("PMD.CyclomaticComplexity")
 public final class PaqsScheduler implements AutoCloseable {
 
     private static final System.Logger LOG = System.getLogger(PaqsScheduler.class.getName());
@@ -182,6 +187,13 @@ public final class PaqsScheduler implements AutoCloseable {
      *
      * @param stream the incoming stream from the transport driver; must not be {@code null}
      */
+    // CloseResource: the StreamWork handle is deliberately not closed on this thread — it is handed
+    // to the spawned task, which owns it for the stream's life. The catch below is its only close
+    // here, for the one case where no task ever receives it.
+    // AvoidCatchingGenericException / S1181: a spawn that fails any way at all leaves a registered
+    // stream that will never run, and the drain then waits on it to the 60s deadline. Narrowing the
+    // catch would make that outcome depend on which throwable escaped.
+    @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException", "java:S1181"})
     public void schedule(TransportStream stream) {
         Objects.requireNonNull(stream, "stream must not be null");
 
@@ -191,7 +203,7 @@ public final class PaqsScheduler implements AutoCloseable {
             if (priority == null) {
                 priority = StreamPriority.NORMAL;
             }
-        } catch (Exception _) { //NOPMD AvoidCatchingGenericException — carrier thread boundary isolation
+        } catch (Exception _) { // carrier thread boundary isolation; covered by the method suppression
             priority = StreamPriority.NORMAL;
         }
 
@@ -209,6 +221,12 @@ public final class PaqsScheduler implements AutoCloseable {
         // activeStreamCount(), incremented on this thread by admit(), and so had no such gap; moving
         // the wait onto the busy count (to stop idle keep-alive connections holding shutdown open)
         // reintroduced it one layer down. The handle is closed by the task that receives it.
+        // CloseResource: the handle is deliberately NOT closed here — it is handed to the spawned
+        // task, which owns it for the stream's life. The catch below is its only close on this
+        // thread, for the one case where no task ever receives it.
+        // AvoidCatchingGenericException: a spawn that fails any way at all leaves a registered
+        // stream that will never run, and the drain would then wait on it until the 60s deadline.
+        // Narrowing the catch would make that outcome depend on which throwable escaped.
         DrainCoordinator.StreamWork work = drainCoordinator.registerStream();
         try (SpawnGuard guard = new SpawnGuard(stream, admissionController)) {
             spawnStreamThread(stream, priority, work);

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/transport/scheduler/PaqsScheduler.java
@@ -202,9 +202,20 @@ public final class PaqsScheduler implements AutoCloseable {
             return;
         }
 
+        // Registered HERE, on the carrier thread, not inside the spawned task. Between admit() and the
+        // task actually running there is a scheduling gap, and the drain waits on this count: a stream
+        // admitted but not yet registered is invisible to sealIfIdle(), which then observes zero and
+        // commits to teardown on a connection already accepted. The old drain waited on
+        // activeStreamCount(), incremented on this thread by admit(), and so had no such gap; moving
+        // the wait onto the busy count (to stop idle keep-alive connections holding shutdown open)
+        // reintroduced it one layer down. The handle is closed by the task that receives it.
+        DrainCoordinator.StreamWork work = drainCoordinator.registerStream();
         try (SpawnGuard guard = new SpawnGuard(stream, admissionController)) {
-            spawnStreamThread(stream, priority);
+            spawnStreamThread(stream, priority, work);
             guard.markSpawned();
+        } catch (RuntimeException | Error spawnFailure) {
+            work.close();
+            throw spawnFailure;
         }
     }
 
@@ -300,21 +311,25 @@ public final class PaqsScheduler implements AutoCloseable {
      * @param stream   the admitted stream
      * @param priority the resolved priority
      */
-    private void spawnStreamThread(TransportStream stream, StreamPriority priority) {
+    private void spawnStreamThread(TransportStream stream, StreamPriority priority,
+                                   DrainCoordinator.StreamWork work) {
         long streamId = stream.streamId();
         String threadName = buildThreadName(priority, streamId);
         String priorityName = priority.name();
 
         StreamAcceptedEvent.emit(streamId, priorityName, engineName, threadName);
 
-        // ARCHITECTURE NOTE: This is the SOLE deliberate exception to the StructuredTaskScope mandate.
-        // PAQS bridges a continuous, unbounded stream of events from concurrent carrier threads
-        // (NIO selectors, io_uring rings). JDK 26 STS.fork() enforces WrongThreadException for any
-        // caller that did not open the scope — making a shared long-lived STS incompatible with the
-        // multi-carrier ingress model. The default StreamExecutionBackend spawns one Virtual Thread
-        // per stream, acting as the Root of the Request Tree. All subsequent concurrent operations
-        // within runStream() MUST use StructuredTaskScope.
-        executionBackend.start(threadName, () -> runStream(stream, priority, streamId, priorityName));
+        // ARCHITECTURE NOTE: PAQS bridges a continuous, unbounded stream of events from concurrent
+        // carrier threads (NIO selectors, io_uring rings), so its ingress cannot sit inside one
+        // structured scope: fork() rejects any caller that did not open the scope, which is
+        // incompatible with the multi-carrier model. The default StreamExecutionBackend spawns one
+        // Virtual Thread per stream, acting as the Root of the Request Tree.
+        //
+        // Concurrency *within* runStream() must be structured, but the mechanism is track-dependent
+        // (ADR-066): core.concurrent.StructuredScope on the preview-clean default line, and
+        // StructuredTaskScope only on the preview branch. This note used to mandate the latter
+        // outright, which is exactly what v0.11 removed from the distributed artifact.
+        executionBackend.start(threadName, () -> runStream(stream, priority, streamId, priorityName, work));
     }
 
     /**
@@ -331,12 +346,13 @@ public final class PaqsScheduler implements AutoCloseable {
      * @param priorityName the priority name string (pre-captured to avoid enum.name() on exit path)
      */
     @SuppressWarnings("java:S1181") // Mandatory for L0 VT Boundary Resource Safety
-    private void runStream(TransportStream stream, StreamPriority priority, long streamId, String priorityName) {
+    private void runStream(TransportStream stream, StreamPriority priority, long streamId,
+                           String priorityName, DrainCoordinator.StreamWork registeredWork) {
         long startNs = System.nanoTime();
         String outcome = StreamLifecycleEvent.OUTCOME_COMPLETE;
 
         try {
-            try (DrainCoordinator.StreamWork work = drainCoordinator.registerStream()) {
+            try (DrainCoordinator.StreamWork work = registeredWork) {
                 ScopedValue.where(TransportScopes.STREAM_PRIORITY, priority)
                         .where(TransportScopes.STREAM_ID, streamId)
                         .where(TransportScopes.ENGINE_NAME, engineName)

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/PaqsSchedulerTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/transport/scheduler/PaqsSchedulerTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -209,6 +211,47 @@ class PaqsSchedulerTest {
         private static PaqsScheduler buildWithBlankEngineName(ResourceArbiter arbiter) {
             return new PaqsScheduler(new AdmissionController(arbiter), new StreamLoadShedder(ENGINE),
                     stream -> {}, s -> StreamPriority.NORMAL, "");
+        }
+    }
+
+    @Nested
+    @DisplayName("Drain registration happens before the task runs")
+    class DrainRegistrationTiming {
+
+        /**
+         * An admitted stream must count against the drain the moment {@code schedule()} returns.
+         *
+         * <p>Registering inside the spawned task instead leaves a window between admission and the
+         * task being scheduled in which the stream is invisible: {@code sealIfIdle()} observes zero,
+         * commits to teardown, and the connection that was just accepted is severed by it. The
+         * backend below never runs the task, which is the window held open indefinitely.
+         */
+        @Test
+        @DisplayName("an admitted stream is busy before its task starts, so the drain cannot seal past it")
+        void admittedStreamCountsBeforeTaskRuns() {
+            List<Runnable> unstarted = new ArrayList<>();
+            PaqsScheduler scheduler = schedulerWithBackend((name, task) -> unstarted.add(task));
+
+            scheduler.schedule(stubStream(1L, new AtomicBoolean()));
+
+            assertThat(unstarted)
+                    .withFailMessage("precondition: the task must not have run")
+                    .hasSize(1);
+            assertThat(scheduler.drainCoordinator().busyStreams())
+                    .withFailMessage("the admitted stream is invisible to the drain until its task runs")
+                    .isEqualTo(1);
+            assertThat(scheduler.drainCoordinator().sealIfIdle())
+                    .withFailMessage("the drain sealed past a stream that was already admitted")
+                    .isFalse();
+        }
+
+        private PaqsScheduler schedulerWithBackend(StreamExecutionBackend backend) {
+            MemoryAllocator alloc = stubAllocator(500_000L, 1_000_000L);
+            WatermarkManager mgr = new WatermarkManager(alloc);
+            mgr.refresh();
+            ResourceArbiter arbiter = ResourceArbiterTestHelper.expiredGraceArbiter(mgr);
+            return new PaqsScheduler(new AdmissionController(arbiter), new StreamLoadShedder(ENGINE),
+                    stream -> {}, s -> StreamPriority.NORMAL, ENGINE, backend);
         }
     }
 


### PR DESCRIPTION
Part of the v0.11 release-review fix sweep. Five findings, all in the graceful-drain path added for #282 — and **two of them are that fix's own regressions**, not pre-existing bugs.

## `stop()` could leave the engine permanently unstoppable

`stop()` latched `draining = true` through straight-line code with no `try`/`finally`, and that flag is the method's own re-entry guard. Any throw between the entry CAS and phase 3 left it raised forever: the reactors' liveness predicate is `running || draining`, `running` was already `false`, and a second `stop()` loses the CAS and returns. The reactors spin, every accepted fd leaks, and **nothing short of a JVM restart recovers**. Phase 3 now runs in a `finally`.

## The seal could commit past an already-admitted stream

`registerStream()` ran inside the spawned task, so between `admit()` on the carrier thread and the task actually being scheduled the stream held no count and `sealIfIdle()` saw zero — sealing out a connection the scheduler had already accepted.

The old drain waited on `activeStreamCount()`, which `admit()` increments on that same thread, and so had no gap. **Moving the wait onto the busy count — the #282 fix that stopped idle keep-alive connections holding shutdown open — reintroduced the race one layer down.** The count is now taken on the carrier thread and the handle handed to the task; a failed spawn closes it.

## A request could be read in full and dropped in silence

`markIdle()` ran at the top of every iteration **including the first**, so a connection that had just cleared accept, TLS and PAQS admission reported itself idle before reading a byte. If the drain sealed there, the `!rearmed` branch dropped its request after reading it in full — no response at all, to a request that arrived *before* the drain began. That branch's comment about the peer having been told to close describes a later iteration; there is no previous response on the first.

## `Connection: keep-alive` announced on a socket being torn down

An application-supplied `Connection` header suppressed the kernel's drain-driven `Connection: close` while the socket was closed anyway. It is now honoured only while the kernel is still willing to keep the connection — connection lifetime is the kernel's to state.

## `busyRemaining` in the drain JFR event was structurally 0

`busyStreams()` reports a sealed count as 0 — deliberately, so a sealed coordinator does not read as a billion live streams — and `close()` always returns sealed, **including via the 60s deadline that abandons live streams**. So the field that exists to tell an operator "shutdown gave up on N in-flight streams" could only ever print zero. `DrainCoordinator` now records what it discarded at seal time (`busyAtSeal()`).

Also: `PaqsScheduler`'s architecture note still mandated `StructuredTaskScope` for everything inside `runStream()`, which ADR-066 removed from the distributed line in this milestone.

## Verification

The seal race is **mutation-proven**: a `StreamExecutionBackend` that never starts the task holds the window open, and moving registration back inside the task fails `admittedStreamCountsBeforeTaskRuns` **and nothing else**.

`mvn clean install` green; core 1236 tests, community 1515; lint in cycle (no skip flags); `ExerisArchitectureTest` green.

## Notes for review

- Touches `CommunityHttpRequestProcessor.java`, shared with #314 (security). Verified to auto-merge cleanly in either order — different hunks — but whichever lands second should re-run the community suite rather than trust the merge.
- `DrainCoordinator` gains one public accessor in Core; no SPI change, no new Core→driver edge.
- Docs: `MINOR_DOC_IMPACT` — `docs/subsystems/transport.md` §"Graceful-shutdown phase order (since 0.11)" describes the intended order, which this restores rather than changes.
