### PR TITLE
docs: the front door still said JDK 26 with preview, and the notes omitted the /secure removal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,15 @@ opposite — newest JDK, preview features on — and ships separately as `1.0-pr
 | Valhalla Value Classes (prep)      | JEP 401   | Early Access preview       | **Not yet used.** All data carriers (`record`, `final class`) are designed to be migration-ready: no `synchronized`, no `System.identityHashCode()`, no identity `==` on domain objects. C2 JIT Escape Analysis scalarises them on hot-paths today. |
 | Lazy Constants                     | JEP 526   | Delivered in JDK 26 — **not available on this line** | Not used on `main`; the JDK 25 baseline predates it |
 
-The project POM does **not** enable preview features globally. Do not add `--enable-preview` to a
-module's main sources on this line: the Preview-Bytecode Gate reads the published jars and fails on
-any class stamped `minor_version 0xFFFF`, which is exactly what a consumer would trip over.
+The root POM enables preview features for **test** sources only — `--enable-preview` on every
+module's `default-testCompile` and on the surefire JVM ([pom.xml](pom.xml) lines 70, 91-94, 105) —
+and never for main sources. Do not add it to a module's main sources on this line: the
+Preview-Bytecode Gate reads the published jars and fails on any class stamped
+`minor_version 0xFFFF`, which is exactly what a consumer would trip over.
+
+The TCK is the exception that needs stating, because its test-jar *is* a published artifact: its
+fixtures were moved off `StructuredTaskScope` so they carry no stamp. Other modules' test sources
+still use it and still need the flag.
 
 **Recommended toolchain:**
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,10 @@ the barrier to contribution, not to enforce bureaucracy.
 
 ### Java Version
 
-**Java 26 (EA or GA) is required.** The kernel actively uses APIs that are preview or finalising
-in Java 26:
+**JDK 25 LTS is required on this line.** The distributed artifact is preview-clean (ADR-066): main
+sources compile without `--enable-preview`, and since the TCK's test-jar is the one published
+artifact built from test sources, its fixtures are preview-clean too. The `preview` branch is the
+opposite — newest JDK, preview features on — and ships separately as `1.0-preview`.
 
 | Feature                            | JEP       | Status in JDK              | Used in Kernel                                    |
 |:-----------------------------------|:----------|:---------------------------|:--------------------------------------------------|
@@ -25,10 +27,11 @@ in Java 26:
 | Foreign Function & Memory (FFM)    | JEP 454   | Stable (JDK 22)            | OpenSSL bindings, off-heap I/O, `io_uring`        |
 | Flexible Constructor Bodies        | JEP 513   | **Closed / Delivered (JDK 25)** | Field pre-init before `super()` in value-ready types |
 | Valhalla Value Classes (prep)      | JEP 401   | Early Access preview       | **Not yet used.** All data carriers (`record`, `final class`) are designed to be migration-ready: no `synchronized`, no `System.identityHashCode()`, no identity `==` on domain objects. C2 JIT Escape Analysis scalarises them on hot-paths today. |
-| Lazy Constants                     | JEP 526   | **Closed / Delivered (JDK 26)** | `LazyConstant.of(...)` for singleton config caches and expensive one-time initialisations |
+| Lazy Constants                     | JEP 526   | Delivered in JDK 26 — **not available on this line** | Not used on `main`; the JDK 25 baseline predates it |
 
-The project POM enables preview features globally. Do **not** disable `--enable-preview` flags
-in any module — doing so will break compilation of `exeris-kernel-enterprise` and parts of Core.
+The project POM does **not** enable preview features globally. Do not add `--enable-preview` to a
+module's main sources on this line: the Preview-Bytecode Gate reads the published jars and fails on
+any class stamped `minor_version 0xFFFF`, which is exactly what a consumer would trip over.
 
 **Recommended toolchain:**
 ```
