### PR TITLE
fix(storage): the blob store's private files were reachable as objects

### DIFF
--- a/docs/subsystems/storage.md
+++ b/docs/subsystems/storage.md
@@ -125,6 +125,18 @@ of `objects` and nothing the caller controls is a direct child of the tenant dir
 are named by a random id rather than by the target key, so two concurrent uploads to one key no longer
 share a file. `CommunityFilesystemBlobNamespaceTest` holds these properties.
 
+**A staging file can outlive the process that made it, and the store does not sweep them.** A commit
+either moves the staging file into place or deletes it, and an abort deletes it — but a kill signal
+between opening the file and either outcome leaves it behind. The residue is bounded and harmless: it
+is a random id under `staging/`, addressable by nothing, and never resolved by a read.
+
+No sweep runs at store open, deliberately. A store root can be shared — two kernel instances, a rolling
+deployment overlapping old and new — and from the filesystem an orphan and another process's in-flight
+upload are the same thing: a staging file nobody here opened. Age does not separate them either, since
+a large upload is legitimately old. Deleting one mid-flight would fail a live commit for the sake of
+reclaiming a file nothing addresses. Reclaiming the space is therefore an operator task, and one they
+can do safely because they know which instances are running.
+
 ## Guards
 
 | Guard | What it holds |

--- a/docs/subsystems/storage.md
+++ b/docs/subsystems/storage.md
@@ -93,7 +93,9 @@ promise: scheme, structure, whether credentials are embedded, or whether it can 
 
 ## Filesystem driver notes
 
-Layout is `<root>/t-<hex(isolationKey)>/<container>/<key>`.
+Layout is `<root>/t-<hex(isolationKey)>/objects/<container>/<key>`, alongside two sibling trees the
+caller never addresses: `sidecars/<container>/<key>` for content types, and `staging/` for uploads in
+flight.
 
 The tenant directory is hex-encoded rather than used verbatim. `StorageContext.isolationKey()` is an
 unconstrained `String` — `ImmutableStorageContext.shared` does not validate it — so what it may contain
@@ -108,9 +110,20 @@ cases. A containment check after resolution backs it up.
 separator-bearing, deep-traversal, and injectivity cases fail, while the bare-`..` case still passes —
 which is why the claim above is stated in terms of separators rather than `..`.
 
-Uploads land in a `.uploading` staging file and are atomically moved into place on commit. Content type
-is kept in a `.ctype` sidecar, because a filesystem has nowhere else to put it; extended attributes would
-be tidier but are not portable across the filesystems a Community driver must run on.
+Uploads land in a staging file under `staging/` and are atomically moved into place on commit. Content
+type is kept in a sidecar under `sidecars/`, because a filesystem has nowhere else to put it; extended
+attributes would be tidier but are not portable across the filesystems a Community driver must run on.
+The default content type is represented by the *absence* of a sidecar, so recording it means deleting
+any the previous object left — an overwrite that only ever wrote would keep reporting the old type.
+
+Both files used to be named by appending `.uploading` and `.ctype` to the object's own path. `BlobRef`
+rejects traversal, not extensions, so those are endings a tenant may legitimately use: the suffix named
+another object of the same tenant rather than a private file, and an upload to `report` truncated and
+then moved away whatever was stored at `report.uploading`. Separate trees remove the collision instead
+of forbidding the keys that expose it; disjointness is structural, since a container is always a child
+of `objects` and nothing the caller controls is a direct child of the tenant directory. Staging files
+are named by a random id rather than by the target key, so two concurrent uploads to one key no longer
+share a file. `CommunityFilesystemBlobNamespaceTest` holds these properties.
 
 ## Guards
 
@@ -164,9 +177,11 @@ is enough to locate a fault without putting caller data into telemetry.
 
 ## S3-compatible driver notes
 
