### PR TITLE
fix(scheduling): a settled job kept its payload, and an undispatchable one never settled

### DIFF
--- a/docs/subsystems/scheduling.md
+++ b/docs/subsystems/scheduling.md
@@ -61,9 +61,17 @@ Two semantics worth stating because they surprise people:
 `PrincipalContext` and `StorageContext` are captured at `submit` and rebound with `ScopedValue` on
 the dispatching thread. Two consequences are normative:
 
-- **A job with no captured context fails closed.** It does not run under an ambient or default
-  identity — the same reasoning as ADR-012 §4a, that a resolution the kernel cannot honour is a deny
-  rather than a downgrade. The refusal is a JFR event carrying `EX-JOB-9001`.
+- **A job with no captured context fails closed, and does so once.** It does not run under an
+  ambient or default identity — the same reasoning as ADR-012 §4a, that a resolution the kernel
+  cannot honour is a deny rather than a downgrade. The refusal is a JFR event carrying
+  `EX-JOB-9001`, and it **retires the job**, repeating trigger or not. Because the capture is a
+  snapshot (below), a refusal is a permanent property of that job rather than a bad run: rescheduling
+  it would re-refuse on every interval forever, turning one deny into an unbounded failure stream.
+- **A settled job releases what it was holding.** The handle stays addressable by id — that is what
+  post-mortem lookup needs — but the job body and the captured identity are dropped once the job can
+  no longer run. Keeping them would pin one closure and one identity per job the scheduler has ever
+  run, for the scheduler's whole life. A job cancelled mid-flight releases when the body returns, not
+  when the cancel lands.
 - **The capture is a snapshot.** A job firing an hour after submission carries the identity that
   scheduled it, which may since have lost the rights it holds. Re-validating a token at dispatch time
   is an identity decision, not a scheduling one, and is out of scope here.

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
@@ -26,8 +26,15 @@ final class CommunityJobHandle implements JobHandle {
 
     private final CommunityJobRegistry registry;
     private final String jobId;
-    private final JobDescriptor descriptor;
-    private final CapturedContext context;
+    private final String jobName;
+
+    // Not final, and nulled on terminal settle: the descriptor holds the application's job body and
+    // the captured context holds the submitter's PrincipalContext and StorageContext. A handle stays
+    // addressable by id after the job ends, so keeping these alive would pin one closure and one
+    // identity per job the scheduler has ever run, for the scheduler's lifetime. Nothing reads them
+    // past the settle — the trigger is consulted while deciding it, not after.
+    private JobDescriptor descriptor;
+    private CapturedContext context;
 
     private long dueNanos;
     private JobState state = JobState.SCHEDULED;
@@ -39,6 +46,8 @@ final class CommunityJobHandle implements JobHandle {
         this.jobId = jobId;
         this.descriptor = descriptor;
         this.context = context;
+        // Copied out because jobName() must keep answering once the descriptor is released.
+        this.jobName = descriptor.jobName();
         this.dueNanos = dueNanos;
     }
 
@@ -49,7 +58,7 @@ final class CommunityJobHandle implements JobHandle {
 
     @Override
     public String jobName() {
-        return descriptor.jobName();
+        return jobName;
     }
 
     @Override
@@ -70,6 +79,17 @@ final class CommunityJobHandle implements JobHandle {
 
     /* default */ CapturedContext context() {
         return context;
+    }
+
+    /**
+     * Drops the job body and the submitter's identity once the job can no longer run.
+     *
+     * <p>Caller holds the lock. Idempotent — a settle can be reached from cancellation, from a
+     * one-shot completing, and from scheduler shutdown.
+     */
+    /* default */ void releasePayload() {
+        this.descriptor = null;
+        this.context = null;
     }
 
     /* default */ long dueNanos() {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
@@ -76,12 +76,19 @@ final class CommunityJobHandle implements JobHandle {
         return registry.cancel(this);
     }
 
+    /**
+     * The job body and trigger, or {@code null} once the job has settled.
+     *
+     * <p>Callers on the dispatch path never see null: a settled job is out of the queue, so nothing
+     * reaches {@code execute()} for it. Callers deciding what happens NEXT must order their checks
+     * so this is not read after a settle — {@code finishRun} tests {@code !running} first for
+     * exactly that reason.
+     */
     /* default */ JobDescriptor descriptor() {
         return descriptor;
     }
 
-
-
+    /** The submitter's captured identity, or {@code null} once the job has settled. */
     /* default */ CapturedContext context() {
         return context;
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobHandle.java
@@ -22,6 +22,11 @@ import eu.exeris.kernel.spi.scheduling.JobState;
  *
  * @since 0.11.0
  */
+// TooManyMethods: the JobHandle contract itself is most of them, and releasePayload/settle add the
+// lifecycle the payload release needs. Splitting would put the released fields and the code that
+// releases them in different classes, which is the one arrangement that makes the invariant harder
+// to check.
+@SuppressWarnings("PMD.TooManyMethods")
 final class CommunityJobHandle implements JobHandle {
 
     private final CommunityJobRegistry registry;
@@ -87,6 +92,10 @@ final class CommunityJobHandle implements JobHandle {
      * <p>Caller holds the lock. Idempotent — a settle can be reached from cancellation, from a
      * one-shot completing, and from scheduler shutdown.
      */
+    // NullAssignment is the point, not a smell: absence is the state being recorded. There is no
+    // sentinel a JobDescriptor or a CapturedContext could take instead that would not itself keep a
+    // closure and an identity alive, which is the whole reason for the release.
+    @SuppressWarnings("PMD.NullAssignment")
     /* default */ void releasePayload() {
         this.descriptor = null;
         this.context = null;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobRegistry.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobRegistry.java
@@ -97,8 +97,14 @@ final class CommunityJobRegistry {
             if (handle.isTerminal() || handle.rawState() == JobState.CANCELLED) {
                 return false;
             }
+            boolean wasRunning = handle.rawState() == JobState.RUNNING;
             handle.rawState(JobState.CANCELLED);
             queue.remove(handle);
+            // Not while a body is in flight — it is still reading the descriptor. finishRun() releases
+            // that one when the run ends.
+            if (!wasRunning) {
+                settle(handle);
+            }
             clock.signal();
             return true;
         } finally {
@@ -118,10 +124,13 @@ final class CommunityJobRegistry {
         clock.lock().lock();
         try {
             if (handle.rawState() == JobState.CANCELLED) {
+                // Cancelled mid-run: the body has now finished, so the payload it was reading can go.
+                settle(handle);
                 return;
             }
             if (!running || handle.descriptor().trigger() instanceof JobTrigger.OneShot) {
                 handle.rawState(outcome);
+                settle(handle);
                 return;
             }
             // SCHEDULED, not the outcome: a requeued job reporting COMPLETED would look terminal to
@@ -136,6 +145,42 @@ final class CommunityJobRegistry {
         }
     }
 
+    /**
+     * Caller holds the lock. Drops what a job that can no longer run was holding.
+     *
+     * <p>The handle itself stays in {@link #jobs} so {@code scheduler.handle(id)} keeps answering —
+     * that reachability is what ADR-057 §6 asks for. What goes is the application's job body and the
+     * submitter's identity, which would otherwise be pinned for the scheduler's whole life, once per
+     * job it has ever run.
+     */
+    private void settle(CommunityJobHandle handle) {
+        handle.releasePayload();
+        triggers.forget(handle.jobId());
+    }
+
+    /**
+     * Retires a job that can never dispatch, whatever its trigger says.
+     *
+     * <p>Distinct from {@link #finishRun}: that one asks the trigger whether to run again, which is
+     * the right question after a run and the wrong one after a refusal. A job refused for having no
+     * captured context will be refused identically on every future fire — the context is captured at
+     * submission and does not come back — so requeueing it produces an endless failure loop rather
+     * than a retry.
+     */
+    /* default */ void settleUnrunnable(CommunityJobHandle handle, JobState outcome) {
+        clock.lock().lock();
+        try {
+            if (handle.rawState() != JobState.CANCELLED) {
+                handle.rawState(outcome);
+            }
+            queue.remove(handle);
+            settle(handle);
+            clock.signal();
+        } finally {
+            clock.lock().unlock();
+        }
+    }
+
     /** Caller holds the lock. Stops accepting work and settles everything still queued. */
     /* default */ void shutdown() {
         running = false;
@@ -143,6 +188,7 @@ final class CommunityJobRegistry {
             if (!handle.isTerminal()) {
                 handle.rawState(JobState.COMPLETED);
             }
+            settle(handle);
         }
         queue.clear();
         clock.signal();

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobRegistry.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobRegistry.java
@@ -25,6 +25,10 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @since 0.11.0
  */
+// TooManyMethods: settle/settleUnrunnable are two more terminal paths on a class that already owns
+// every one of them. Concentrating them here is what makes "a settled job releases its payload"
+// checkable in one place.
+@SuppressWarnings("PMD.TooManyMethods")
 final class CommunityJobRegistry {
 
     private final CommunitySchedulerClock clock;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobScheduler.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityJobScheduler.java
@@ -171,6 +171,7 @@ public final class CommunityJobScheduler implements JobScheduler {
         // Pessimistic: an Error escaping the body unwinds through the finally below, and retiring it
         // as COMPLETED would record a job that died as one that succeeded.
         JobState outcome = JobState.FAILED;
+        boolean unrunnable = false;
         try {
             if (!registry.isRunningNow()) {
                 // close() may have snapshotted inFlight and joined this worker before it was ever
@@ -184,11 +185,16 @@ public final class CommunityJobScheduler implements JobScheduler {
                 // acquires authority nobody granted it.
                 CommunityJobJfrEvents.emitFailure(schedulerName, handle.jobName(), handle.jobId(),
                         KernelErrorCodes.EX_JOB_9001, NO_CONTEXT_REASON);
+                // Terminal, not just failed. The context is captured once at submission, so a refusal
+                // here is a permanent property of this job, not a bad run: rescheduling a repeating
+                // one re-refuses on every interval, forever, emitting the same failure event and
+                // never settling. A job that can never dispatch must stop being due.
+                unrunnable = true;
                 return;
             }
             outcome = execute(handle);
         } finally {
-            retire(handle, outcome);
+            retire(handle, outcome, unrunnable);
         }
     }
 
@@ -214,12 +220,16 @@ public final class CommunityJobScheduler implements JobScheduler {
         return JobState.COMPLETED;
     }
 
-    private void retire(CommunityJobHandle handle, JobState outcome) {
+    private void retire(CommunityJobHandle handle, JobState outcome, boolean unrunnable) {
         clock.lock().lock();
         try {
             inFlight.remove(Thread.currentThread());
         } finally {
             clock.lock().unlock();
+        }
+        if (unrunnable) {
+            registry.settleUnrunnable(handle, outcome);
+            return;
         }
         registry.finishRun(handle, outcome);
     }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityTriggerClock.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityTriggerClock.java
@@ -40,6 +40,11 @@ final class CommunityTriggerClock {
         }
     }
 
+    /** Drops a settled job's compiled cron schedule; harmless for a job that never had one. */
+    /* default */ void forget(String jobId) {
+        cronSchedules.remove(jobId);
+    }
+
     /* default */ long firstDue(String jobId, JobTrigger trigger) {
         return switch (trigger) {
             case JobTrigger.OneShot(Duration delay) -> clock.nanoTime() + delay.toNanos();

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityJobLifecycleTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityJobLifecycleTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.scheduling;
+
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.scheduling.JobDescriptor;
+import eu.exeris.kernel.spi.scheduling.JobScheduler;
+import eu.exeris.kernel.spi.scheduling.JobSchedulerConfig;
+import eu.exeris.kernel.spi.scheduling.JobState;
+import eu.exeris.kernel.spi.scheduling.JobTrigger;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a job stops holding, and when — the settle half of the scheduler's lifecycle.
+ *
+ * <h2>Why these assertions reach past the SPI</h2>
+ * <p>{@link eu.exeris.kernel.spi.scheduling.JobHandle} deliberately keeps answering after a job ends
+ * (ADR-057 §6), so at the SPI level a settled job and one that merely finished look identical. The
+ * difference is what the handle still points at: the application's job body and the submitter's
+ * captured identity. Nothing in the public contract can see that, which is why these are
+ * package-local — the alternative is not a better test but no test, which is what this path had.
+ *
+ * <h2>The one that was not covered</h2>
+ * <p>A context-less job is refused fail-closed, and {@code CommunityJobJfrTest} already covers that
+ * for a <b>one-shot</b> trigger — the shape that retired correctly even before this was repaired,
+ * because a one-shot retires whatever the outcome. A <b>repeating</b> trigger is the shape that did
+ * not: the refusal left it runnable, so it came due again on the next interval and was refused again
+ * for a reason that cannot change between intervals, since the context is captured once at
+ * submission and never re-derived.
+ */
+@DisplayName("CommunityJobScheduler — what a settled job releases")
+class CommunityJobLifecycleTest {
+
+    private static final long TIMEOUT_SECONDS = 5L;
+    private static final Duration INTERVAL = Duration.ofMinutes(1);
+    /** Intervals stepped past a refusal — a job still due would fire this many more times. */
+    private static final int EXTRA_INTERVALS = 3;
+    /** Run count that proves a repeating job survived its first settle decision. */
+    private static final int SECOND_RUN = 2;
+
+    @Nested
+    @DisplayName("A job that can never dispatch")
+    class Unrunnable {
+
+        @Test
+        @DisplayName("a REPEATING context-less job retires instead of coming due again")
+        void repeatingContextLessJobRetires() {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+            AtomicInteger bodyRuns = new AtomicInteger();
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                // Submitted with no context bound at all — the fail-closed refusal (ADR-057 §5).
+                CommunityJobHandle handle = (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                        "unscoped-repeating",
+                        new JobTrigger.FixedInterval(Duration.ZERO, INTERVAL),
+                        bodyRuns::incrementAndGet));
+
+                // Waiting on state() would race: finishRun() sets FAILED and only THEN computes the
+                // next deadline, so a test that advanced the clock on seeing FAILED could sail past
+                // the requeue and never observe it. Waiting for the release is waiting for the
+                // settle itself to be complete, which is the fact under test.
+                awaitReleased(handle);
+
+                for (int i = 0; i < EXTRA_INTERVALS; i++) {
+                    clock.advance(INTERVAL);
+                }
+
+                assertThat(handle.state())
+                        .as("terminal after one refusal — a job whose context can never come back "
+                            + "is not a job having a bad run")
+                        .isEqualTo(JobState.FAILED);
+                assertThat(bodyRuns)
+                        .as("and the body never ran, refusal or not")
+                        .hasValue(0);
+            }
+        }
+
+        @Test
+        @DisplayName("jobName() still answers after the descriptor is released")
+        void jobNameSurvivesRelease() {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                CommunityJobHandle handle = (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                        "named", new JobTrigger.OneShot(Duration.ZERO), () -> { }));
+                awaitReleased(handle);
+
+                // jobName() used to read through the descriptor. Releasing it without copying the
+                // name out turns every post-mortem lookup — the thing ADR-057 §6 keeps the handle
+                // addressable FOR — into a NullPointerException.
+                assertThat(handle.jobName()).isEqualTo("named");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("A job that finishes")
+    class Finished {
+
+        @Test
+        @DisplayName("a completed one-shot drops its body and the submitter's identity")
+        void completedOneShotReleasesPayload() {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+            CountDownLatch ran = new CountDownLatch(1);
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                CommunityJobHandle handle = ScopedValue
+                        .where(KernelProviders.STORAGE_CONTEXT,
+                                ImmutableStorageContext.shared("tenant-alpha"))
+                        .call(() -> (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                                "reporting", new JobTrigger.OneShot(Duration.ZERO),
+                                ran::countDown)));
+                awaitQuietly(ran);
+                awaitReleased(handle);
+
+                assertThat(handle.context())
+                        .as("the captured context carries the submitter's identity; a scheduler that "
+                            + "kept one per job it has ever run pins an identity per job, forever")
+                        .isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("a repeating job keeps its body between runs")
+        void repeatingJobKeepsPayloadBetweenRuns() {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+            AtomicInteger runs = new AtomicInteger();
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                CommunityJobHandle handle = ScopedValue
+                        .where(KernelProviders.STORAGE_CONTEXT,
+                                ImmutableStorageContext.shared("tenant-alpha"))
+                        .call(() -> (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                                "heartbeat",
+                                new JobTrigger.FixedInterval(Duration.ZERO, INTERVAL),
+                                runs::incrementAndGet)));
+
+                // The guard on the release: a settle that fired after every run would leave the
+                // second dispatch with no body to call. Two runs is the smallest proof it does not.
+                awaitRuns(runs, SECOND_RUN, clock);
+
+                // At least, not exactly: the loop advances until the count moves, and a step can
+                // carry the clock past more than one deadline. The claim is that a second run
+                // happened at all, which is what a premature release would have made impossible.
+                assertThat(runs.get()).isGreaterThanOrEqualTo(SECOND_RUN);
+                assertThat(handle.descriptor()).as("still holds its body, having not settled").isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("A job that is cancelled")
+    class Cancelled {
+
+        @Test
+        @DisplayName("cancelling a queued job releases immediately")
+        void cancellingQueuedJobReleases() {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                CommunityJobHandle handle = ScopedValue
+                        .where(KernelProviders.STORAGE_CONTEXT,
+                                ImmutableStorageContext.shared("tenant-alpha"))
+                        .call(() -> (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                                "far-future",
+                                new JobTrigger.OneShot(Duration.ofHours(1)),
+                                () -> { })));
+
+                assertThat(handle.cancel()).isTrue();
+                assertThat(handle.descriptor())
+                        .as("nothing is reading it — the job never started")
+                        .isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("cancelling a RUNNING job waits for the body before releasing")
+        void cancellingRunningJobDefersRelease() throws InterruptedException {
+            VirtualSchedulerClock clock = new VirtualSchedulerClock();
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch release = new CountDownLatch(1);
+
+            try (JobScheduler scheduler = new CommunityJobScheduler(
+                    new JobSchedulerConfig("lifecycle"), clock)) {
+                CommunityJobHandle handle = ScopedValue
+                        .where(KernelProviders.STORAGE_CONTEXT,
+                                ImmutableStorageContext.shared("tenant-alpha"))
+                        .call(() -> (CommunityJobHandle) scheduler.submit(new JobDescriptor(
+                                "in-flight", new JobTrigger.OneShot(Duration.ZERO), () -> {
+                                    started.countDown();
+                                    awaitQuietly(release);
+                                })));
+                assertThat(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+
+                assertThat(handle.cancel()).isTrue();
+                assertThat(handle.descriptor())
+                        .as("the body is mid-flight and execute() is still reading this descriptor; "
+                            + "releasing on the canceller's thread would null it under the runner")
+                        .isNotNull();
+
+                release.countDown();
+                awaitReleased(handle);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Fixture
+    // =========================================================================
+
+    /**
+     * Polls until the handle has dropped its payload.
+     *
+     * <p>Polling, not sleeping: it returns the moment the settle lands, and its bound is a failure
+     * timeout rather than a delay every run pays. A handle that never releases fails the assertion
+     * that follows rather than hanging the suite.
+     */
+    private static void awaitReleased(CommunityJobHandle handle) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (handle.descriptor() != null && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertThat(handle.descriptor())
+                .as("a job that can no longer run must not keep the application's body alive; the "
+                    + "handle stays addressable by id, what it points at does not")
+                .isNull();
+    }
+
+    /**
+     * Advances the virtual clock until the body has run {@code target} times.
+     *
+     * <p>Advancing a fixed number of intervals up front does not work: the next deadline is computed
+     * from the clock as it stands when the previous run FINISHES, so every advance can land before
+     * the requeue and leave the job due in a future the test already skipped past. Stepping until the
+     * count moves is indifferent to where the requeue lands.
+     */
+    private static void awaitRuns(AtomicInteger runs, int target, VirtualSchedulerClock clock) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (runs.get() < target && System.nanoTime() < deadline) {
+            clock.advance(INTERVAL);
+            Thread.onSpinWait();
+        }
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException _) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Part of the v0.11 release-review fix sweep. Two findings, both ending in something that is never released.

## A settled job kept its payload for the scheduler's lifetime

`CommunityJobRegistry.jobs` and `CommunityTriggerClock.cronSchedules` were write-only: cancel, a one-shot completing, and shutdown all left the entry behind.

The handle staying reachable is **deliberate** — ADR-057 §6 wants a dispatch no handle can reach to be impossible, and the TCK pins addressability by id. What rode along with it was not: the application's **job body** (one closure per job) and the submitter's **`PrincipalContext` and `StorageContext`** — one captured identity per job the scheduler had ever run, pinned for as long as the scheduler lived.

So the handle stays and the payload goes. `descriptor` and `context` are dropped at every terminal settle; `jobName` is copied out at construction because it must keep answering afterwards. Cancellation of a `RUNNING` job defers the release to `finishRun`, since the body is still reading the descriptor at that moment.

## A repeating job with an empty context re-fired forever and never settled

A repeating job whose `CapturedContext` is empty is refused fail-closed on every fire — and rescheduled anyway. The context is captured **once at submission**, so the refusal is a permanent property of the job rather than a bad run: it re-fired every interval forever, emitting an `EX-JOB-9001` failure event each time and never settling.

`finishRun` asks the trigger whether to run again, which is the right question after a run and the wrong one after a *refusal* — hence `settleUnrunnable`, which retires the job whatever its trigger says.

## Verification

`mvn clean install` green; community 1515 tests, core 1235; lint in cycle (no skip flags); `ExerisArchitectureTest` green.

## Owed test debt

A TCK case for the second finding: a repeating job submitted with an empty context settles instead of re-firing. Belongs in the scheduling TCK because it is contract behaviour a provider must reproduce, not a Community detail. Tracked, not blocking.

## Notes for review

- Community-only; no SPI change, no Core change.
- The addressability property ADR-057 §6 asks for is **preserved** — `jobId` → handle → state still answers after settle. Only the payload is released. Worth checking that reading in review, since it is the one thing this change must not break.
- Docs: `NO_DOC_IMPACT`.