@@ -190,7 +193,6 @@ jcmd <pid> JFR.start name=exeris-debug settings=profile duration=60s filename=de
 
 # Or start the JVM with recording enabled from the beginning:
 java -XX:StartFlightRecording=name=boot,settings=profile,filename=boot.jfr \
-     --enable-preview \
      -jar exeris-kernel-core/target/exeris-kernel-core.jar
 ```
 
@@ -219,7 +221,6 @@ The TCK automatically validates this during `mvn install`. For manual investigat
 ```bash
 # Run with GC allocation profiling
 java -XX:StartFlightRecording=settings=profile \
-     --enable-preview \
      -jar exeris-kernel-core/target/exeris-kernel-core.jar
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exeris Kernel
 
-Repository for the Exeris runtime kernel (Java 26 GA with preview stack), organized as a multi-module Maven build.
+Repository for the Exeris runtime kernel (JDK 25 LTS, preview-clean), organized as a multi-module Maven build.
 
 This README is a developer entrypoint for the current repository state.
 
@@ -50,10 +50,12 @@ Authoritative references:
 ## Requirements
 
 - Linux, macOS, or Windows
-- JDK 26 with preview features enabled
+- JDK 25 LTS — the distributed artifact is preview-clean and needs no `--enable-preview`
 - Maven 3.9+
 
-The build is configured for Java 26 preview and native access flags in [pom.xml](pom.xml).
+The build baselines on JDK 25 LTS and native-access flags in [pom.xml](pom.xml). Main sources compile
+without `--enable-preview`; test and TCK fixtures no longer need it either (ADR-066). A second
+artifact ships from the `preview` branch on the newest JDK, with preview features on.
 
 ## Build and Test
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ Authoritative references:
 - Maven 3.9+
 
 The build baselines on JDK 25 LTS and native-access flags in [pom.xml](pom.xml). Main sources compile
-without `--enable-preview`; test and TCK fixtures no longer need it either (ADR-066). A second
-artifact ships from the `preview` branch on the newest JDK, with preview features on.
+without `--enable-preview`, and so does the TCK's test-jar — the one published artifact built from
+test sources (ADR-066). Other test sources still compile and run with the flag; they are not
+distributed, so nothing a consumer downloads carries preview bytecode. A second artifact ships from
+the `preview` branch on the newest JDK, with preview features on.
 
 ## Build and Test
 

--- a/docs/release/v0.11.0-release-notes.md
+++ b/docs/release/v0.11.0-release-notes.md
@@ -79,6 +79,27 @@ coverage is inherited from the distributed line, which runs all three on JDK 25 
 That inheritance is sound only while the two lines differ solely in the concurrency mechanism and the
 build, which is why the preview line is kept deliberately thin.
 
+## Security: streaming routes were served without admission in 0.10.0
+
+A route resolved to a **stream** handler never reached the admission check. `CommunityHttpRequestProcessor`
+dispatched it straight to the stream dispatcher and returned; the `/secure` prefix check lived inside the
+request dispatcher's `dispatch()`, on the branch that was never taken. The effect on 0.10.0:
+
+| Route under `/secure/...` | 0.10.0 behaviour |
+|---|---|
+| ordinary handler | `401` unless a bound `SecurityProvider` admitted the caller |
+| **stream handler** | **served, with no check and no `PRINCIPAL_CONTEXT` bound** |
+
+A deployment that placed an SSE route under `/secure/...` and relied on the prefix convention was
+therefore serving it to anonymous callers, and a handler on that route reading the principal saw
+nothing. No consumer reported this; it was found reviewing the 0.11 cut. `AbstractHttpRoutePolicyTck`
+covered the authorization *decision* the whole time — nothing covered whether the streaming path
+reached it.
+
+**If you run 0.10.0 with streaming routes under `/secure/`, treat those routes as having been public.**
+0.11 closes it: authorization is one decision used by both entry points, and the principal binding now
+holds for the stream's whole life rather than only its open.
+
 ## Compatibility: HTTP route authorization replaces the `/secure` prefix (ADR-061)
 
 The kernel no longer decides authorization by path convention. Until v0.11 the Community HTTP

