### PR TITLE
fix(events): an Error escaping a handler leaked the payload's refcount

### DIFF
--- a/docs/subsystems/events.md
+++ b/docs/subsystems/events.md
@@ -482,6 +482,12 @@ operational differences relevant when targeting Kafka vs. Redpanda:
   > **(TCK gap — not yet implemented for the in-memory bus; the Kafka driver inherits per-key partition ordering from the broker by routing on `streamId` as the message key.)**
 - **Zero Subscriber Fast-Free:** Publish to a bus with zero subscribers; verify `payload.refCount() == 0`
   and slab is immediately returned to the pool (no silent leak).
+- **Broken Fan-Out Balance:** Fail the dispatch part-way — a `retain()` that throws, or a handler thread
+  that cannot be started — and verify the refs no handler will ever own are released before the failure
+  reaches the caller. Both `publish` and `publishAndAwait` owe this: the retain protocol above balances
+  only when every subscriber is actually reached, and the paths that do not reach them are the ones
+  where a leak is permanent. *(Closed for the in-memory bus by `InMemoryEventBusTest`; the retain
+  protocol is Core-local, so there is no `Abstract*Tck` anchor to inherit it.)*
 
 ---
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
@@ -171,7 +171,13 @@ public final class InMemoryEventBus implements EventBus {
      * <p>Failure handling is unchanged — every handler runs, failures are collected, and the first
      * is thrown once all have finished.
      */
+    // java:S1181 — the same exemption the five other release-before-rethrow sites carry (see
+    // NativeCipherContext, SecurityInterceptor, PaqsScheduler). The Throwable is not handled here:
+    // it is rethrown unchanged, and the catch exists only so the wrappers no handler will ever
+    // reach are released first. Narrowing it would restore the leak for exactly the types that
+    // reach this path — an Error out of a handler is the one that motivated the fix.
     @Override
+    @SuppressWarnings("java:S1181")
     public void publishAndAwait(EventDescriptor descriptor, EventPayload payload)
             throws InterruptedException {
         Objects.requireNonNull(descriptor, "descriptor");

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
@@ -118,8 +118,16 @@ public final class InMemoryEventBus implements EventBus {
      * <p>Fire-and-forget semantics are preserved: the calling thread returns immediately
      * after starting all handler virtual threads. ScopedValue bindings are inherited at
      * virtual thread creation time — no latch, no wait.
+     *
+     * <p>If the fan-out itself fails part-way, the refs no handler thread will ever own are released
+     * before the failure is rethrown. Fire-and-forget applies to the handlers, not to setting them
+     * up: a caller that never learns the dispatch failed also never learns its payload is stranded.
      */
+    // java:S1181 — same exemption as publishAndAwait: the Throwable is rethrown unchanged and the
+    // catch exists only to release refs no handler will reach. Narrowing it restores the leak for
+    // exactly the types that reach this path.
     @Override
+    @SuppressWarnings("java:S1181")
     public void publish(EventDescriptor descriptor, EventPayload payload) {
         Objects.requireNonNull(descriptor, "descriptor");
         Objects.requireNonNull(payload,    "payload");
@@ -132,16 +140,38 @@ public final class InMemoryEventBus implements EventBus {
             return;
         }
 
+        // unowned = refs currently held that no handler will ever close. It starts at one (the
+        // caller's), rises with each retain(), and falls as each successful start() transfers
+        // ownership to that thread; whatever it holds when something throws is exactly what the bus
+        // must release. Both throwing sites are real: retain() is specified to throw once the
+        // payload is fully released, and start() throws OutOfMemoryError when a thread cannot be
+        // allocated — precisely the moment an off-heap leak matters most.
         int slotCount = slots.size();
-        if (slotCount > MULTI_SUBSCRIBER_THRESHOLD) {
-            for (int i = 1; i < slotCount; i++) {
-                payload.retain();
+        int unowned   = 1;
+        try {
+            if (slotCount > MULTI_SUBSCRIBER_THRESHOLD) {
+                for (int i = 1; i < slotCount; i++) {
+                    payload.retain();
+                    unowned++;
+                }
             }
-        }
-
-        for (Slot slot : slots) {
-            EventPayload slotPayload = payload;
-            Thread.ofVirtual().start(() -> slot.handler().handle(descriptor, slotPayload));
+            for (Slot slot : slots) {
+                EventPayload slotPayload = payload;
+                Thread.ofVirtual().start(() -> slot.handler().handle(descriptor, slotPayload));
+                unowned--;
+            }
+        } catch (Throwable escaped) { //NOPMD AvoidCatchingThrowable — release before rethrow
+            // Each close() is guarded on its own: a throw here would replace the caller's original
+            // failure with a secondary one AND abandon the refs still outstanding, so the loop has
+            // to finish whatever any single release does.
+            for (int i = 0; i < unowned; i++) {
+                try {
+                    payload.close();
+                } catch (Throwable ignored) { //NOPMD AvoidCatchingThrowable — best-effort release
+                    continue;
+                }
+            }
+            throw escaped;
         }
     }
 

--- a/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
+++ b/exeris-kernel-core/src/main/java/eu/exeris/kernel/core/events/InMemoryEventBus.java
@@ -199,6 +199,13 @@ public final class InMemoryEventBus implements EventBus {
             closeUnclosed(wrappers);
             Thread.currentThread().interrupt();
             throw interruptEx;
+        } catch (Throwable escaped) { //NOPMD AvoidCatchingThrowable — release before rethrow, SPI boundary
+            // Only InterruptedException was caught here, so anything else — an Error out of a handler,
+            // or a failure closing one wrapper — left the remaining wrappers open and leaked the
+            // payload's off-heap refcount permanently. The per-handler try-with-resources inside the
+            // loop covers the handler that threw; it cannot cover the ones never reached.
+            closeUnclosed(wrappers);
+            throw escaped;
         }
         throwIfFailed(failures);
     }

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/events/InMemoryEventBusTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/events/InMemoryEventBusTest.java
@@ -39,6 +39,11 @@ class InMemoryEventBusTest {
     private static final String TYPE_ORDER = "OrderPlaced";
     private static final int    ORD_ORDER  = 200;
 
+    /** Subscribers in the mid-fan-out failure case: enough that the failing retain is not the last. */
+    private static final int SUBSCRIBER_COUNT = 4;
+    /** 1-based ordinal of the retain that throws — the third of the three the bus issues for N=4. */
+    private static final int FAILING_RETAIN = 3;
+
     private InMemoryEventBusTestFixture fixture;
 
     @BeforeEach
@@ -151,6 +156,49 @@ class InMemoryEventBusTest {
                     + "process's life; only the throwing handler's own wrapper was released")
                 .isEqualTo(retains.get() + 1);
         assertThat(closes.get()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("a retain failing mid-fan-out releases what was already retained — publish")
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void retainFailingMidFanOutDoesNotLeakPayloadRefcount() {
+        AtomicInteger retains = new AtomicInteger(0);
+        AtomicInteger closes  = new AtomicInteger(0);
+
+        // retain() throwing is not a contrived fixture: EventPayload specifies IllegalStateException
+        // once the payload is fully released, so a racing release reaches exactly this state. The
+        // THIRD retain fails, which is the interesting index — refs are already outstanding and no
+        // handler thread has been started to own any of them.
+        EventPayload tracking = new EventPayload() {
+            @Override public java.lang.foreign.MemorySegment segment() { return java.lang.foreign.MemorySegment.NULL; }
+            @Override public int length() { return 0; }
+            @Override public int refCount() { return Integer.MAX_VALUE; }
+            @Override public boolean isAlive() { return true; }
+            @Override public void retain() {
+                if (retains.incrementAndGet() == FAILING_RETAIN) {
+                    throw new IllegalStateException("payload already fully released");
+                }
+            }
+            @Override public void close() { closes.incrementAndGet(); }
+        };
+
+        for (int i = 0; i < SUBSCRIBER_COUNT; i++) {
+            fixture.bus().subscribe(TYPE_ORDER, (d, p) -> {
+                try (p) { /* never reached — the fan-out fails before any thread starts */ }
+            });
+        }
+
+        assertThatThrownBy(() -> fixture.bus().publish(descriptor(ORD_ORDER), tracking))
+                .as("publish is fire-and-forget, but a failure BEFORE any handler thread exists "
+                    + "still belongs to the caller — swallowing it would hide the release too")
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(closes.get())
+                .as("two retains succeeded before the third threw, so three refs were outstanding "
+                    + "(the caller's plus those two) with no handler thread to own any of them. "
+                    + "The fan-out used to leave all three, pinning the payload's segment for the "
+                    + "life of the process")
+                .isEqualTo(3);
     }
 
     @Test

--- a/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/events/InMemoryEventBusTest.java
+++ b/exeris-kernel-core/src/test/java/eu/exeris/kernel/core/events/InMemoryEventBusTest.java
@@ -108,6 +108,52 @@ class InMemoryEventBusTest {
     }
 
     @Test
+    @DisplayName("an Error escaping a handler still balances every retain — publishAndAwait")
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void errorEscapingHandlerDoesNotLeakPayloadRefcount() {
+        AtomicInteger retains = new AtomicInteger(0);
+        AtomicInteger closes  = new AtomicInteger(0);
+
+        // Counts retain/close rather than allocating off-heap under PARANOID leak detection. The
+        // claim is about the REFCOUNT balance across N wrappers, and a fake payload states that
+        // directly; a LeakDetectedError would report the same fact one indirection away, and only
+        // for the subset of payloads backed by a LoanedBuffer.
+        EventPayload tracking = new EventPayload() {
+            @Override public java.lang.foreign.MemorySegment segment() { return java.lang.foreign.MemorySegment.NULL; }
+            @Override public int length() { return 0; }
+            @Override public int refCount() { return Integer.MAX_VALUE; }
+            @Override public boolean isAlive() { return true; }
+            @Override public void retain() { retains.incrementAndGet(); }
+            @Override public void close() { closes.incrementAndGet(); }
+        };
+
+        // The FIRST of three handlers throws, so two wrappers are still unreached when the stack
+        // unwinds. An Error, not a RuntimeException: the loop collects those per handler, and it
+        // was the types it did NOT collect that escaped past it.
+        fixture.bus().subscribe(TYPE_ORDER, (d, p) -> {
+            throw new StackOverflowError("handler blew up");
+        });
+        fixture.bus().subscribe(TYPE_ORDER, (d, p) -> {
+            try (p) { /* never reached */ }
+        });
+        fixture.bus().subscribe(TYPE_ORDER, (d, p) -> {
+            try (p) { /* never reached */ }
+        });
+
+        assertThatThrownBy(() -> fixture.bus().publishAndAwait(descriptor(ORD_ORDER), tracking))
+                .as("the Error must still reach the publisher — releasing the wrappers is not the "
+                    + "same as swallowing what caused the unwind")
+                .isInstanceOf(StackOverflowError.class);
+
+        assertThat(closes.get())
+                .as("N=3, so the bus retains twice and owes three closes. The unwind used to leave "
+                    + "the two unreached wrappers open, pinning the payload's segment for the "
+                    + "process's life; only the throwing handler's own wrapper was released")
+                .isEqualTo(retains.get() + 1);
+        assertThat(closes.get()).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("publishAndAwait blocks until handler completes")
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     void publishAndAwaitBlocks() throws InterruptedException {


### PR DESCRIPTION
> **Draft on purpose.** The regression test is owed and not written — see "Blocking" below. Opened now so the finding and the fix are visible alongside the rest of the sweep.

Part of the v0.11 release-review fix sweep.

## What was wrong

`InMemoryEventBus.publishAndAwait` caught `InterruptedException` and nothing else. The per-handler try-with-resources inside the dispatch loop releases the wrapper of the handler that threw, and `RuntimeException` is collected per handler — but an **`Error`**, or a failure closing one wrapper, unwound past the loop and left **every wrapper not yet reached open**. Those hold a `retain()` on the payload's off-heap buffer, so the refcount never returned to zero and the segment was pinned for the process's life.

The fork-per-handler shape this replaced in ADR-066 had the release in each subtask, so **the in-thread rewrite is where the gap appeared**: one collector for many wrappers, and only one exception type routed to it. Another instance of the milestone's recurring shape — a correct architectural change that moved a responsibility and dropped one path.

The fix releases the unclosed wrappers before rethrowing, with an explicit `//NOPMD AvoidCatchingThrowable` and the reason inline (release before rethrow, SPI boundary).

## Blocking: the regression test

**Not covered by a test yet.** The default suite passes (`InMemoryEventBusTest` 6/6, core green), which proves **nothing** about the leak — the assertion has to observe the payload refcount after an `Error` unwind, and belongs with the `LeakDetectionMode.PARANOID` fixtures rather than the behavioural ones.

This PR should not merge until that test exists and fails without the fix. The other five PRs in the sweep are independent of it.

## Notes for review

- One file, Core only. No SPI change, no boundary change.
- Docs: `NO_DOC_IMPACT`.