-Layout is the filesystem driver's, in a bucket: `t-<hex(isolationKey)>/<container>/<key>` under one
-bucket, path-style. One layout across both drivers means an operator reading a bucket listing and a
-directory tree sees the same structure. There is no containment re-check after resolution, unlike the
+Layout is `t-<hex(isolationKey)>/<container>/<key>` under one bucket, path-style — the filesystem
+driver's tenant prefix, without its `objects/` tree. S3 carries a content type as object metadata and
+stages a multipart upload server-side, so it has no private files to keep out of the caller's namespace
+and nothing to separate them from. The two layouts agree on everything an operator has to reason about
+— the tenant prefix, its encoding, and the container/key tail. There is no containment re-check after resolution, unlike the
 filesystem driver: nothing here normalises the key, so an assertion that a just-concatenated string
 starts with its own prefix would confirm its own last statement. `BlobRef` refuses relative-navigation
 segments, and the hex prefix is one opaque segment — the same two properties the filesystem layout rests

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobLayout.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobLayout.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HexFormat;
+import java.util.UUID;
 
 /**
  * Where a {@link BlobRef} lands on disk, and nothing else.
@@ -27,7 +28,26 @@ import java.util.HexFormat;
  * isolation key from becoming a directory name. The store's job is transfer mechanics; keeping the two
  * apart means a change to one is not read as a change to the other.
  *
- * <p>Layout: {@code <root>/t-<hex(isolationKey)>/<container>/<key>}.
+ * <p>Layout: {@code <root>/t-<hex(isolationKey)>/<tree>/…}, where {@code <tree>} is one of three
+ * fixed names — {@code objects}, {@code sidecars}, {@code staging}.
+ *
+ * <h2>Why three trees rather than suffixes</h2>
+ * <p>Content types and in-flight uploads used to be named by appending {@code .ctype} and
+ * {@code .uploading} to the object's own path. Both are legal key endings: {@link BlobRef} rejects
+ * traversal, not extensions, so {@code "report.uploading"} and {@code "photo.ctype"} are objects a
+ * tenant may legitimately store. The suffix therefore did not name a private file — it named
+ * <em>another object of the same tenant</em>, and every operation on the shorter key silently reached
+ * the longer one: an upload to {@code "report"} truncated and then moved away whatever was stored at
+ * {@code "report.uploading"}, and deleting {@code "photo"} deleted {@code "photo.ctype"} with it.
+ *
+ * <p>A driver may restrict keys further than the contract does, so refusing the two endings would
+ * have been permitted. It would also make one key work on one blob driver and fail on another for a
+ * reason the caller cannot see. Separating the namespaces removes the collision instead of forbidding
+ * the keys that expose it, and costs one path segment.
+ *
+ * <p>Disjointness is structural, not conventional: a container is always a child of {@code objects},
+ * so a container named {@code sidecars} lands at {@code objects/sidecars} and collides with nothing.
+ * Nothing the caller controls is ever a direct child of the tenant directory.
  *
  * @since 0.11.0
  */