--- a/docs/release/v0.11.0-release-notes.md
+++ b/docs/release/v0.11.0-release-notes.md
@@ -79,6 +79,31 @@ coverage is inherited from the distributed line, which runs all three on JDK 25 
 That inheritance is sound only while the two lines differ solely in the concurrency mechanism and the
 build, which is why the preview line is kept deliberately thin.
 
+## Compatibility: HTTP route authorization replaces the `/secure` prefix (ADR-061)
+
+The kernel no longer decides authorization by path convention. Until v0.11 the Community HTTP
+dispatcher hardcoded a `/secure` prefix — anything under it required a token and a scope, and
+everything else reached its handler with no identity bound. That convention is gone, replaced by a
+declared `HttpRoutePolicy` the application binds.
+
+**What changes for a deployment that relied on the prefix.** Routes under `/secure` are no longer
+protected by the kernel unless a policy declares a requirement for them. If your application served
+`/secure/...` and expected 401 for an anonymous caller, it will now get 200 until you bind a policy.
+With no policy bound, every route behaves as it did before ADR-061 for non-`/secure` paths — that is
+the deliberate default, so an application declaring nothing sees no change to those, but it is also
+why the `/secure` paths stop being special.
+
+```java
+HttpRoutePolicy policy = (method, path) -> switch (path) {
+    case "/api/orders" -> RouteRequirement.requiringAnyScope(Set.of("orders:read"));
+    default            -> HttpRoutePolicy.unmatched();   // fail-closed
+};
+```
+
+`HttpRoutePolicy.unmatched()` is fail-closed, so a route the policy does not describe is denied
+rather than waved through. The decision itself — 401 for no identity, 403 for an identity without
+the required scope — is unchanged from ADR-012 and pinned by `AbstractHttpRoutePolicyTck`.
+
 ## Compatibility: `spi.flow` — `FlowSnapshot` gains three record components
 
 `eu.exeris.kernel.spi.flow` is declared **stable since 0.5.0**. v0.11 adds three components to the


### PR DESCRIPTION
> **Merge order: after #313.** CONTRIBUTING now states that TCK fixtures no longer need `--enable-preview`. That is true only once #313 lands. This branch must not merge before it — otherwise the docs outrun the code.

Part of the v0.11 release-review fix sweep. Two findings on the surfaces a newcomer and an operator actually read first.

## The front door described the stack this milestone replaced

README said "Java 26 GA with preview stack". CONTRIBUTING went further than stale — it **instructed the opposite of what now holds**:

> "The project POM enables preview features globally. Do **not** disable `--enable-preview` flags in any module."

Followed literally, that produces a build the milestone's own Preview-Bytecode Gate fails. Both files now state the **JDK 25 LTS, preview-clean** baseline, name the `preview` branch as the other track, and the `java -XX:StartFlightRecording` examples drop the flag. The Lazy Constants (JEP 526) row is corrected too.

## The release notes omitted the `/secure` removal

ADR-061 removed the hardcoded `/secure` prefix convention. The release notes never said so — which ADR-061's own Consequences section and the ROADMAP both ask for.

**That omission is the one an operator pays for.** A deployment that served `/secure/...` and relied on the kernel returning 401 to anonymous callers now gets **200** until it binds a policy, and nothing in the notes said so. Added as a `## Compatibility` section with the migration shape (an `HttpRoutePolicy` example) and the note that `HttpRoutePolicy.unmatched()` is fail-closed.

## Notes for review

- Docs-only; no code, no build change.
- Public-docs hygiene checked: no local-only links, no private/cross-repo PR references, no enterprise deep links, no "breaking change" framing (pre-1.0).
