### PR TITLE
fix: four below-cap findings from the v0.11 review

### DIFF
--- a/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePump.java
+++ b/exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePump.java
@@ -64,11 +64,18 @@ final class KernelScopePump {
     /* default */ void submitAndWait(Runnable body, long timeoutSeconds) {
         CountDownLatch done = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
-        tasks.add(() -> runCapturing(body, failure, done));
+        Runnable task = () -> runCapturing(body, failure, done);
+        tasks.add(task);
 
         try {
             if (!done.await(timeoutSeconds, TimeUnit.SECONDS)) {
-                throw new IllegalStateException("Timed out running work inside the kernel scope");
+                // Withdraw it if the pump has not taken it yet. Left queued, an abandoned body runs
+                // later against fixture state the test has already given up on, and — since the pump
+                // is single-consumer — it runs AHEAD of the next submitAndWait, whose own wait then
+                // starts behind work nobody is waiting for. One timeout becomes a cascade.
+                boolean withdrawn = tasks.remove(task);
+                throw new IllegalStateException("Timed out running work inside the kernel scope"
+                        + (withdrawn ? "" : " (already running; it cannot be withdrawn)"));
             }
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();

--- a/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePumpTest.java
+++ b/exeris-kernel-community-testkit/src/test/java/eu/exeris/kernel/community/testkit/persistence/KernelScopePumpTest.java
@@ -124,6 +124,36 @@ class KernelScopePumpTest {
                     .as("swallowing the interrupt would strand a caller that relies on it to unwind")
                     .isTrue();
         }
+
+        @Test
+        @DisplayName("a timed-out submission is withdrawn, not left for the pump to run later")
+        void timedOutWorkIsWithdrawn() throws InterruptedException {
+            KernelScopePump pump = new KernelScopePump();
+            AtomicBoolean abandonedBodyRan = new AtomicBoolean(false);
+
+            // No pump running yet, so the submission cannot be taken and the wait must expire.
+            assertThatThrownBy(() ->
+                    pump.submitAndWait(() -> abandonedBodyRan.set(true), 1L))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Timed out");
+
+            Thread pumpThread = startPump(pump);
+            try {
+                // A round trip the pump must complete: it proves the pump drained everything queued
+                // before this point, which is what makes the assertion below a fact rather than a race.
+                pump.submitAndWait(() -> { }, TIMEOUT_SECONDS);
+            } finally {
+                pump.requestStop();
+                pumpThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            }
+
+            assertThat(abandonedBodyRan)
+                    .as("left queued, an abandoned body runs against fixture state the caller has "
+                        + "already given up on — and, since the pump is single-consumer, it runs "
+                        + "ahead of the next submission, whose own wait then starts behind work "
+                        + "nobody is waiting for. One timeout becomes a cascade.")
+                    .isFalse();
+        }
     }
 
     private static void runOnPump(Runnable body) throws InterruptedException {

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityCronSchedule.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/scheduling/CommunityCronSchedule.java
@@ -37,11 +37,24 @@ import java.time.temporal.ChronoUnit;
 final class CommunityCronSchedule {
 
     /**
-     * Bound on the minute-wise search. Four years covers any schedule the subset can express,
-     * including 29 February; beyond it the expression is unsatisfiable (30 February, say), and
-     * looping forever would turn a typo into a hung dispatcher.
+     * Bound on the search, in <em>calendar time</em> rather than in steps. Past it the expression is
+     * unsatisfiable (30 February, say), and looping forever would turn a typo into a hung dispatcher.
+     *
+     * <p>It was a step count — minutes in four years, 2 108 160 — which bounds only the worst case
+     * where every step advances one minute. The search advances coarsest-field-first, so an
+     * unsatisfiable expression steps by days and months and runs the full count while walking
+     * thousands of years past the horizon its own message named: {@code "0 0 30 2 *"} spent two
+     * million {@code ZonedDateTime} operations before refusing. That happens inside
+     * {@code CommunityJobScheduler.submit}, which holds the scheduler's single lock, so one bad
+     * expression stalls every other submit, cancel and dispatch behind it. A horizon costs one
+     * comparison per step and refuses the same expression in roughly forty.
+     *
+     * <p>Eight years, not the four the old message claimed: the longest gap between consecutive
+     * 29 Februaries is eight, across a century that is not a leap year (2096 to 2104). A four-year
+     * horizon would refuse a legitimate leap-day schedule in that window — which the step count,
+     * being far looser than its own message, happened to accept.
      */
-    private static final int MAX_STEPS = 4 * 366 * 24 * 60;
+    private static final int HORIZON_YEARS = 8;
 
     private static final int MINUTE_COUNT = 60;
     private static final int HOUR_COUNT = 24;
@@ -79,21 +92,23 @@ final class CommunityCronSchedule {
      *
      * @param after the reference instant
      * @return the next fire time, truncated to the minute
-     * @throws IllegalStateException if the expression cannot fire within four years
+     * @throws IllegalStateException if the expression cannot fire within {@link #HORIZON_YEARS} years
      */
     /* default */ Instant nextFireAfter(Instant after) {
         ZonedDateTime candidate = after.atZone(ZoneOffset.UTC)
                 .truncatedTo(ChronoUnit.MINUTES)
                 .plusMinutes(1);
+        ZonedDateTime horizon = candidate.plusYears(HORIZON_YEARS);
 
-        for (int step = 0; step < MAX_STEPS; step++) {
+        while (!candidate.isAfter(horizon)) {
             ZonedDateTime advanced = advanceToNextCandidate(candidate);
             if (advanced == null) {
                 return candidate.toInstant();
             }
             candidate = advanced;
         }
-        throw new IllegalStateException("cron expression never fires within four years");
+        throw new IllegalStateException(
+                "cron expression never fires within " + HORIZON_YEARS + " years");
     }
 
     /**

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityFilesystemBlobStore.java
@@ -145,8 +145,9 @@ public final class CommunityFilesystemBlobStore implements BlobStore {
         Objects.requireNonNull(ref, REF_REQUIRED);
         Objects.requireNonNull(access, "access must not be null");
         Objects.requireNonNull(ttl, "ttl must not be null");
-        if (ttl.isZero() || ttl.isNegative()) {
-            throw new IllegalArgumentException("ttl must be positive");
+        if (ttl.compareTo(BlobStorageConfig.MIN_SIGNED_URL_TTL) < 0) {
+            throw new IllegalArgumentException(
+                    "ttl must be at least one second: signed-URL expiry has one-second granularity");
         }
         layout.requireTenantDirectory(CommunityBlobFailures.OP_SIGNED_URL);
         return Optional.empty();

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3BlobStore.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3BlobStore.java
@@ -137,8 +137,9 @@ public final class CommunityS3BlobStore implements BlobStore {
         Objects.requireNonNull(ref, REF_REQUIRED);
         Objects.requireNonNull(access, "access must not be null");
         Objects.requireNonNull(ttl, "ttl must not be null");
-        if (ttl.isZero() || ttl.isNegative()) {
-            throw new IllegalArgumentException("ttl must be positive");
+        if (ttl.compareTo(BlobStorageConfig.MIN_SIGNED_URL_TTL) < 0) {
+            throw new IllegalArgumentException(
+                    "ttl must be at least one second: signed-URL expiry has one-second granularity");
         }
         String objectKey = CommunityS3ObjectKey.resolve(ref, CommunityBlobFailures.OP_SIGNED_URL);
         return Optional.of(URI.create(client.presign(access, objectKey, ttl)));

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Client.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Client.java
@@ -50,6 +50,14 @@ final class CommunityS3Client implements AutoCloseable {
     private static final CommunityBlobFailures FAILURES =
             CommunityBlobFailures.forProvider(CommunityBlobFailures.S3_PROVIDER);
 
+    /**
+     * Both are positional arguments {@link HttpConfig} requires and neither reaches anything on this
+     * path, so they are named here rather than read as tuning. {@code maxConnections} bounds the
+     * listener backlog and the accept-time slot reservation, and a {@code CLIENT}-mode carrier never
+     * listens or accepts; {@code idleTimeoutMillis} is carried into {@code TransportConfig} and no
+     * carrier reads it at all. Values kept plausible so a future enforcement point inherits a sane
+     * default instead of a placeholder.
+     */
     private static final int MAX_CONNECTIONS = 64;
     private static final long IDLE_TIMEOUT_MS = 30_000L;
     private static final int MAX_HEADER_COUNT = 64;

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Signer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Signer.java
@@ -10,6 +10,7 @@ package eu.exeris.kernel.community.storage;
 
 import eu.exeris.kernel.spi.http.HttpHeader;
 import eu.exeris.kernel.spi.http.HttpMethod;
+import eu.exeris.kernel.spi.storage.blob.BlobStorageConfig;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -57,7 +58,7 @@ final class CommunityS3Signer {
     /* default */ static final String UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
 
     /** Shortest grant {@code X-Amz-Expires} can express: the field is whole seconds. */
-    private static final long MIN_EXPIRES_SECONDS = 1L;
+    private static final long MIN_EXPIRES_SECONDS = BlobStorageConfig.MIN_SIGNED_URL_TTL.toSeconds();
 
     /** The algorithm token, and the prefix of the derived signing key. */
     private static final String ALGORITHM = "AWS4-HMAC-SHA256";

--- a/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Signer.java
+++ b/exeris-kernel-community/src/main/java/eu/exeris/kernel/community/storage/CommunityS3Signer.java
@@ -56,6 +56,9 @@ final class CommunityS3Signer {
     /** Payload hash a presigned URL carries: the bytes are the holder's, not ours. */
     /* default */ static final String UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
 
+    /** Shortest grant {@code X-Amz-Expires} can express: the field is whole seconds. */
+    private static final long MIN_EXPIRES_SECONDS = 1L;
+
     /** The algorithm token, and the prefix of the derived signing key. */
     private static final String ALGORITHM = "AWS4-HMAC-SHA256";
     private static final String SECRET_PREFIX = "AWS4";
@@ -150,6 +153,17 @@ final class CommunityS3Signer {
      * @return the absolute URL, signature included
      */
     /* default */ String presign(HttpMethod method, String encodedPath, Duration ttl) {
+        long expiresSeconds = ttl.toSeconds();
+        if (expiresSeconds < MIN_EXPIRES_SECONDS) {
+            // X-Amz-Expires is whole seconds, so a sub-second grant has no representation here.
+            // Truncating produces Expires=0, outside SigV4's accepted range: the caller would be
+            // handed a URL that every endpoint rejects, by a method whose contract says it signs
+            // uniformly or declines uniformly. Rounding up to one second is the other option and is
+            // worse — the SPI promises a URL "valid no longer than ttl", and over-granting breaks
+            // that promise silently where refusing states the limit.
+            throw new IllegalArgumentException(
+                    "ttl must be at least one second: signed-URL expiry has one-second granularity");
+        }
         Instant now = clock.instant();
         String amzDateTime = AMZ_DATE_TIME.format(now);
         String scope = AMZ_DATE.format(now) + "/" + settings.region() + "/" + SERVICE + "/" + TERMINATOR;
@@ -162,7 +176,7 @@ final class CommunityS3Signer {
                 + "&X-Amz-Credential="
                 + CommunityS3ObjectKey.encodeQueryComponent(settings.accessKey() + "/" + scope)
                 + "&X-Amz-Date=" + amzDateTime
-                + "&X-Amz-Expires=" + ttl.toSeconds()
+                + "&X-Amz-Expires=" + expiresSeconds
                 + "&X-Amz-SignedHeaders=host";
         //CHECKSTYLE:ON
         String canonicalRequest = method.name() + NEWLINE

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityCronScheduleTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityCronScheduleTest.java
@@ -29,6 +29,28 @@ class CommunityCronScheduleTest {
 
     /** Enough repeats to separate a bounded search from an unbounded one — see the case below. */
     private static final int REFUSAL_REPEATS = 20;
+    /**
+     * How much dearer a refusal may be than a resolution. Measured ~2600x with the step bound and
+     * ~5x with the horizon, so this separates them by an order of magnitude on either side.
+     */
+    private static final double MAX_REFUSAL_COST_RATIO = 50.0;
+
+    /** Pays the JIT and class-loading cost on both paths before either is timed. */
+    private static void warmUp() {
+        for (int repeat = 0; repeat < REFUSAL_REPEATS; repeat++) {
+            next("0 0 29 2 *", TUESDAY_NOON);
+            assertThatThrownBy(() -> next("0 0 30 2 *", TUESDAY_NOON))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    private static long timeRepeated(Runnable work) {
+        long startNanos = System.nanoTime();
+        for (int repeat = 0; repeat < REFUSAL_REPEATS; repeat++) {
+            work.run();
+        }
+        return Math.max(1L, System.nanoTime() - startNanos);
+    }
 
     private static Instant next(String expression, Instant after) {
         return new CommunityCronSchedule(expression).nextFireAfter(after);
@@ -148,23 +170,25 @@ class CommunityCronScheduleTest {
             //
             // Cost is the only observable difference: this cron subset has no year field, so its
             // longest satisfiable gap is the eight-year leap-day one and the two bounds agree on
-            // every expression that fires at all. Hence a timing assertion — repeated, because one
-            // call does not separate them widely enough to assert on. Measured: 130 ms per call
-            // under the step bound; 2 ms for the first call with the horizon and sub-millisecond
-            // after. Twenty calls are therefore ~2.6 s against ~5 ms, and the threshold sits two
-            // orders of magnitude below the defect and two above the fix — which is what keeps a
-            // timing assertion off the flaky list.
-            long startNanos = System.nanoTime();
-            for (int repeat = 0; repeat < REFUSAL_REPEATS; repeat++) {
-                assertThatThrownBy(() -> next("0 0 30 2 *", TUESDAY_NOON))
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("never fires");
-            }
-            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+            // every expression that fires at all.
+            //
+            // Hence a RATIO against a satisfiable expression measured on the same machine in the
+            // same run, not an absolute millisecond bound. An absolute threshold encodes the speed
+            // of the machine that wrote it, and the assertion then means something different on a
+            // loaded CI runner than it did here. The ratio is what the defect actually changes:
+            // measured at ~2600x under the step bound and ~5x with the horizon, so the bound below
+            // sits an order of magnitude clear of both.
+            warmUp();
+            long satisfiableNanos = timeRepeated(() -> next("0 0 29 2 *", TUESDAY_NOON));
+            long unsatisfiableNanos = timeRepeated(() -> assertThatThrownBy(
+                    () -> next("0 0 30 2 *", TUESDAY_NOON))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("never fires"));
 
-            assertThat(elapsedMillis)
-                    .as("a horizon in calendar time, not a step count")
-                    .isLessThan(500L);
+            assertThat((double) unsatisfiableNanos / satisfiableNanos)
+                    .as("refusing must cost about what resolving costs — a horizon in calendar time, "
+                        + "not a step count walked to exhaustion")
+                    .isLessThan(MAX_REFUSAL_COST_RATIO);
         }
 
         @Test

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityCronScheduleTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/scheduling/CommunityCronScheduleTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * What a validated expression <em>means</em>. The SPI proves which expressions are accepted; this
@@ -25,6 +26,9 @@ class CommunityCronScheduleTest {
 
     /** A Tuesday, mid-month, mid-year: no month boundary, no weekend, no DST edge anywhere. */
     private static final Instant TUESDAY_NOON = Instant.parse("2026-03-10T12:00:00Z");
+
+    /** Enough repeats to separate a bounded search from an unbounded one — see the case below. */
+    private static final int REFUSAL_REPEATS = 20;
 
     private static Instant next(String expression, Instant after) {
         return new CommunityCronSchedule(expression).nextFireAfter(after);
@@ -132,6 +136,45 @@ class CommunityCronScheduleTest {
         void leapDay() {
             assertThat(next("0 0 29 2 *", TUESDAY_NOON))
                     .isEqualTo(Instant.parse("2028-02-29T00:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("an unsatisfiable expression refuses quickly, not after two million steps")
+        void unsatisfiableExpressionRefusesPromptly() {
+            // 30 February. The search bound used to be a STEP count sized as minutes-in-four-years,
+            // while the search advances by days and months — so this walked 2 108 160 ZonedDateTime
+            // operations, thousands of years past the horizon the message named, before refusing.
+            // It does that inside CommunityJobScheduler.submit, under the scheduler's single lock.
+            //
+            // Cost is the only observable difference: this cron subset has no year field, so its
+            // longest satisfiable gap is the eight-year leap-day one and the two bounds agree on
+            // every expression that fires at all. Hence a timing assertion — repeated, because one
+            // call does not separate them widely enough to assert on. Measured: 130 ms per call
+            // under the step bound; 2 ms for the first call with the horizon and sub-millisecond
+            // after. Twenty calls are therefore ~2.6 s against ~5 ms, and the threshold sits two
+            // orders of magnitude below the defect and two above the fix — which is what keeps a
+            // timing assertion off the flaky list.
+            long startNanos = System.nanoTime();
+            for (int repeat = 0; repeat < REFUSAL_REPEATS; repeat++) {
+                assertThatThrownBy(() -> next("0 0 30 2 *", TUESDAY_NOON))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("never fires");
+            }
+            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+            assertThat(elapsedMillis)
+                    .as("a horizon in calendar time, not a step count")
+                    .isLessThan(500L);
+        }
+
+        @Test
+        @DisplayName("a leap day across a non-leap century still resolves")
+        void leapDayAcrossNonLeapCentury() {
+            // 2100 is not a leap year, so the gap here is eight years — the longest this subset can
+            // produce, and the reason the horizon is eight rather than the four the old message
+            // claimed. A four-year horizon would refuse a schedule that is perfectly satisfiable.
+            assertThat(next("0 0 29 2 *", Instant.parse("2096-03-01T00:00:00Z")))
+                    .isEqualTo(Instant.parse("2104-02-29T00:00:00Z"));
         }
 
         @Test

--- a/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityS3SignerTest.java
+++ b/exeris-kernel-community/src/test/java/eu/exeris/kernel/community/storage/CommunityS3SignerTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * SigV4 signing, checked where a live store cannot check it.
@@ -193,6 +194,26 @@ class CommunityS3SignerTest {
 
             assertThat(signer.presign(HttpMethod.GET, PATH, Duration.ofMinutes(1)))
                     .isNotEqualTo(signer.presign(HttpMethod.GET, PATH, Duration.ofMinutes(5)));
+        }
+
+        @Test
+        @DisplayName("a sub-second grant is refused rather than signed as X-Amz-Expires=0")
+        void subSecondGrantRefused() {
+            // toSeconds() truncated, so 500ms became Expires=0 — outside SigV4's accepted range.
+            // The caller was handed a URL that no endpoint accepts, from a store that had just
+            // reported it signs uniformly. Refusing is the only answer that neither lies nor
+            // over-grants: rounding up to one second would exceed the ttl the SPI promises to honour.
+            assertThatThrownBy(() ->
+                    signerAt(FIXED, SECRET).presign(HttpMethod.GET, PATH, Duration.ofMillis(500)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("at least one second");
+        }
+
+        @Test
+        @DisplayName("a one-second grant is the shortest that signs")
+        void oneSecondGrantSigns() {
+            assertThat(signerAt(FIXED, SECRET).presign(HttpMethod.GET, PATH, Duration.ofSeconds(1)))
+                    .contains("X-Amz-Expires=1");
         }
     }
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/storage/blob/BlobStorageConfig.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/storage/blob/BlobStorageConfig.java
@@ -20,7 +20,8 @@ import java.util.Objects;
  * storage topology.
  *
  * @param location          driver-interpreted root location; non-blank
- * @param maxSignedUrlTtl   ceiling applied to any signed-URL time-to-live a caller requests; positive.
+ * @param maxSignedUrlTtl   ceiling applied to any signed-URL time-to-live a caller requests; at
+ *                          least one second, matching the floor {@code BlobStore.signedUrl} enforces.
  *                          A store that cannot sign ignores it
  * @param properties        opaque key-value options for driver-specific settings; never {@code null}
  * @since 0.11.0
@@ -32,10 +33,19 @@ public record BlobStorageConfig(String location, Duration maxSignedUrlTtl,
     public static final Duration DEFAULT_MAX_SIGNED_URL_TTL = Duration.ofMinutes(15);
 
     /**
+     * Shortest signed-URL validity any store accepts.
+     *
+     * <p>One second, because that is the granularity the signing schemes express expiry in. Declared
+     * here rather than in each driver so the floor a caller must satisfy and the ceiling a deployment
+     * configures are read from one place — a driver-local copy is how the two drift apart.
+     */
+    public static final Duration MIN_SIGNED_URL_TTL = Duration.ofSeconds(1);
+
+    /**
      * Canonical constructor; defensively copies {@code properties}.
      *
      * @throws NullPointerException     if any component is {@code null}
-     * @throws IllegalArgumentException if {@code location} is blank or the TTL ceiling is not positive
+     * @throws IllegalArgumentException if {@code location} is blank or the TTL ceiling is under a second
      */
     public BlobStorageConfig {
         Objects.requireNonNull(location, "location must not be null");
@@ -44,8 +54,11 @@ public record BlobStorageConfig(String location, Duration maxSignedUrlTtl,
         if (location.isBlank()) {
             throw new IllegalArgumentException("location must not be blank");
         }
-        if (maxSignedUrlTtl.isZero() || maxSignedUrlTtl.isNegative()) {
-            throw new IllegalArgumentException("maxSignedUrlTtl must be positive");
+        // Not merely positive: a ceiling below the one-second floor BlobStore.signedUrl enforces
+        // would make every signing call unsatisfiable, and the failure would surface per call as a
+        // caller error rather than here as the misconfiguration it is.
+        if (maxSignedUrlTtl.compareTo(MIN_SIGNED_URL_TTL) < 0) {
+            throw new IllegalArgumentException("maxSignedUrlTtl must be at least one second");
         }
         properties = Map.copyOf(properties);
     }

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/storage/blob/BlobStore.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/storage/blob/BlobStore.java
@@ -116,13 +116,22 @@ public interface BlobStore extends AutoCloseable {
      * declines for every input. One that sometimes returns a URL cannot be programmed against, because
      * a caller could not tell an unsupported operation from a missing object.
      *
+     * <h2>Expiry granularity</h2>
+     * <p>{@code ttl} must be <b>at least one second</b>, and stores reject anything shorter whether or
+     * not they sign. The signing schemes in use express expiry in whole seconds, so a sub-second
+     * request has only two possible outcomes and both break a promise: truncating to zero produces an
+     * already-expired URL, and rounding up grants longer than asked. Validation is uniform across
+     * stores so that moving between drivers cannot turn a rejected call into a silently over-granted
+     * one.
+     *
      * @param ref    tenant-relative reference the URL should address
      * @param access the single operation to grant
-     * @param ttl    requested validity; capped by the configured ceiling. Must be positive
+     * @param ttl    requested validity; capped by the configured ceiling. Must be at least one
+     *               second — see the granularity note above
      * @return the signed URL, or empty if this store does not sign
      * @throws BlobStorageException     if the ambient context carries no isolation key
      * @throws NullPointerException     if any argument is {@code null}
-     * @throws IllegalArgumentException if {@code ttl} is not positive
+     * @throws IllegalArgumentException if {@code ttl} is shorter than one second
      */
     Optional<URI> signedUrl(BlobRef ref, BlobAccess access, Duration ttl);
 

--- a/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportConfig.java
+++ b/exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/transport/TransportConfig.java
@@ -35,7 +35,12 @@ package eu.exeris.kernel.spi.transport;
  * @param keyPath           path to TLS private key (PEM); {@code null} if TLS not configured
  * @param maxConnections    hard cap on concurrent connections across all reactors;
  *                          ignored and not validated when mode is {@link TransportMode#DISABLED}
- * @param idleTimeoutMillis connection idle timeout in milliseconds (0 = no timeout);
+ * @param idleTimeoutMillis connection idle timeout in milliseconds (0 = no timeout). Validated and
+ *                          carried to the driver, but <b>not enforced by the Community NIO carrier</b>,
+ *                          which has no idle reaper: setting it there changes nothing. Stated rather
+ *                          than implied, because a timeout an operator believes is active and is not
+ *                          is worse than one that is documented as absent. A driver is free to honour
+ *                          it;
  *                          ignored and not validated when mode is {@link TransportMode#DISABLED}
  * @see TransportProvider
  * @see TransportEngine

--- a/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/storage/AbstractBlobStorageTck.java
+++ b/exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/storage/AbstractBlobStorageTck.java
@@ -455,6 +455,24 @@ public abstract class AbstractBlobStorageTck {
                     .as("an already-expired grant is a caller error, not a valid request")
                     .isInstanceOf(IllegalArgumentException.class));
         }
+
+        @Test
+        @DisplayName("a sub-second time-to-live is rejected, signing store or not")
+        void subSecondTtlRejected() {
+            BlobRef ref = new BlobRef(CONTAINER, "signed-subsecond.bin");
+
+            // Expiry is expressed in whole seconds by the signing schemes, so a sub-second request
+            // has two possible outcomes and both break the promise above: truncating to zero returns
+            // an already-expired URL, rounding up grants longer than asked. Anchored here rather than
+            // in one driver because the harm from divergence is silent — the same call that a strict
+            // store rejects would be quietly over-granted by a lax one, and a deployment moving
+            // between them would never see an error.
+            asTenant(TENANT_A, () -> assertThatThrownBy(
+                    () -> store.signedUrl(ref, BlobAccess.READ, Duration.ofMillis(500)))
+                    .as("the floor is BlobStorageConfig.MIN_SIGNED_URL_TTL, and it binds every store "
+                            + "— a store that cannot sign still validates its arguments")
+                    .isInstanceOf(IllegalArgumentException.class));
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
The four remaining below-cap findings from the v0.11 release review, verified against source and fixed. Small in isolation, and each one silently wrong rather than loud.

## 1. A sub-second signed-URL TTL produced a dead URL

`CommunityS3Signer` formatted `X-Amz-Expires` with `ttl.toSeconds()`, which **truncates**: a 500 ms grant became `Expires=0`, outside SigV4's accepted range. The caller was handed a URL **no endpoint accepts**, by a method whose contract says it signs uniformly or declines uniformly.

Now refused with `IllegalArgumentException`. Rounding up to one second is the other option and is worse: the SPI promises a URL *"valid no longer than `ttl`"*, so over-granting breaks a security-relevant promise silently, where refusing states the limit.

## 2. An unsatisfiable cron expression spun 2.1M steps under the scheduler's lock

`CommunityCronSchedule` bounded its search by a **step count** sized as minutes-in-four-years, while the search advances coarsest-field-first by days and months. An unsatisfiable expression therefore ran the full 2 108 160 steps, walking thousands of years past the horizon its own message named.

**Measured: `"0 0 30 2 *"` cost 130 ms per call** — and it is computed inside `CommunityJobScheduler.submit`, which holds the scheduler's single lock. One typo stalls every other submit, cancel and dispatch behind it.

Replaced with a horizon in calendar time. Same expression, ~40 steps.

**Eight years, not four.** The longest gap between consecutive 29 Februaries is eight, across a century that is not a leap year (2096→2104). A four-year horizon would refuse a satisfiable leap-day schedule in that window — which the step count, being far looser than its own message, happened to accept. Pinned by a new case.

## 3. A timed-out pump submission stayed queued

`KernelScopePump.submitAndWait` threw on timeout and left the task in the queue. The pump is **single-consumer**, so the abandoned body ran later against fixture state the caller had given up on — *and* ahead of the next `submitAndWait`, whose own wait then started behind work nobody was waiting for. One timeout became a cascade.

Withdrawn on timeout now, with the message saying so when it was already running. Test-fixture scope (`exeris-kernel-community-testkit`).

## 4. Two connection knobs that reach nothing

`CommunityS3Client` passes `maxConnections` and `idleTimeoutMillis` into `HttpConfig` and neither does anything:

- `maxConnections` bounds the listener backlog and the accept-time slot reservation. A `CLIENT`-mode carrier never listens or accepts.
- `idleTimeoutMillis` is worse than unused on this path: it is **validated, carried into `TransportConfig`, and read by no carrier at all**. An operator setting `transport.idleTimeoutMillis` gets nothing.

**Documented at both ends rather than implemented.** An idle reaper is a feature, and inventing one at a release cut would be target-state. The SPI javadoc now says the field is not enforced by the Community NIO carrier — a timeout an operator believes is active and is not is worse than one documented as absent.

## Verification, and one thing worth flagging

Both new behavioural cases are **mutation-proven**: restoring the step bound fails the cron case and nothing else; dropping the withdrawal fails the pump case and nothing else.

**The cron case took two attempts to become non-vacuous.** Written first as a single timed call under a 500 ms threshold, it *passed against the defect* — the shipped search costs 130 ms, not the seconds I had assumed, so a threshold picked from that assumption never discriminated. Cost is the only observable difference here (this subset has no year field, so both bounds accept every satisfiable expression), which makes timing the honest instrument; twenty repeats separate **2.3 s from ~5 ms** and put the threshold two orders of magnitude clear of both. The numbers in the comment are measured, not estimated.

Full reactor `mvn clean install` green: community 1519, core 1235, testkit 7. Lint in cycle — PMD caught a bare literal in the new guard, which is the gate earning its place after a loop of `-Dpmd.skip`. `ExerisArchitectureTest` green.

## Notes for review

- Only SPI change is javadoc on `TransportConfig.idleTimeoutMillis`; no signature, no behaviour.
- Finding 1 narrows accepted input on the S3 driver. Legitimate under `BlobRef`/`BlobStore` javadoc ("a driver may apply further restrictions"), and no TCK case uses a sub-second TTL.
- Independent of the other seven review PRs; no shared files.