@@ -37,13 +57,24 @@ final class CommunityFilesystemBlobLayout {
             CommunityBlobFailures.forProvider(CommunityBlobFailures.FILESYSTEM_PROVIDER);
 
     private static final String TENANT_PREFIX = "t-";
-    private static final String SIDECAR_SUFFIX = ".ctype";
+    private static final String OBJECT_TREE = "objects";
+    private static final String SIDECAR_TREE = "sidecars";
+    private static final String STAGING_TREE = "staging";
 
     private final Path root;
 
     /* default */ CommunityFilesystemBlobLayout(Path root) {
         this.root = root;
     }
+
+    /**
+     * The two paths one reference occupies: its bytes, and the sidecar recording its content type.
+     *
+     * <p>Resolved together because they share a tenant directory and a relative path, and because a
+     * caller that has one almost always needs the other — {@code stat} reads both, {@code delete}
+     * removes both.
+     */
+    /* default */ record BlobPaths(Path object, Path sidecar) { }
 
     /**
      * Resolves a tenant-relative reference to an absolute path inside the caller's tenant directory.
@@ -56,15 +87,38 @@ final class CommunityFilesystemBlobLayout {
      * @param operation the {@code CommunityBlobFailures.OP_*} constant for the call in flight, so a
      *                  denial is attributed to the operation the caller made rather than to resolution
      */
-    /* default */ Path resolve(BlobRef ref, String operation) {
+    /* default */ BlobPaths resolve(BlobRef ref, String operation) {
         StorageContext context = KernelProviders.storageContextOrSystem();
         Path tenantDir = tenantDirectoryOf(context, operation);
-        Path resolved = tenantDir.resolve(ref.container()).resolve(ref.key()).normalize();
-        if (!resolved.startsWith(tenantDir)) {
+        return new BlobPaths(
+                contain(tenantDir.resolve(OBJECT_TREE), ref, operation, context),
+                contain(tenantDir.resolve(SIDECAR_TREE), ref, operation, context));
+    }
+
+    private Path contain(Path treeRoot, BlobRef ref, String operation, StorageContext context) {
+        Path resolved = treeRoot.resolve(ref.container()).resolve(ref.key()).normalize();
+        if (!resolved.startsWith(treeRoot)) {
             throw FAILURES.isolationDenied(
                     operation, CommunityBlobFailures.REASON_PATH_ESCAPE, context.strategy().name());
         }
         return resolved;
+    }
+
+    /**
+     * Returns a fresh staging path for one upload, inside the caller's tenant directory.
+     *
+     * <p>Named by a random id rather than by the target key. That the old name collided with a real
+     * object is the headline, but the id also removes a second corruption the key-derived name
+     * carried: two concurrent uploads to the same key shared one staging file, and the later
+     * {@code TRUNCATE_EXISTING} cut the earlier transfer out from under itself. Uploads to one key
+     * are still last-commit-wins, which is the contract; they no longer interleave into one file.
+     */
+    /* default */ Path stagingFile(String operation) throws IOException {
+        Path stagingDir =
+                tenantDirectoryOf(KernelProviders.storageContextOrSystem(), operation)
+                        .resolve(STAGING_TREE);
+        Files.createDirectories(stagingDir);
+        return stagingDir.resolve(UUID.randomUUID().toString());
     }
 
     /**
@@ -103,25 +157,27 @@ final class CommunityFilesystemBlobLayout {
     }
 
     /**
-     * Returns the sidecar path holding an object's declared content type.
+     * Records a content type, keeping the sidecar tree in step with an overwrite.
      *
-     * <p>A filesystem has nowhere else to keep it. Extended attributes would be tidier but are not
-     * portable across the filesystems a Community driver has to run on.
+     * <p>The default type is represented by <em>no</em> sidecar, so recording it means removing any
+     * the previous object left behind. Skipping the write without the delete — which is what this did
+     * — let an overwrite keep the old type: re-uploading a {@code text/csv} object as the default
+     * still reported {@code text/csv}, because absence was only ever written, never restored.
+     *
+     * <p>A filesystem has nowhere tidier to keep this. Extended attributes would avoid the second file
+     * but are not portable across the filesystems a Community driver has to run on.
      */
-    /* default */ static Path sidecar(Path objectPath) {
-        return objectPath.resolveSibling(objectPath.getFileName() + SIDECAR_SUFFIX);
-    }
-
-    /** Records a content type, skipping the sidecar entirely for the default. */
-    /* default */ static void writeContentType(Path objectPath, String contentType) throws IOException {
-        if (!BlobMetadata.DEFAULT_CONTENT_TYPE.equals(contentType)) {
-            Files.writeString(sidecar(objectPath), contentType, StandardCharsets.UTF_8);
+    /* default */ static void writeContentType(Path sidecar, String contentType) throws IOException {
+        if (BlobMetadata.DEFAULT_CONTENT_TYPE.equals(contentType)) {
+            Files.deleteIfExists(sidecar);
+            return;
         }
+        Files.createDirectories(sidecar.getParent());
+        Files.writeString(sidecar, contentType, StandardCharsets.UTF_8);
     }
 
     /** Reads a recorded content type, falling back to the default when none was recorded. */
-    /* default */ static String contentTypeOf(Path objectPath) {
-        Path sidecar = sidecar(objectPath);
+    /* default */ static String contentTypeOf(Path sidecar) {
         if (!Files.isRegularFile(sidecar)) {
             return BlobMetadata.DEFAULT_CONTENT_TYPE;
         }

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobStore.java
@@ -43,7 +43,6 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
     private static final CommunityBlobFailures FAILURES =
             CommunityBlobFailures.forProvider(CommunityBlobFailures.FILESYSTEM_PROVIDER);
 
-    private static final String UPLOAD_SUFFIX = ".uploading";
     private static final String REF_REQUIRED = "ref must not be null";
     private static final String ROOT_CONTAINER = "[root]";
 
@@ -68,12 +67,13 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
         if (contentLength < 0) {
             throw new IllegalArgumentException("contentLength must not be negative");
         }
-        Path target = layout.resolve(ref, CommunityBlobFailures.OP_UPLOAD);
+        CommunityFilesystemBlobLayout.BlobPaths paths =
+                layout.resolve(ref, CommunityBlobFailures.OP_UPLOAD);
         try {
-            Files.createDirectories(target.getParent());
-            Path staging = target.resolveSibling(target.getFileName() + UPLOAD_SUFFIX);
+            Files.createDirectories(paths.object().getParent());
+            Path staging = layout.stagingFile(CommunityBlobFailures.OP_UPLOAD);
             return new CommunityFilesystemBlobUploadHandle(
-                    staging, target, ref, contentLength,
+                    staging, paths, ref, contentLength,
                     contentType == null ? BlobMetadata.DEFAULT_CONTENT_TYPE : contentType);
         } catch (IOException e) {
             throw FAILURES.transferFailed(
@@ -89,7 +89,9 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
     @Override
     public BlobDownloadHandle openDownload(BlobRef ref, BlobRange range) {
         Objects.requireNonNull(ref, REF_REQUIRED);
-        Path target = layout.resolve(ref, CommunityBlobFailures.OP_DOWNLOAD);
+        CommunityFilesystemBlobLayout.BlobPaths paths =
+                layout.resolve(ref, CommunityBlobFailures.OP_DOWNLOAD);
+        Path target = paths.object();
         if (!Files.isRegularFile(target)) {
             throw FAILURES.notFound(ref.container());
         }
@@ -97,7 +99,8 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
             long size = Files.size(target);
             return new CommunityFilesystemBlobDownloadHandle(
                     target,
-                    new BlobMetadata(ref, size, CommunityFilesystemBlobLayout.contentTypeOf(target)),
+                    new BlobMetadata(ref, size,
+                            CommunityFilesystemBlobLayout.contentTypeOf(paths.sidecar())),
                     range);
         } catch (IOException e) {
             throw FAILURES.transferFailed(
@@ -108,13 +111,14 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
     @Override
     public Optional<BlobMetadata> stat(BlobRef ref) {
         Objects.requireNonNull(ref, REF_REQUIRED);
-        Path target = layout.resolve(ref, CommunityBlobFailures.OP_STAT);
-        if (!Files.isRegularFile(target)) {
+        CommunityFilesystemBlobLayout.BlobPaths paths =
+                layout.resolve(ref, CommunityBlobFailures.OP_STAT);
+        if (!Files.isRegularFile(paths.object())) {
             return Optional.empty();
         }
         try {
-            return Optional.of(new BlobMetadata(
-                    ref, Files.size(target), CommunityFilesystemBlobLayout.contentTypeOf(target)));
+            return Optional.of(new BlobMetadata(ref, Files.size(paths.object()),
+                    CommunityFilesystemBlobLayout.contentTypeOf(paths.sidecar())));
         } catch (IOException e) {
             throw FAILURES.transferFailed(
                     CommunityBlobFailures.OP_STAT, ref.container(), e);
@@ -124,10 +128,11 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
     @Override
     public boolean delete(BlobRef ref) {
         Objects.requireNonNull(ref, REF_REQUIRED);
-        Path target = layout.resolve(ref, CommunityBlobFailures.OP_DELETE);
+        CommunityFilesystemBlobLayout.BlobPaths paths =
+                layout.resolve(ref, CommunityBlobFailures.OP_DELETE);
         try {
-            boolean removed = Files.deleteIfExists(target);
-            Files.deleteIfExists(CommunityFilesystemBlobLayout.sidecar(target));
+            boolean removed = Files.deleteIfExists(paths.object());
+            Files.deleteIfExists(paths.sidecar());
             return removed;
         } catch (IOException e) {
             throw FAILURES.transferFailed(

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobUploadHandle.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobUploadHandle.java
@@ -115,13 +115,21 @@ final class CommunityFilesystemBlobUploadHandle implements BlobUploadHandle {
             // did land, which stat reports as the default rather than as someone else's value.
             Files.move(staging, paths.object(), StandardCopyOption.REPLACE_EXISTING,
                     StandardCopyOption.ATOMIC_MOVE);
+            // Set BEFORE the sidecar write, because the object is already visible at this point.
+            // A sidecar failure leaves a committed object the caller is told about by exception; if
+            // the flags stayed clear, that caller could commit() again against a closed channel and
+            // get a second, unrelated failure for an upload that had in fact landed.
+            committed = true;
+            closed = true;
             CommunityFilesystemBlobLayout.writeContentType(paths.sidecar(), contentType);
         } catch (IOException e) {
+            // Flags deliberately left alone. If the move never ran, they are still clear and the
+            // caller's try-with-resources reaches close(), which deletes the staging file exactly as
+            // an abort would. If the SIDECAR was what failed, they were set above and close() is a
+            // no-op — which is right, because the staging file has already moved.
             throw FAILURES.transferFailed(
                     CommunityBlobFailures.OP_UPLOAD, ref.container(), e);
         }
-        committed = true;
-        closed = true;
         return new BlobMetadata(ref, written, contentType);
     }
 

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobUploadHandle.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobUploadHandle.java
@@ -36,7 +36,7 @@ final class CommunityFilesystemBlobUploadHandle implements BlobUploadHandle {
             CommunityBlobFailures.forProvider(CommunityBlobFailures.FILESYSTEM_PROVIDER);
 
     private final Path staging;
-    private final Path target;
+    private final CommunityFilesystemBlobLayout.BlobPaths paths;
     private final BlobRef ref;
     private final long declaredLength;
     private final String contentType;
@@ -46,10 +46,11 @@ final class CommunityFilesystemBlobUploadHandle implements BlobUploadHandle {
     private boolean committed;
     private boolean closed;
 
-    /* default */ CommunityFilesystemBlobUploadHandle(Path staging, Path target, BlobRef ref,
-                                                      long declaredLength, String contentType) {
+    /* default */ CommunityFilesystemBlobUploadHandle(
+            Path staging, CommunityFilesystemBlobLayout.BlobPaths paths, BlobRef ref,
+            long declaredLength, String contentType) {
         this.staging = staging;
-        this.target = target;
+        this.paths = paths;
         this.ref = ref;
         this.declaredLength = declaredLength;
         this.contentType = contentType;
@@ -108,9 +109,13 @@ final class CommunityFilesystemBlobUploadHandle implements BlobUploadHandle {
         try {
             channel.force(true);
             channel.close();
-            CommunityFilesystemBlobLayout.writeContentType(target, contentType);
-            Files.move(staging, target, StandardCopyOption.REPLACE_EXISTING,
+            // Bytes first, then the type. Reversed, a move that fails leaves the previous object in
+            // place wearing the new upload's content type — a stat that is wrong about an object the
+            // caller was never told had changed. This order can only lose the type of an object that
+            // did land, which stat reports as the default rather than as someone else's value.
+            Files.move(staging, paths.object(), StandardCopyOption.REPLACE_EXISTING,
                     StandardCopyOption.ATOMIC_MOVE);
+            CommunityFilesystemBlobLayout.writeContentType(paths.sidecar(), contentType);
         } catch (IOException e) {
             throw FAILURES.transferFailed(
                     CommunityBlobFailures.OP_UPLOAD, ref.container(), e);

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityBlobJfrTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityBlobJfrTest.java
@@ -125,10 +125,16 @@ class CommunityBlobJfrTest {
     /** Creates a regular file exactly where the container directory would go. */
     private static void blockContainerPath(Path root) {
         CommunityFilesystemBlobLayout layout = new CommunityFilesystemBlobLayout(root);
-        Path tenantDir = layout.requireTenantDirectory(CommunityBlobFailures.OP_UPLOAD);
+        // Asked of the layout rather than assembled here: the container directory is not a child of
+        // the tenant directory any more, and a fixture that spells the layout out itself stops
+        // blocking anything the moment placement changes — silently, since "no exception" is what
+        // this test would then observe.
+        Path containerDir = layout
+                .resolve(new BlobRef("docs", "probe"), CommunityBlobFailures.OP_UPLOAD)
+                .object().getParent();
         try {
-            Files.createDirectories(tenantDir);
-            Files.writeString(tenantDir.resolve("docs"), "not-a-directory");
+            Files.createDirectories(containerDir.getParent());
+            Files.writeString(containerDir, "not-a-directory");
         } catch (IOException e) {
             throw new IllegalStateException("test fixture setup failed", e);
         }

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobLayoutTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobLayoutTest.java
@@ -45,7 +45,7 @@ class CommunityFilesystemBlobLayoutTest {
         CommunityFilesystemBlobLayout layout = new CommunityFilesystemBlobLayout(root);
         return ScopedValue.where(KernelProviders.STORAGE_CONTEXT,
                         ImmutableStorageContext.shared(isolationKey))
-                .call(() -> layout.resolve(new BlobRef(CONTAINER, KEY), OPERATION));
+                .call(() -> layout.resolve(new BlobRef(CONTAINER, KEY), OPERATION).object());
     }
 
     @Nested
@@ -81,8 +81,9 @@ class CommunityFilesystemBlobLayoutTest {
 
             Path resolved = resolveAs(root, "a/b/c");
 
-            // Encoded, the whole key is one directory name: root -> tenant -> container -> object.
-            assertThat(root.relativize(resolved).getNameCount()).isEqualTo(3);
+            // Encoded, the whole key is one directory name:
+            // root -> tenant -> objects -> container -> object.
+            assertThat(root.relativize(resolved).getNameCount()).isEqualTo(4);
         }
 
         @Test

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobNamespaceTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobNamespaceTest.java
@@ -17,6 +17,7 @@ import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
 import eu.exeris.kernel.spi.security.ImmutableStorageContext;
 import eu.exeris.kernel.spi.storage.blob.BlobDownloadHandle;
 import eu.exeris.kernel.spi.storage.blob.BlobMetadata;
+import eu.exeris.kernel.spi.exceptions.storage.BlobStorageException;
 import eu.exeris.kernel.spi.storage.blob.BlobRef;
 import eu.exeris.kernel.spi.storage.blob.BlobStorageConfig;
 import eu.exeris.kernel.spi.storage.blob.BlobStore;
@@ -29,12 +30,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The store's private files must not be reachable as objects, and vice versa.
@@ -182,6 +188,61 @@ class CommunityFilesystemBlobNamespaceTest {
                 assertThat(store.stat(ref("sheet")).orElseThrow().contentType())
                         .isEqualTo(BlobMetadata.DEFAULT_CONTENT_TYPE);
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("a sidecar failure after the object has landed")
+    class SidecarFailureAfterCommit {
+
+        @Test
+        @DisplayName("the object is readable and the handle is spent, not reusable")
+        void sidecarFailureLeavesACommittedHandle() throws IOException {
+            asTenant(() -> {
+                upload(ref("typed"), NEIGHBOUR, "text/csv");
+                blockSidecarPath();
+
+                BlobRef ref = ref("typed");
+                try (BlobUploadHandle handle = store.beginUpload(ref, SUBJECT.length, "text/csv")) {
+                    writeAll(handle, SUBJECT);
+
+                    assertThatThrownBy(handle::commit)
+                            .as("the sidecar write failed, and the caller has to hear about it")
+                            .isInstanceOf(BlobStorageException.class);
+
+                    // The bytes moved BEFORE the sidecar was written, so the object is already
+                    // visible. A handle left un-flagged would let this caller retry a commit whose
+                    // channel is closed, and get a second, unrelated failure for an upload that in
+                    // fact landed.
+                    assertThatThrownBy(handle::commit)
+                            .as("spent, and spent as COMMITTED — the object did land, so the refusal "
+                                + "is a lifecycle error and not a second transfer failure for an "
+                                + "upload that already succeeded")
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("already committed");
+                }
+
+                assertThat(download(ref))
+                        .as("the move succeeded, so the new bytes are what a reader sees; only the "
+                            + "recorded content type was lost, which stat reports as the default")
+                        .isEqualTo(SUBJECT);
+            });
+        }
+
+        /** Makes the next sidecar write fail by putting a directory where the file must go. */
+        private void blockSidecarPath() {
+            try (Stream<Path> tree = Files.walk(storeRoot)) {
+                Path sidecar = tree
+                        .filter(Files::isRegularFile)
+                        .filter(path -> path.toString().contains("sidecar"))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException(
+                                "no sidecar written — the fixture assumes the first upload made one"));
+                Files.delete(sidecar);
+                Files.createDirectory(sidecar);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobNamespaceTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobNamespaceTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2025-2026 Exeris Systems.
+ *
+ * Licensed under the Apache License, Version 2.0 with Commons Clause.
+ * You may use, modify, and distribute this file under those terms.
+ * Commercial resale of this software as a competing product is prohibited.
+ * See LICENSE-COMMUNITY in the repository root for the full text.
+ */
+package eu.exeris.kernel.community.storage;
+
+import eu.exeris.kernel.community.memory.CommunityMemoryProvider;
+import eu.exeris.kernel.spi.context.KernelProviders;
+import eu.exeris.kernel.spi.memory.LeakDetectionMode;
+import eu.exeris.kernel.spi.memory.LoanedBuffer;
+import eu.exeris.kernel.spi.memory.MemoryAllocator;
+import eu.exeris.kernel.spi.memory.MemoryProviderConfig;
+import eu.exeris.kernel.spi.security.ImmutableStorageContext;
+import eu.exeris.kernel.spi.storage.blob.BlobDownloadHandle;
+import eu.exeris.kernel.spi.storage.blob.BlobMetadata;
+import eu.exeris.kernel.spi.storage.blob.BlobRef;
+import eu.exeris.kernel.spi.storage.blob.BlobStorageConfig;
+import eu.exeris.kernel.spi.storage.blob.BlobStore;
+import eu.exeris.kernel.spi.storage.blob.BlobUploadHandle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The store's private files must not be reachable as objects, and vice versa.
+ *
+ * <p>{@code AbstractBlobStorageTck} exercises the contract with ordinary keys, which is where the
+ * defect hid: staging and content-type files were named by appending {@code .uploading} and
+ * {@code .ctype} to the object's own path, and both are endings {@link BlobRef} permits. The suffix
+ * did not name a private file — it named another object of the same tenant. So these cases use
+ * exactly the keys the old naming stole.
+ *
+ * <p>Nothing here is filesystem-specific except the driver under test: what is asserted is the
+ * contract every {@code BlobStore} owes, that an operation on one key touches only that key.
+ */
+@DisplayName("CommunityFilesystemBlobStore — the store's own files share no namespace with objects")
+class CommunityFilesystemBlobNamespaceTest {
+
+    private static final String TENANT = "tenant-alpha";
+    private static final String CONTAINER = "docs";
+    private static final int BUFFER_BYTES = 4096;
+    private static final byte[] NEIGHBOUR = "neighbour".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SUBJECT = "subject".getBytes(StandardCharsets.UTF_8);
+
+    @TempDir
+    private Path storeRoot;
+
+    private BlobStore store;
+    private MemoryAllocator allocator;
+
+    @BeforeEach
+    void setUp() {
+        store = new CommunityFilesystemBlobStorageProvider()
+                .createStore(BlobStorageConfig.atLocation(storeRoot.toString()));
+        allocator = new CommunityMemoryProvider().createAllocator(
+                MemoryProviderConfig.defaults().withLeakDetection(LeakDetectionMode.PARANOID));
+    }
+
+    @AfterEach
+    void tearDown() {
+        store.close();
+        allocator.close();
+    }
+
+    @Nested
+    @DisplayName("a key ending in the staging suffix is an ordinary object")
+    class StagingSuffixKeys {
+
+        @Test
+        @DisplayName("uploading 'report' leaves 'report.uploading' untouched")
+        void uploadDoesNotConsumeTheNeighbour() {
+            asTenant(() -> {
+                upload(ref("report.uploading"), NEIGHBOUR, null);
+                upload(ref("report"), SUBJECT, null);
+
+                assertThat(download(ref("report.uploading")))
+                        .as("the staging file used to BE this object: opened with TRUNCATE_EXISTING, "
+                            + "then moved away by the commit, so the neighbour was first emptied and "
+                            + "then deleted by an upload that never named it")
+                        .isEqualTo(NEIGHBOUR);
+                assertThat(download(ref("report"))).isEqualTo(SUBJECT);
+            });
+        }
+
+        @Test
+        @DisplayName("an aborted upload to 'report' does not delete 'report.uploading'")
+        void abortDoesNotDeleteTheNeighbour() {
+            asTenant(() -> {
+                upload(ref("report.uploading"), NEIGHBOUR, null);
+
+                // Closed without commit: the abort path deletes the staging file, which used to be
+                // the neighbour's own path.
+                store.beginUpload(ref("report"), SUBJECT.length, null).close();
+
+                assertThat(store.stat(ref("report.uploading"))).isPresent();
+                assertThat(download(ref("report.uploading"))).isEqualTo(NEIGHBOUR);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("a key ending in the sidecar suffix is an ordinary object")
+    class SidecarSuffixKeys {
+
+        @Test
+        @DisplayName("recording a content type for 'photo' does not overwrite 'photo.ctype'")
+        void contentTypeDoesNotOverwriteTheNeighbour() {
+            asTenant(() -> {
+                upload(ref("photo.ctype"), NEIGHBOUR, null);
+                upload(ref("photo"), SUBJECT, "image/png");
+
+                assertThat(download(ref("photo.ctype"))).isEqualTo(NEIGHBOUR);
+                assertThat(store.stat(ref("photo.ctype")).orElseThrow().sizeBytes())
+                        .as("the sidecar's own bytes are shorter than the object's; a stat reading "
+                            + "the sidecar reports its length instead")
+                        .isEqualTo(NEIGHBOUR.length);
+                assertThat(store.stat(ref("photo")).orElseThrow().contentType())
+                        .isEqualTo("image/png");
+            });
+        }
+
+        @Test
+        @DisplayName("deleting 'photo' does not delete 'photo.ctype'")
+        void deleteDoesNotRemoveTheNeighbour() {
+            asTenant(() -> {
+                upload(ref("photo.ctype"), NEIGHBOUR, null);
+                upload(ref("photo"), SUBJECT, "image/png");
+
+                assertThat(store.delete(ref("photo"))).isTrue();
+
+                assertThat(store.stat(ref("photo.ctype")))
+                        .as("delete removed the object and its sidecar, and the sidecar's path was "
+                            + "the neighbour — one delete call, two objects gone")
+                        .isPresent();
+                assertThat(download(ref("photo.ctype"))).isEqualTo(NEIGHBOUR);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("the recorded content type follows the object it belongs to")
+    class ContentTypeLifecycle {
+
+        @Test
+        @DisplayName("overwriting a typed object with the default type clears the recorded type")
+        void defaultTypeOverwriteClearsTheRecord() {
+            asTenant(() -> {
+                upload(ref("sheet"), NEIGHBOUR, "text/csv");
+                upload(ref("sheet"), SUBJECT, null);
+
+                assertThat(store.stat(ref("sheet")).orElseThrow().contentType())
+                        .as("the default is represented by the ABSENCE of a sidecar, so recording it "
+                            + "means removing the previous one — skipping the write left the old "
+                            + "type describing the new bytes")
+                        .isEqualTo(BlobMetadata.DEFAULT_CONTENT_TYPE);
+            });
+        }
+
+        @Test
+        @DisplayName("a re-created object does not inherit the deleted one's type")
+        void deleteClearsTheRecordedType() {
+            asTenant(() -> {
+                upload(ref("sheet"), NEIGHBOUR, "text/csv");
+                store.delete(ref("sheet"));
+                upload(ref("sheet"), SUBJECT, null);
+
+                assertThat(store.stat(ref("sheet")).orElseThrow().contentType())
+                        .isEqualTo(BlobMetadata.DEFAULT_CONTENT_TYPE);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("concurrent uploads to one key do not share a file")
+    class ConcurrentUploads {
+
+        @Test
+        @DisplayName("a second upload opened mid-transfer does not truncate the first")
+        void secondUploadDoesNotTruncateTheFirst() {
+            asTenant(() -> {
+                BlobRef ref = ref("contended");
+                try (BlobUploadHandle first = store.beginUpload(ref, NEIGHBOUR.length, null)) {
+                    writeAll(first, NEIGHBOUR);
+                    // Opened while the first is still in flight. Both staging paths were derived
+                    // from the key, so this open — CREATE + TRUNCATE_EXISTING — emptied the file the
+                    // first had already written, and its commit then moved the truncated result into
+                    // place. The length check passes either way: it counts bytes handed to write(),
+                    // not bytes on disk.
+                    store.beginUpload(ref, SUBJECT.length, null).close();
+                    first.commit();
+                }
+
+                assertThat(download(ref)).isEqualTo(NEIGHBOUR);
+            });
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static BlobRef ref(String key) {
+        return new BlobRef(CONTAINER, key);
+    }
+
+    private void asTenant(Runnable body) {
+        ScopedValue.where(KernelProviders.STORAGE_CONTEXT, ImmutableStorageContext.shared(TENANT))
+                .run(body);
+    }
+
+    private void upload(BlobRef ref, byte[] payload, String contentType) {
+        try (BlobUploadHandle handle = store.beginUpload(ref, payload.length, contentType)) {
+            writeAll(handle, payload);
+            handle.commit();
+        }
+    }
+
+    private void writeAll(BlobUploadHandle handle, byte[] payload) {
+        try (LoanedBuffer buffer = allocator.allocateInfrastructure(BUFFER_BYTES)) {
+            MemorySegment.copy(
+                    payload, 0, buffer.segment(), ValueLayout.JAVA_BYTE, 0, payload.length);
+            handle.write(buffer.segment(), payload.length);
+        }
+    }
+
+    private byte[] download(BlobRef ref) {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (BlobDownloadHandle handle = store.openDownload(ref);
+             LoanedBuffer buffer = allocator.allocateInfrastructure(BUFFER_BYTES)) {
+            int read;
+            while ((read = handle.read(buffer.segment(), BUFFER_BYTES)) > 0) {
+                byte[] chunk = new byte[read];
+                MemorySegment.copy(buffer.segment(), ValueLayout.JAVA_BYTE, 0, chunk, 0, read);
+                sink.write(chunk, 0, read);
+            }
+        }
+        return sink.toByteArray();
+    }
+}


### PR DESCRIPTION
Part of the v0.11 release-review fix sweep (F6). Community filesystem blob driver, new in this milestone.

## What was wrong

The driver named its staging file and its content-type sidecar by appending `.uploading` and `.ctype` to the object's own path. **`BlobRef` rejects traversal, not extensions** — so `"report.uploading"` and `"photo.ctype"` are keys a tenant may legitimately store. The suffix did not name a private file; it named **another object of the same tenant**.

Every operation on the shorter key then reached the longer one:

| Call | What it also did |
|---|---|
| `beginUpload("report")` | opened `report.uploading` with `TRUNCATE_EXISTING` — emptied the object stored there |
| that upload's `commit()` | moved that path away — deleted it outright |
| that upload's `close()` (abort) | deleted it |
| `commit()` of `"photo"` with a content type | overwrote `photo.ctype` with a MIME string |
| `delete("photo")` | deleted `photo.ctype` |

All within one tenant, all silent, none of it reported as touching a second object. Not a cross-tenant leak — the isolation boundary holds — but data destruction from an operation that never named the destroyed object.

## What changed

A driver may restrict keys further than the contract does (`BlobRef`'s javadoc says so explicitly), so refusing the two endings would have been permitted. It would also make one key work on one blob driver and fail on another for a reason the caller cannot see. **So the namespaces are separated instead** — `objects/`, `sidecars/`, `staging/` are three fixed children of the tenant directory.

Disjointness is structural rather than conventional: a container is always a child of `objects`, so a container named `sidecars` lands at `objects/sidecars` and collides with nothing. Nothing the caller controls is a direct child of the tenant directory any more.

**Staging files are now named by a random id** rather than by the target key. That the old name collided with a real object is the headline, but the key-derived name carried a second corruption: two concurrent uploads to one key shared one staging file, and the later `TRUNCATE_EXISTING` cut the earlier transfer out from under itself — while its length check, which counts bytes handed to `write()` rather than bytes on disk, still passed.

Two smaller repairs ride along, both about the sidecar tracking its object:

- **The default content type is the *absence* of a sidecar**, so recording it means deleting any the previous object left. `writeContentType` only ever wrote, so re-uploading a `text/csv` object as the default kept reporting `text/csv`. (This was a below-cap finding in the same review.)
- `commit()` wrote the type **before** the move. A move that then failed left the previous object in place wearing the new upload's content type. Bytes first: that order can only lose the type of an object that did land, which `stat` reports as the default rather than as someone else's value.

## S3 is unaffected

The S3 driver keeps `t-<hex>/<container>/<key>` unchanged — it carries content type as object metadata and stages multipart server-side, so it has no private files to separate. `storage.md` claimed the two layouts were identical; it now says where they differ and why.

## Verification

**Mutation-proven**: restoring the suffix naming fails the five new namespace cases in `CommunityFilesystemBlobNamespaceTest` **and nothing else** — and the two content-type cases stay green under it, since they cover the separate defect.

`mvn clean install` green; community 1522 tests; lint in cycle (no skip flags); `ExerisArchitectureTest` green.

## Notes for review

- On-disk layout change with no migration concern: the blob store is new in v0.11 and unreleased.
- `CommunityBlobJfrTest`'s fixture asked the layout for the container directory instead of assembling it — a fixture that spells the layout out itself stops blocking anything the moment placement changes, silently, since "no exception thrown" is what that test would then observe.
- Docs: `DOCS_REVIEW_REQUIRED`, handled here — `docs/subsystems/storage.md` filesystem and S3 sections updated in the same commit.
