### PR TITLE
docs(guides): a how-to-start path for building on the kernel and implementing against it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,28 +152,33 @@ mvn test -pl exeris-kernel-tck
 
 ## Local Environment
 
-The full local environment requires only **Docker or Podman**. No cloud account, no managed service,
-no port-forwarding magic. This is a direct consequence of ADR-001 (Cloud Agnostic Infrastructure).
+**There is no local stack to start.** The repository has no `docker-compose.yml`, and nothing needs
+one. Tests that require Postgres or Kafka start their own containers through Testcontainers and tear
+them down again — so the only prerequisite is a running **Docker or Podman** daemon. This is a direct
+consequence of ADR-001 (Cloud Agnostic Infrastructure): no cloud account, no managed service, no
+port-forwarding magic.
 
-### Start the Local Stack
+Container images are pinned in the test sources, e.g.
+`new PostgreSQLContainer<>("postgres:16")` in
+`exeris-kernel-community/src/test/java/eu/exeris/kernel/community/persistence/CommunityPersistenceIsolationLeakTckIT.java:37`.
+
+### You do not need a daemon for the default build
+
+Container-backed tests are tagged (`integration`, `continuity`, `stress`) and are **excluded from
+`mvn clean install`**. A machine with no Docker daemon still gets a green default build — and that
+green build is not evidence those tests pass. Run them explicitly when you touch what they cover:
 
 ```bash
-docker compose up -d
+mvn -pl <module> -DincludedGroups=integration -DexcludedGroups= test
 ```
 
-The `docker-compose.yml` at the repository root provisions:
-- **PostgreSQL 16** on `localhost:5432` (used by `JdbcCitadelRepository` in Community tier)
-- **Redis 7** on `localhost:6379` (session/distributed cache, used by Security subsystem)
+The exclusion list is per-module — see the `excludedGroups` property in each module's `pom.xml`
+(e.g. `exeris-kernel-community-kafka/pom.xml:31`) for which tags that module holds back and why.
 
-Default credentials are aligned with the repository's test fixtures. Do not change them without updating the corresponding test fixtures.
+### Consuming the kernel rather than contributing to it
 
-### Stopping the Stack
-
-```bash
-docker compose down
-```
-
-Data is ephemeral by default (no named volume mounts). Each `up` starts with a clean database.
+Different requirements — notably no `--enable-preview` — and different coordinates. See
+[docs/guides/01-platform-and-dependencies.md](docs/guides/01-platform-and-dependencies.md).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ export DYLD_LIBRARY_PATH="$(brew --prefix openssl@3)/lib:$DYLD_LIBRARY_PATH"
 | Tool       | Minimum Version | Purpose                                      |
 |:-----------|:----------------|:---------------------------------------------|
 | Maven      | 3.9+            | Build system                                 |
-| Docker     | 24+             | Local environment (Postgres, Redis)          |
+| Docker     | 24+             | Testcontainers-backed tests (Postgres, Kafka) |
 | Podman     | 4.x (alternative) | Drop-in Docker replacement                 |
 | `jcmd`     | bundled with JDK | JFR snapshot inspection                    |
 | JDK Mission Control (JMC) | 9.0+ | Visual JFR analysis (optional)        |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Root reactor modules from [pom.xml](pom.xml):
 - exeris-kernel-core
 - exeris-kernel-community-testkit
 - exeris-kernel-community
+- exeris-kernel-community-kafka
+- exeris-kernel-diagnostics-cli
 
 Related directories present in workspace but not part of the root reactor include:
 
@@ -78,6 +80,7 @@ mvn -pl exeris-kernel-core -am clean install
 
 ## Documentation Index
 
+- Getting started (developer guides): [docs/guides](docs/guides)
 - Architecture overview: [docs/architecture.md](docs/architecture.md)
 - Performance contract: [docs/performance-contract.md](docs/performance-contract.md)
 - Whitepaper: [docs/whitepaper.md](docs/whitepaper.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,13 +8,13 @@
 ## Executive Summary
 
 The **Exeris Kernel** is a next‑generation, zero‑copy runtime for cloud‑native, high‑performance applications.  
-Built on **Java 26**, it leverages:
+Built on **JDK 25 LTS** (distributed preview-clean, ADR-066), it leverages:
 
 - **Virtual Threads** (Project Loom, JEP 444) for 1:1 request‑to‑thread mapping.
 - **Panama FFM** (JEP 454) for zero‑copy I/O and deterministic off‑heap memory management.
 - **Scoped Values** (JEP 506) for strict, ThreadLocal-free context propagation.
 - **Flexible Constructor Bodies** (JEP 513, Closed/Delivered in JDK 25) for pre-initialising fields before `super()` in value-ready types.
-- **Lazy Constants** (JEP 526, Closed/Delivered in JDK 26) for JVM constant-folding of singleton config caches.
+- **Compute-once config caches** via the Supplier + `AtomicReference` CAS pattern, mirroring the `LazyConstant` semantic (JEP 526) without depending on it — JEP 526 is not on the JDK 25 baseline.
 - **Valhalla Readiness (JEP 401):** All data carriers (`record`, `final class`) avoid `synchronized`, `System.identityHashCode()`, and identity `==` so they scalarise via C2 JIT Escape Analysis today. Migration to `value record`/`value class` will be performed once JEP 401 reaches mainline GA.
 
 **No Waste Compute** is the core principle:
@@ -271,6 +271,9 @@ For the complete deployment diagram, infrastructure requirements, and SLA/SLO ba
 
 To understand how these concepts map to actual code, read the subsystem definitions:
 
+**Getting started:**
+- [Developer Guides](guides/) – task-oriented paths: platform and dependencies, building an application, implementing a provider
+
 **Physical Modules (The Wall):**
 - [SPI Module](modules/01-spi.md) – The Constitution & Contracts
 - [Core Module](modules/02-core.md) – The Brain & Orchestration
@@ -283,6 +286,7 @@ To understand how these concepts map to actual code, read the subsystem definiti
 - [Bootstrap](subsystems/bootstrap.md) | [Config](subsystems/config.md) | [Memory](subsystems/memory.md) | [Security](subsystems/security.md)
 - [Transport](subsystems/transport.md) | [Persistence](subsystems/persistence.md) | [Graph](subsystems/graph.md) | [Flow](subsystems/flow.md)
 - [Crypto](subsystems/crypto.md) | [Telemetry](subsystems/telemetry.md) | [Events](subsystems/events.md)
+- [HTTP](subsystems/http.md) | [Scheduling](subsystems/scheduling.md) | [Storage](subsystems/storage.md) | [Exceptions](subsystems/exceptions.md)
 
 ---
 

--- a/docs/guides/01-platform-and-dependencies.md
+++ b/docs/guides/01-platform-and-dependencies.md
@@ -1,0 +1,215 @@
+# Platform and Dependencies
+
+**Audience:** anyone consuming Exeris Kernel as a dependency — whether you are building an
+application on it or implementing a provider for it.
+
+> **Verified against** `0.11.0-SNAPSHOT` at commit `1b93bf65`, 2026-08-11. Every snippet below is
+> quoted or minimally adapted from the cited file, and the citation is printed above it. If a
+> snippet and its source disagree, **the source wins and this guide is the bug**.
+
+---
+
+## Scope
+
+This page answers the *consumer* question: which JDK, which artifact line, which JVM flags, and
+which Maven coordinates. It is the only page that states them.
+
+It does **not** cover the toolchain for building this repository from source — that is
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md), and it answers a different question with different
+requirements.
+
+---
+
+## Which artifact line
+
+v0.11 ships two artifacts. They carry the **same kernel** — same SPI, same subsystems, same tests —
+and differ in one axis plus the build that follows from it.
+
+| | `0.11.0` | `0.11.0-preview` |
+|:--|:--|:--|
+| **JDK** | **25 LTS** | newest available — JDK 28 EA today |
+| **`--enable-preview`** | **not required, and not imposed on you** | required, by definition |
+| **Structured concurrency** | `StructuredScope` — virtual threads + `ScopedValue`, both GA | `StructuredTaskScope` |
+| **Class-file major** | 69 | 72 |
+| **For** | anything published, and any deployment that does not control its JVM | JVM-controlled deployments |
+
+Source: [`docs/release/v0.11.0-release-notes.md`](../release/v0.11.0-release-notes.md) (quoted).
+
+**Take `0.11.0` unless you have a reason not to.** The preview line exists to absorb JDK API churn
+ahead of the LTS it converges into, not to be the better artifact.
+
+Why this matters to you rather than to us: `--enable-preview` is not a per-library opt-in. It is a
+whole-compilation and whole-JVM flag, and the bytecode it produces is pinned to one exact class-file
+major. Had the distributed artifact carried that stamp, **you** would have to build and run your
+entire application with the flag and pin to our exact JDK. As of `0.11.0` it carries none of it —
+measured at the cut, not asserted: 930 distributed classes, class-file major 69, zero preview-stamped,
+enforced by a CI gate that reads the shipped class files (`tools/preview-bytecode-scan/`). The
+decision and its reasoning are ADR-066 ([`docs/adr/`](../adr/)).
+
+---
+
+## JVM baseline
+
+- **JDK 25 LTS or newer** for the distributed line. The JDK baseline moved 26 → 25, which for a
+  consumer is a *widening*: anything that ran on 26 still runs, and LTS-only environments become
+  reachable. Nothing in the kernel used a JDK-26-only API.
+- **No `--enable-preview`.** See above.
+- **`--enable-native-access=ALL-UNNAMED`** when the Panama FFM paths run — the native TCP transport
+  and the OpenSSL-backed crypto engine. This is the flag the kernel's own build passes to its test
+  JVM (root [`pom.xml`](../../pom.xml), `jvm.args`).
+
+> **Gap.** [`docs/operations/jvm-flags-baseline.md`](../operations/jvm-flags-baseline.md) covers
+> container awareness, GC, large pages, and CDS/AOT — but not native-access or preview. This page is
+> currently the only place the consumer-facing flag requirement is written down. Use that doc for
+> everything else about JVM tuning.
+
+---
+
+## Coordinates
+
+groupId is `eu.exeris` throughout. Import the BOM to inherit validated versions:
+
+Source: `exeris-kernel-bom/README.md:16-23` (adapted — `${project.version}` replaced by a literal;
+that property only resolves inside this reactor).
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>eu.exeris</groupId>
+            <artifactId>exeris-kernel-bom</artifactId>
+            <version>0.11.0-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Then one dependency:
+
+```xml
+<dependency>
+    <groupId>eu.exeris</groupId>
+    <artifactId>exeris-kernel-community</artifactId>
+</dependency>
+```
+
+### What that one dependency gets you
+
+`exeris-kernel-community` brings `exeris-kernel-core` and `exeris-kernel-spi` transitively, along
+with the Community providers for every subsystem. You do not declare them separately.
+
+> **How this is verified.** `exeris-kernel-diagnostics-cli` is a module in this reactor whose only
+> kernel dependency is `exeris-kernel-community` (`exeris-kernel-diagnostics-cli/pom.xml:34-40`,
+> comment: *"Brings spi + core + the Community providers to bootstrap and introspect"*) and whose
+> `main()` constructs `KernelBootstrap`
+> (`exeris-kernel-diagnostics-cli/src/main/java/eu/exeris/kernel/diagnostics/cli/DiagnosticsCli.java:75-88`).
+> It is compiled and tested by `mvn clean install` on every run.
+>
+> It calls `inspect()` rather than `boot()`. `boot()` end-to-end over a real socket is covered
+> separately by `KernelBootstrapHttpEngineFixtureIntegrationTest` in `exeris-kernel-community`.
+>
+> **Not verified:** resolution from a remote repository — see *Resolving today* below.
+
+### What the BOM manages
+
+`exeris-kernel-spi`, `-core`, `-community`, `-community-testkit`, `-community-kafka`, and
+`-tck` (both the plain jar and the `tests` / `test-jar` variant). Source:
+`exeris-kernel-bom/pom.xml:50-88`.
+
+`exeris-kernel-diagnostics-cli` is a reactor module but is **not** exported by the BOM.
+
+### Test-scope coordinates
+
+For testing an application against a real booted kernel — see
+[02 — Build an Application](./02-build-an-application.md):
+
+```xml
+<dependency>
+    <groupId>eu.exeris</groupId>
+    <artifactId>exeris-kernel-community-testkit</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+The fixtures live in that module's **main** sources, so this is a plain `test`-scoped dependency —
+no classifier. The BOM does not set a scope, so you declare it (as
+`exeris-kernel-community/pom.xml:125-129` does).
+
+For binding the TCK when implementing a provider — see
+[03 — Implement a Provider](./03-implement-a-provider.md):
+
+Source: `exeris-kernel-community/pom.xml:93-100` (quoted).
+
+```xml
+<!-- TCK abstract test classes -->
+<dependency>
+    <groupId>eu.exeris</groupId>
+    <artifactId>exeris-kernel-tck</artifactId>
+    <classifier>tests</classifier>
+    <type>test-jar</type>
+    <scope>test</scope>
+</dependency>
+```
+
+The `classifier` and `type` are both required: the abstract TCK suites live in the TCK module's
+*test* sources and are published as a test-jar.
+
+---
+
+## Resolving today
+
+**No `0.11.0` has been released.** This repository's HEAD is `0.11.0-SNAPSHOT`, and the publish
+target is GitHub Packages (`pom.xml`, `distributionManagement`), which requires authentication.
+
+So the path that actually works right now is local:
+
+```bash
+git clone git@github.com:exeris-systems/exeris-kernel.git
+cd exeris-kernel
+mvn clean install
+```
+
+then depend on `0.11.0-SNAPSHOT`, which resolves from your local repository. Nothing is published to
+Maven Central.
+
+---
+
+## The first failure you are likely to hit
+
+`EX-CFG-0001` — no `ConfigProvider` on the classpath. The kernel resolves one via `ServiceLoader`
+during bootstrap and fails hard if none is found; there is no built-in default.
+
+Source: `exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java:410-420`
+(quoted).
+
+```java
+return ServiceLoader.load(ConfigProvider.class, classLoader)
+        .stream()
+        .map(ServiceLoader.Provider::get)
+        .max(Comparator.comparingInt(ConfigProvider::priority))
+        .orElseThrow(() -> new BootstrapException(
+                "No ConfigProvider found on classpath. "
+                + "Add exeris-kernel-community (SimpleFileConfigProvider) "
+                + "or exeris-kernel-enterprise to the runtime classpath. "
+                + "[EX-CFG-0001]"));
+```
+
+Adding `exeris-kernel-community` fixes it.
+
+> **The message names a class that does not exist.** There is no `SimpleFileConfigProvider`. The
+> class Community actually registers is
+> `eu.exeris.kernel.community.config.CommunityConfigProvider`. If you searched for the name in the
+> error and found nothing, that is why. Tracked as a follow-up; the message is stale, the fix is not.
+
+---
+
+## See also
+
+- [02 — Build an Application](./02-build-an-application.md)
+- [03 — Implement a Provider](./03-implement-a-provider.md)
+- [`docs/support-matrix.md`](../support-matrix.md) — supported database, broker, TLS, and HTTP versions
+- [`docs/stability-matrix.md`](../stability-matrix.md) — how far you can lean on each SPI surface
+- [`docs/operations/jvm-flags-baseline.md`](../operations/jvm-flags-baseline.md) — GC, container, and CDS/AOT tuning
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — building this repository from source

--- a/docs/guides/01-platform-and-dependencies.md
+++ b/docs/guides/01-platform-and-dependencies.md
@@ -42,9 +42,11 @@ Why this matters to you rather than to us: `--enable-preview` is not a per-libra
 whole-compilation and whole-JVM flag, and the bytecode it produces is pinned to one exact class-file
 major. Had the distributed artifact carried that stamp, **you** would have to build and run your
 entire application with the flag and pin to our exact JDK. As of `0.11.0` it carries none of it —
-measured at the cut, not asserted: 930 distributed classes, class-file major 69, zero preview-stamped,
-enforced by a CI gate that reads the shipped class files (`tools/preview-bytecode-scan/`). The
-decision and its reasoning are ADR-066 ([`docs/adr/`](../adr/)).
+measured at the cut, not asserted: 2 282 classes of ours across the eight published modules,
+class-file major 69, zero preview-stamped. A CI gate reads the published jars and fails the build on
+any preview stamp (`tools/preview-bytecode-scan/`); it scans 15 181 classes in total, because a
+preview-stamped class vendored into the shaded diagnostics CLI would break you exactly as one of ours
+would. The decision and its reasoning are ADR-066 ([`docs/adr/`](../adr/)).
 
 ---
 

--- a/docs/guides/02-build-an-application.md
+++ b/docs/guides/02-build-an-application.md
@@ -1,0 +1,352 @@
+# Build an Application on Exeris Kernel
+
+**Audience:** you are writing an application and want the kernel to run it — boot it, serve HTTP,
+configure it, and test it.
+
+**Prerequisite:** [01 — Platform and Dependencies](./01-platform-and-dependencies.md). This page
+assumes `eu.exeris:exeris-kernel-community` is on your classpath.
+
+> **Verified against** `0.11.0-SNAPSHOT` at commit `1b93bf65`, 2026-08-11. Every snippet below is
+> quoted or minimally adapted from the cited file, and the citation is printed above it. If a
+> snippet and its source disagree, **the source wins and this guide is the bug**.
+
+---
+
+## What you are building
+
+The kernel is a library that runs inside *your* JVM process, started from *your* `main()`. There is
+no container to deploy into, no application server, and no framework that owns the lifecycle. You
+call `KernelBootstrap`, it brings up the subsystems you asked for, and it hands control back to a
+`Runnable` you supply.
+
+---
+
+## The one thing to get right
+
+**`boot(Runnable)` is blocking, and the `Runnable` you pass it *is* your application's lifetime.**
+When that `Runnable` returns, the kernel shuts down — in reverse-topological order, from a `finally`
+block that always runs
+(`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java:294-298`).
+
+So a server must **park inside the lambda**. If you boot and return immediately, you have written a
+program that starts a kernel and then stops it.
+
+Source: `exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java:192-196`
+(adapted — the fixture's latch and `AtomicReference` plumbing removed).
+
+```java
+bootstrap.boot(() -> {
+    // The kernel is up. Everything you do lives here.
+    awaitShutdownSignal(stop);   // your own park — a latch, a queue take, whatever fits
+});
+// Control reaches here only after the kernel has shut down.
+```
+
+> **There is no signal handling.** From
+> [`docs/subsystems/bootstrap.md`](../subsystems/bootstrap.md):
+> *"Signal handling (SIGTERM/SIGINT) is not yet implemented; callers are responsible for invoking
+> `boot()` and managing JVM shutdown."*
+> If you want Ctrl-C or `SIGTERM` to shut down cleanly, you register the hook that releases your
+> park. The kernel will not do it for you.
+
+---
+
+## A minimal boot
+
+`KernelBootstrap` is a builder. This is the only real `main()` in the repository:
+
+Source: `exeris-kernel-diagnostics-cli/src/main/java/eu/exeris/kernel/diagnostics/cli/DiagnosticsCli.java:75-88`
+(quoted).
+
+```java
+public static void main(String[] args) throws KernelBootstrap.BootstrapException {
+    ObjectMapper mapper = newMapper();
+    KernelBootstrap.builder()
+            .selector(BootstrapSelector.all())
+            .build()
+            .inspect(() -> {
+                DiagnosticsCli cli = new DiagnosticsCli(loadDiagnostics(), mapper);
+                try {
+                    cli.serve(System.in, System.out);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+}
+```
+
+Note it calls **`inspect()`**, not `boot()`. The two differ in how far they take the kernel:
+
+| | `boot(Runnable)` | `inspect(Runnable)` |
+|:--|:--|:--|
+| Resolves config + subsystem topology | yes | yes |
+| Calls `initialize()` / `start()` | **yes** | **no** |
+| Use for | running an application | introspecting what *would* boot |
+
+`inspect()` is the zero-risk way to check your classpath resolves before you commit to a real boot.
+
+Builder options (`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/KernelBootstrap.java:464-513`): `selector(...)`, `failurePolicy(...)`,
+`classLoader(...)`, `build()`.
+
+---
+
+## Choosing which subsystems come up
+
+`BootstrapSelector` decides what boots. **You never list dependencies by hand** — the orchestrator
+expands the transitive closure for you.
+
+```java
+BootstrapSelector.all()                        // everything on the classpath
+BootstrapSelector.none()                       // config scope only, no subsystems
+BootstrapSelector.forNames("http")             // http + everything it depends on
+BootstrapSelector.forNames("persistence", "events")
+```
+
+Source: `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/BootstrapSelector.java:67, 81, 102`.
+
+The Community subsystems, with what each declares:
+
+| Subsystem | `dependsOn()` | `phase()` |
+|:--|:--|:--|
+| `memory` | — | FOUNDATION |
+| `crypto` | `memory` | SERVICES |
+| `security` | `memory` | SERVICES |
+| `persistence` | `memory` | SERVICES |
+| `transport` | `memory`, `crypto` | SERVICES |
+| `graph` | `memory`, `persistence` | SERVICES |
+| `scheduling` | — | SERVICES |
+| `events` | `memory`, `persistence` | RUNTIME |
+| `flow` | `persistence` | RUNTIME |
+| `http` | `memory` | RUNTIME |
+
+Source: the `name()` / `dependsOn()` / `phase()` methods of
+`exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/Community*Subsystem.java`
+(read from source, 2026-08-11).
+
+Phases run in order — `FOUNDATION(0)` → `SERVICES(1)` → `RUNTIME(2)` — and a subsystem in phase N
+starts only after every subsystem in phase N-1 is `RUNNING`
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/BootstrapPhase.java:12-22`).
+
+> **Note on [`docs/subsystems/bootstrap.md`](../subsystems/bootstrap.md).** Its Diagram 1 predates
+> the current Community set — it omits `security` and `scheduling` — and its `(parallel)` phase
+> labels predate the v0.11 change described later in that same document, where phases start on the
+> booting thread (ADR-066). The table above is the current set; read the diagram for the DAG
+> concept, not the membership.
+
+### Failure policy
+
+`FAIL_FAST` is the default: any subsystem failing to start aborts the boot. `DEGRADE` continues past
+failures, but only for subsystems that declare `isOptional()`, and never for `FOUNDATION`.
+
+---
+
+## Serving HTTP
+
+### The rule: bind the handler *around* `boot()`, not inside it
+
+Your handler reaches the HTTP engine through a `ScopedValue`,
+`HttpKernelProviders.HTTP_SERVER_HANDLER`
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpKernelProviders.java:80`). The HTTP
+subsystem reads it during `start()`.
+
+That ordering is the whole trick. From `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/BootstrapPhase.java:16-22`:
+
+> *"the Core orchestrator starts them in order on the booting thread (ADR-066), because a subsystem's
+> `start()` must observe the `ScopedValue` bindings the application established around `boot()`, and
+> those cannot be carried onto another thread."*
+
+Bind it inside the lambda and the subsystem has already started without it.
+
+Source: `exeris-kernel-community-testkit/src/main/java/eu/exeris/kernel/community/testkit/http/KernelBootstrapHttpEngineFixture.java:185-202`
+(adapted — latch, `AtomicReference`, and failure capture removed).
+
+```java
+KernelBootstrap bootstrap = KernelBootstrap.builder()
+        .selector(BootstrapSelector.forNames("http"))
+        .build();
+
+ScopedValue.where(HttpKernelProviders.HTTP_SERVER_HANDLER, handler)
+        .run(() -> {
+            try {
+                bootstrap.boot(() -> awaitShutdownSignal(stop));
+            } catch (KernelBootstrap.BootstrapException e) {
+                throw new IllegalStateException(e);
+            }
+        });
+```
+
+**If you bind nothing**, the subsystem falls back to built-in health routes — `/health`,
+`/health/live`, `/health/ready` — and every other path is unserved. A kernel that answers only
+`/health` usually means the bind never happened.
+
+### Writing a handler
+
+`HttpHandler` is a `@FunctionalInterface` with one method, `void handle(HttpExchange)`
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpHandler.java:37-50`). On the exchange you get `request()`,
+`pathParams()`, and `respond(...)` — which you must call **exactly once**.
+
+Source: `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/testing/http/KernelBootstrapHttpEngineFixtureIntegrationTest.java:38-47`
+(quoted).
+
+```java
+fixture.start(exchange -> {
+    HttpResponse response = switch (exchange.request().path()) {
+        case "/fixture" -> HttpResponse.noBody(
+                HttpStatus.OK,
+                exchange.request().version(),
+                List.of(new HttpHeader("X-Fixture-Handler", "active")));
+        default -> HttpResponse.noBody(HttpStatus.NOT_FOUND, exchange.request().version());
+    };
+    exchange.respond(response);
+});
+```
+
+`respond` has four forms (`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/http/HttpExchange.java:86-122`): `respond(HttpResponse)`,
+`respond(HttpTypedResponse)`, `respond(HttpStatus, Object)` — which serialises the payload through
+the response encoder — and `respond(HttpStatus)` for a bare status.
+
+### Routing
+
+You do not have to `switch` on paths. `HttpRouter` **is** an `HttpHandler`
+(`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java:51`), so it
+drops into the same slot.
+
+Source: `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/testing/http/GeneratedAppBootPathReachabilityIntegrationTest.java:66-71, 104-111`
+(quoted, two fragments joined).
+
+```java
+HttpRouter router = HttpRouter.builder()
+        .route(GeneratedAppBootPathReachabilityIntegrationTest::respondWithCapturedId, "/x/{id}",
+                HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE)
+        .route(HttpMethod.POST, "/x", GeneratedAppBootPathReachabilityIntegrationTest::decodeAndEcho)
+        .build();
+
+private static void respondWithCapturedId(HttpExchange exchange) {
+    String id = exchange.pathParams().get("id");
+    exchange.respond(HttpResponse.noBody(
+            HttpStatus.OK,
+            exchange.request().version(),
+            List.of(new HttpHeader("X-Path-Id", id == null ? "" : id))));
+}
+```
+
+Builder surface (`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/http/routing/HttpRouter.java:235-315`): `route(method, path, handler)`,
+`route(handler, path, methods...)`, `prefixRoute(method, prefix, handler)`,
+`streamRoute(method, path, streamHandler)` for SSE, and `notFound(handler)`.
+
+Resolution precedence is **exact → template → prefix**, with a HEAD→GET fallback.
+
+---
+
+## Configuration
+
+There is no configuration file. Community resolves every key in this order:
+
+1. System property `exeris.<key>` — e.g. `-Dexeris.http.port=8080`
+2. Environment variable `EXERIS_<KEY>` — dots and dashes become underscores, uppercased: `EXERIS_HTTP_PORT=8080`
+3. The compiled default
+
+Source: `exeris-kernel-community/src/main/java/eu/exeris/kernel/community/config/CommunityConfigProvider.java:180-197`.
+
+Inside your application, read config with `KernelProviders.CURRENT_CONFIG.get()`.
+
+> **Two limits worth knowing before you design around config.**
+> - **No file is read at startup.** The `DynamicConfigFileWatcher` in Core parses `.properties` files
+>   for *hot-reload* only, from `exeris.config.dir` / `EXERIS_CONFIG_DIR` / `/etc/exeris/config`.
+> - **Community's `watch()` is a documented no-op** — hot-reload is an Enterprise capability
+>   (`exeris-kernel-community/src/main/java/eu/exeris/kernel/community/config/CommunityConfigProvider.java:151-159`: *"No-op — Community tier does not support hot-reload"*).
+>
+> So in Community, configuration is entirely system properties and environment variables. See
+> [`docs/subsystems/config.md`](../subsystems/config.md) for the full contract.
+
+### HTTP keys
+
+`http.mode`, `http.bindHost`, `http.port` (falls back to `network.port`), `http.maxConnections`,
+`http.idleTimeoutMillis`, `http.maxRequestHeaderCount`, `http.maxRequestHeaderSize`,
+`http.maxRequestBodyBytes`, `http.h2cUpgradeEnabled`, `http.maxVersion`.
+
+Source: `exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityHttpConfigResolver.java:65-116`.
+
+> ### Gotcha: HTTP binds nothing, silently
+>
+> If **neither** `http.mode` **nor** a port is set, the resolver returns `HttpMode.DISABLED` and the
+> subsystem binds no socket. No exception, no warning — the `ScopedValue` slots simply stay unbound.
+>
+> Source: `exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityHttpConfigResolver.java:110-112` (quoted).
+>
+> ```java
+> boolean hasExplicitPort = configProvider.getInt("http.port").isPresent()
+>     || configProvider.getInt("network.port").isPresent();
+> return hasExplicitPort ? HttpMode.SERVER : HttpMode.DISABLED;
+> ```
+>
+> Set them explicitly:
+> `-Dexeris.http.mode=SERVER -Dexeris.http.bindHost=127.0.0.1 -Dexeris.http.port=8080`.
+
+---
+
+## Testing against a real kernel
+
+Do not write a double. `exeris-kernel-community-testkit` ships fixtures that boot the **real** kernel,
+and they live in that module's *main* sources so your application can depend on them at `test` scope
+(coordinates in [01](./01-platform-and-dependencies.md#test-scope-coordinates)).
+
+Source: `docs/modules/06-testkit.md` (quoted).
+
+```java
+try (EmbeddedHttpEngineFixture fixture = EmbeddedHttpEngineFixtures.kernelBootstrapFixture()) {
+    fixture.start(exchange -> exchange.respond(HttpStatus.OK));
+    int port = fixture.boundPort();
+    // drive a real client at 127.0.0.1:port
+}
+```
+
+The fixture reserves a loopback port, boots the `http` subsystem, and binds your handler using
+exactly the `ScopedValue` pattern shown above. `close()` is a hard stop that releases the boot and
+joins.
+
+Because it boots the real thing, a router passed to `fixture.start(...)` behaves as it will in
+production — path templates resolve, and a `POST` with a JSON body decodes. That is what
+`GeneratedAppBootPathReachabilityIntegrationTest` asserts over a real socket.
+
+There is also a persistence fixture (`EmbeddedPersistenceEngineFixtures.inMemoryH2()`). See
+[`docs/modules/06-testkit.md`](../modules/06-testkit.md) for both, the threading rules, and what the
+fixtures deliberately do not cover.
+
+---
+
+## When it doesn't work
+
+| Symptom | Cause |
+|:--|:--|
+| Process exits immediately after boot | Your `Runnable` returned. Park inside it. |
+| Nothing listening on the port | `http.mode` and port both unset → `DISABLED`. See the gotcha above. |
+| Only `/health*` responds; everything else unserved | `HTTP_SERVER_HANDLER` was never bound — or was bound *inside* `boot()` instead of around it. |
+| `BootstrapException` … `[EX-CFG-0001]` | No `ConfigProvider` on the classpath. Add `exeris-kernel-community` — see [01](./01-platform-and-dependencies.md). |
+| Ctrl-C leaves resources open | No signal handling exists. Register your own hook to release the park. |
+| A subsystem you expected is missing | Check your `BootstrapSelector`. `forNames` pulls transitive dependencies, but not unrelated subsystems. |
+
+---
+
+## Not available today
+
+Stated so you do not go looking:
+
+- **No signal handling** (`docs/subsystems/bootstrap.md`) — you own the shutdown hook.
+- **No startup configuration file** in Community; properties and environment variables only.
+- **No hot-reload** in Community — `watch()` is a no-op.
+- **No example application or Maven archetype** in this repository. The closest runnable references
+  are `exeris-kernel-diagnostics-cli` and the integration tests cited above.
+- **No published release.** See *Resolving today* in [01](./01-platform-and-dependencies.md).
+
+---
+
+## See also
+
+- [01 — Platform and Dependencies](./01-platform-and-dependencies.md)
+- [03 — Implement a Provider](./03-implement-a-provider.md)
+- [`docs/subsystems/bootstrap.md`](../subsystems/bootstrap.md) — boot DAG, state machine, health probes
+- [`docs/subsystems/http.md`](../subsystems/http.md) — codec, HTTP/2, operational endpoints
+- [`docs/subsystems/config.md`](../subsystems/config.md) — full configuration contract
+- [`docs/modules/06-testkit.md`](../modules/06-testkit.md) — the fixtures in full
+- [`docs/stability-matrix.md`](../stability-matrix.md) — how far you can lean on each surface

--- a/docs/guides/03-implement-a-provider.md
+++ b/docs/guides/03-implement-a-provider.md
@@ -14,8 +14,10 @@ coordinates.
 
 ## What implementing a provider means
 
-You implement one of 15 root interfaces in `exeris-kernel-spi`, register it in a
-`META-INF/services` file, and the kernel finds it through `java.util.ServiceLoader` at bootstrap.
+You implement a root interface in `exeris-kernel-spi`. Most of them — 15 of the 16 — are found
+through `java.util.ServiceLoader` at bootstrap, which means registering the class in a
+`META-INF/services` file. One is not: see *The contract that is not ServiceLoader-discovered* below,
+and check which kind yours is before you write that file.
 
 There is no dependency injection, and that is enforced rather than encouraged —
 `exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/arch/ExerisArchitectureTest.java:107-113`
@@ -24,7 +26,7 @@ use pure constructors and ServiceLoader."*
 
 ---
 
-## The 15 root provider interfaces
+## The 15 ServiceLoader-discovered root interfaces
 
 Each is registered under its fully-qualified name in `META-INF/services/`. This inventory is the
 contents of `exeris-kernel-community/src/main/resources/META-INF/services/` read on 2026-08-11.
@@ -50,11 +52,35 @@ contents of `exeris-kernel-community/src/main/resources/META-INF/services/` read
 Check [`docs/stability-matrix.md`](../stability-matrix.md) before you build on one — some of these
 surfaces are `preview` and may still move.
 
+### The contract that is not ServiceLoader-discovered
+
+`security.identity.IdentityProvider`
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/identity/IdentityProvider.java`,
+ADR-040) is a full root contract — it has its own `AbstractIdentityProviderTck` and a Community
+binding in `CommunityOidcIdentityProviderTckTest` — but it appears in **no** `META-INF/services`
+file, and writing one for it accomplishes nothing.
+
+It is selected per-token instead of per-boot, so a static classpath scan is the wrong mechanism.
+`IdentityProviderRegistry` picks **exactly one** provider: highest `priority()` wins, ties resolve by
+registration order, and the first candidate whose `canAttempt(rawToken)` returns `true` is selected
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/security/identity/IdentityProviderRegistry.java`).
+`SecurityProvider` — which *is* ServiceLoader-discovered — owns the registry and dispatches into it.
+
+The dispatch is fail-closed by contract, and that constrains your implementation: if the selected
+provider's `authenticate` fails, the caller must **not** re-select another provider for the same
+token. Re-dispatch on failure is token-confusion — a token its rightful issuer rejected getting
+accepted by a laxer provider. If no provider claims the token, the registry returns `null` and the
+dispatcher maps that to a terminal `EX-SEC-2002` deny.
+
+So before writing artifact 3 below, check which kind of contract yours is. The four-artifact recipe
+is right for the 15 above; for `IdentityProvider` the third artifact is registry wiring, not a
+services file.
+
 ---
 
 ## The four artifacts
 
-Every provider is exactly four things. **Omitting the third or fourth is the standard failure**: the
+A ServiceLoader-discovered provider is exactly four things. **Omitting the third or fourth is the standard failure**: the
 code compiles, the tests you wrote pass, and the kernel never loads your class.
 
 1. The **SPI interface** you implement.

--- a/docs/guides/03-implement-a-provider.md
+++ b/docs/guides/03-implement-a-provider.md
@@ -1,0 +1,479 @@
+# Implement a Provider
+
+**Audience:** you are implementing one of the kernel's SPI contracts — a driver, an engine, a
+provider — either inside this repository or as your own module.
+
+**Prerequisite:** [01 — Platform and Dependencies](./01-platform-and-dependencies.md) for the TCK
+coordinates.
+
+> **Verified against** `0.11.0-SNAPSHOT` at commit `1b93bf65`, 2026-08-11. Every snippet below is
+> quoted or minimally adapted from the cited file, and the citation is printed above it. If a
+> snippet and its source disagree, **the source wins and this guide is the bug**.
+
+---
+
+## What implementing a provider means
+
+You implement one of 15 root interfaces in `exeris-kernel-spi`, register it in a
+`META-INF/services` file, and the kernel finds it through `java.util.ServiceLoader` at bootstrap.
+
+There is no dependency injection, and that is enforced rather than encouraged —
+`exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/arch/ExerisArchitectureTest.java:107-113`
+fails the build if a Spring, Guice, or `jakarta.inject` type appears in SPI, *"because Zero-Magic DI:
+use pure constructors and ServiceLoader."*
+
+---
+
+## The 15 root provider interfaces
+
+Each is registered under its fully-qualified name in `META-INF/services/`. This inventory is the
+contents of `exeris-kernel-community/src/main/resources/META-INF/services/` read on 2026-08-11.
+
+| SPI interface (`eu.exeris.kernel.spi.…`) | Community implementation | Contract doc |
+|:--|:--|:--|
+| `bootstrap.SubsystemProvider` | `CommunitySubsystemProvider` | [bootstrap](../subsystems/bootstrap.md) |
+| `config.ConfigProvider` | `CommunityConfigProvider` | [config](../subsystems/config.md) |
+| `crypto.KernelCryptoProvider` | `CommunityKernelCryptoProvider` | [crypto](../subsystems/crypto.md) |
+| `diagnostics.KernelDiagnosticsProvider` | `CommunityKernelDiagnosticsProvider` | ADR-033 |
+| `events.EventProvider` | `CommunityEventProvider` | [events](../subsystems/events.md) |
+| `flow.FlowProvider` | `CommunityFlowProvider` | [flow](../subsystems/flow.md) |
+| `graph.GraphProvider` | `CommunityGraphProvider` | [graph](../subsystems/graph.md) |
+| `http.HttpProvider` | `CommunityHttpProvider` | [http](../subsystems/http.md) |
+| `memory.MemoryProvider` | `CommunityMemoryProvider` | [memory](../subsystems/memory.md) |
+| `persistence.PersistenceProvider` | `CommunityPersistenceProvider` | [persistence](../subsystems/persistence.md) |
+| `scheduling.JobSchedulerProvider` | `CommunityJobSchedulerProvider` | [scheduling](../subsystems/scheduling.md) |
+| `security.SecurityProvider` | `CommunitySecurityProvider` | [security](../subsystems/security.md) |
+| `storage.blob.BlobStorageProvider` | `CommunityFilesystemBlobStorageProvider`, `CommunityS3BlobStorageProvider` | [storage](../subsystems/storage.md) |
+| `telemetry.TelemetryProvider` | `CommunityTelemetryProvider` | [telemetry](../subsystems/telemetry.md) |
+| `transport.TransportProvider` | `NativeTcpTransportProvider` | [transport](../subsystems/transport.md) |
+
+Check [`docs/stability-matrix.md`](../stability-matrix.md) before you build on one — some of these
+surfaces are `preview` and may still move.
+
+---
+
+## The four artifacts
+
+Every provider is exactly four things. **Omitting the third or fourth is the standard failure**: the
+code compiles, the tests you wrote pass, and the kernel never loads your class.
+
+1. The **SPI interface** you implement.
+2. Your **implementation class**.
+3. A **`META-INF/services` registration file**.
+4. A **TCK binding test**.
+
+The worked example below is `CommunityTelemetryProvider` — the smallest complete provider-and-TCK
+pair in the repository.
+
+### 1. The SPI interface
+
+Source: `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/telemetry/TelemetryProvider.java:33-58`
+(quoted).
+
+```java
+public interface TelemetryProvider {
+
+    /**
+     * Creates all active sinks for this provider.
+     * ...
+     * @throws TelemetryBootstrapException if a required sink cannot be initialized
+     */
+    List<TelemetrySink> createSinks(TelemetryConfig config);
+
+    /**
+     * Display name used in bootstrap JFR events (e.g., {@code "ExerisEnterprise/BinaryGlassBox"}).
+     */
+    String providerName();
+
+    /**
+     * Higher value wins; Community = 0, Enterprise = 100.
+     */
+    default int priority() {
+        return 0;
+    }
+}
+```
+
+### 2. The implementation
+
+Source: `exeris-kernel-community/src/main/java/eu/exeris/kernel/community/telemetry/CommunityTelemetryProvider.java:36-81`
+(quoted, `closeCreatedSinks` body elided).
+
+```java
+public final class CommunityTelemetryProvider implements TelemetryProvider {
+
+    private static final String PROVIDER_NAME = "ExerisCommunity/TextTelemetry";
+
+    @Override
+    public List<TelemetrySink> createSinks(TelemetryConfig config) {
+        List<TelemetrySink> sinks = new ArrayList<>(4);
+        try {
+            if (config.jfrSinkEnabled()) {
+                sinks.add(new JfrTelemetrySink());
+            } else {
+                sinks.add(new Slf4jTelemetrySink());
+            }
+            // … console and file sinks, conditional on config …
+        } catch (RuntimeException e) { //NOPMD AvoidCatchingGenericException — must close partial sinks
+            closeCreatedSinks(sinks, e);
+            throw new TelemetryBootstrapException(PROVIDER_NAME, "Sink creation failed", e);
+        }
+        return List.copyOf(sinks);
+    }
+
+    @Override
+    public String providerName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}
+```
+
+Three things here are house style, not incidental:
+
+- **`public final class`** with an implicit public no-arg constructor. `ServiceLoader` requires the
+  no-arg constructor; if you add a constructor with arguments and no default, discovery fails at
+  runtime, not at compile time.
+- **`PROVIDER_NAME` as a constant**, returned by `providerName()` and reused in the failure path —
+  not a literal repeated at each site.
+- **Partial construction is cleaned up before throwing.** If the third sink fails, the two already
+  created are closed and their close-failures suppressed onto the original. A provider that
+  half-initialises and throws leaks whatever it opened.
+
+### 3. The registration file
+
+File: `exeris-kernel-community/src/main/resources/META-INF/services/eu.exeris.kernel.spi.telemetry.TelemetryProvider`
+
+```
+eu.exeris.kernel.community.telemetry.CommunityTelemetryProvider
+```
+
+The filename is the fully-qualified interface name; the content is one fully-qualified
+implementation class per line. Two implementations of one interface means two lines — as
+`BlobStorageProvider` does for the filesystem and S3 drivers.
+
+The contract is documented in the SPI itself
+(`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/SubsystemProvider.java:36-45`):
+the factory method MUST be pure — no side effects, no I/O, no locks — the returned list MUST NOT
+contain duplicates, and implementations MUST have a public no-arg constructor.
+
+### 4. The TCK binding test
+
+Source: `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/telemetry/CommunityTelemetryProviderTckTest.java:30-47`
+(quoted — this is the entire class).
+
+```java
+@DisplayName("Community: CommunityTelemetryProvider TCK")
+class CommunityTelemetryProviderTckTest extends AbstractTelemetryProviderTck {
+
+    @Override
+    protected TelemetryProvider createProvider() {
+        return new CommunityTelemetryProvider();
+    }
+
+    @Override
+    protected boolean expectStandardJfrSinkWhenEnabled() {
+        return true;
+    }
+
+    @Override
+    protected boolean expectSlf4jFallbackWhenJfrDisabled() {
+        return true;
+    }
+}
+```
+
+That is the whole binding. You supply a factory; the abstract suite supplies the assertions.
+
+---
+
+## Discovery, priority, and who wins
+
+Every root interface declares `default int priority()` returning `0`. When several providers for the
+same interface are on the classpath, the highest wins.
+
+The convention, quoted from
+`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/events/EventProvider.java:66-72`:
+
+```
+ * Convention:
+ *   Community: 0
+ *   Enterprise: 100
+ *   Test/Noop: -1
+```
+
+> **A real value in this repository does not fit that table, and copying it as a tier is wrong.**
+> `KafkaEventProvider.PRIORITY = 50`
+> (`exeris-kernel-community-kafka/src/main/java/eu/exeris/kernel/community/kafka/KafkaEventProvider.java:41-45`).
+> Its own comment says why: *"above in-memory Community (0) so Kafka wins ServiceLoader, and below
+> the Enterprise tier slot (100). **Intra-Community precedence, not a tier value.**"* Use values
+> between the tier slots to order providers *within* a tier — do not read 50 as a tier of its own.
+
+### Two selection rules, and they differ
+
+- **Most providers** — `BootstrapProviderSelector.loadHighestPriority(...)`
+  (`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/BootstrapProviderSelector.java:65-100`):
+  highest priority wins, filtered by an availability predicate, with a deterministic class-name
+  tie-break so two equal-priority providers never resolve at random.
+- **Subsystems** — `SubsystemRegistryLoader`
+  (`exeris-kernel-core/src/main/java/eu/exeris/kernel/core/bootstrap/SubsystemRegistryLoader.java:66-95`): providers are sorted by
+  priority, then **first write wins per subsystem name** (`putIfAbsent`). A lower-priority provider
+  can still contribute a subsystem that no higher-priority provider claimed.
+
+Community also carries its own copy of the selector for its internal wiring
+(`exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/CommunityProviderDiscovery.java:39-46`).
+
+---
+
+## If your provider owns a subsystem
+
+A provider that needs lifecycle — something to start and stop with the kernel — implements
+`Subsystem` and exposes it through a `SubsystemProvider`.
+
+Contract (`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/Subsystem.java`):
+
+| Method | Line | Purpose |
+|:--|:--|:--|
+| `name()` | 65 | unique identity; what `BootstrapSelector.forNames` matches |
+| `dependsOn()` | 90 | names that must be `RUNNING` first |
+| `phase()` | 100 | `FOUNDATION` / `SERVICES` / `RUNTIME` |
+| `initialize()` | 112 | phase 1 — resolve providers, allocate |
+| `start()` | 123 | phase 2 — bind sockets, begin work |
+| `stop()` | 133 | phase 3 — graceful shutdown |
+| `isRunning()` | 141 | default-implemented health signal |
+| `isOptional()` | 154 | whether `DEGRADE` policy may skip you |
+| `providerBindings()` | 214 | `UnaryOperator<ScopedValue.Carrier>` — called after `initialize()`, before `start()` |
+
+> **`stop()` must not throw.** Quoted from `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/bootstrap/Subsystem.java:128-132`:
+> *"The orchestrator calls `stop()` in reverse topological order so that dependents are always
+> stopped before their dependencies. Implementations MUST NOT throw from this method — exceptions
+> are caught and logged as WARN by the orchestrator."*
+> A throwing `stop()` does not fail loudly; it disappears into a log line while the resource stays
+> open.
+
+For the common shape — one subsystem resolving one provider into one `ScopedValue` slot — extend
+`AbstractSingleProviderSubsystem`
+(`exeris-kernel-community/src/main/java/eu/exeris/kernel/community/bootstrap/AbstractSingleProviderSubsystem.java:62-92`)
+rather than reimplementing discovery.
+
+---
+
+## Errors your provider throws
+
+Every kernel exception extends `ExerisKernelException` and carries a registered error code plus
+**raw, unformatted arguments**. The reason is allocation discipline: failure paths must not build
+strings. The banned-versus-correct contrast is written out at
+`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/memory/MemoryExhaustedException.java:33-45`
+— read it once and the rule sticks.
+
+Two files, always. First the code, in the single registry:
+
+Source: `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/KernelErrorCodes.java:145-154`
+(quoted).
+
+```java
+/**
+ * Telemetry provider failed to initialise one or more sinks.
+ *
+ * <p><b>rawArgs layout for Glass-Box:</b>
+ * <ul>
+ *   <li>index 0 – {@code String} providerName</li>
+ *   <li>index 1 – {@code String} reason</li>
+ * </ul>
+ */
+public static final String EX_BOOT_3001 = "EX-BOOT-3001";
+```
+
+Then the exception, mirroring that layout in its own javadoc:
+
+Source: `exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/telemetry/TelemetryBootstrapException.java:14-36`
+(quoted).
+
+```java
+/**
+ * Thrown when the {@link eu.exeris.kernel.spi.telemetry.TelemetryProvider} cannot initialise one or more sinks.
+ *
+ * <h2>rawArgs Binary Layout</h2>
+ * <pre>
+ * index 0 → String providerName  (which provider failed to initialise)
+ * index 1 → String reason        (failure cause — static constant, never formatted)
+ * </pre>
+ */
+public final class TelemetryBootstrapException extends ExerisKernelException {
+
+    private static final String MESSAGE = "Telemetry provider bootstrap failed";
+
+    public TelemetryBootstrapException(String providerName, String reason) {
+        super(KernelErrorCodes.EX_BOOT_3001, MESSAGE, null, providerName, reason);
+    }
+
+    public TelemetryBootstrapException(String providerName, String reason, Throwable cause) {
+        super(KernelErrorCodes.EX_BOOT_3001, MESSAGE, cause, providerName, reason);
+    }
+}
+```
+
+The invariants: a **static `MESSAGE` constant** with no interpolation; the code referenced through
+the `KernelErrorCodes` constant, never a string literal; and the **rawArgs layout documented in both
+places**, because the binary Glass-Box decoder reads by index and a silent reordering corrupts every
+decoded frame.
+
+Codes are `EX-[DOMAIN]-[4 digits]`. There are 14 domains — `MEM`, `BOOT`, `NET`, `HTTP`, `PERS`,
+`SEC`, `GRPH`, `EVENT`, `FLOW`, `CFG`, `RUN`, `DIAG`, `BLOB`, `JOB`. **Retired codes are never reused**;
+`exeris-kernel-spi/src/main/java/eu/exeris/kernel/spi/exceptions/KernelErrorCodes.java:893` records one retirement explicitly rather than freeing the number.
+
+---
+
+## Naming and packaging
+
+- **Package:** `eu.exeris.kernel.community.<subsystem>`, mirroring the SPI's package segment
+  (`spi.telemetry` → `community.telemetry`).
+- **`Community*` prefix** on the root SPI-implementing class only. Internal collaborators are not
+  prefixed — `JfrTelemetrySink`, `Argon2idPasswordEncoder`, `NativeTcpCarrier`.
+- **Two existing classes break the prefix rule**: `NativeTcpTransportProvider` and
+  `KafkaEventProvider`. They are precedent for descriptive naming where the driver identity matters
+  more than the tier — not a licence to skip the prefix by default.
+- **`providerName()`** is formatted `Tier/Component` — `"ExerisCommunity/TextTelemetry"`,
+  `"ExerisCommunityKafka/Events"`. **`providerId()`** is kebab-case — `"community-transport"`,
+  `"blob-fs-community"`.
+- **Test naming:** `Community<Thing>TckTest`, or `Community<Thing>TckIT` when the test needs
+  Testcontainers — the `IT` suffix and its tag keep it out of the default build.
+
+---
+
+## Binding the TCK
+
+Add the TCK test-jar (coordinates in
+[01](./01-platform-and-dependencies.md#test-scope-coordinates)); the abstract suites live in the TCK
+module's *test* sources at
+`exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/contract/<subsystem>/Abstract*Tck.java`.
+
+Every abstract suite has the same shape: a `How to use` javadoc snippet, one or more `protected
+abstract` factory methods, optional `protected` hooks you override to opt into extra assertions, a
+`@BeforeEach final` setup, and `@Nested` groups.
+
+**The minimum is: implement every abstract method.** Nothing more. The smallest real binding in the
+repository is four lines of body:
+
+Source: `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/transport/CommunityNativeTcpProviderTckTest.java:15-22`
+(quoted — the entire class).
+
+```java
+@DisplayName("Community: NativeTcpTransportProvider TCK")
+class CommunityNativeTcpProviderTckTest extends AbstractTransportProviderTck {
+
+    @Override
+    protected TransportProvider createProvider() {
+        return new NativeTcpTransportProvider();
+    }
+}
+```
+
+Effort varies a lot by contract: `AbstractTransportProviderTck` has one abstract method,
+`AbstractSecurityProviderTck` has thirteen.
+
+> **The suite is what forces artifact 3 to exist.** `AbstractTelemetryProviderTck:273-297` contains a
+> `@Nested` ServiceLoader group asserting the provider is discoverable on the classpath and that the
+> highest-priority provider wins. A provider with no registration file compiles, passes its own unit
+> tests, and fails here.
+
+### Add your own assertions on top
+
+The abstract suite deliberately under-constrains some things so that other tiers can implement them
+differently. Where your binding has a stricter obligation, pin it locally:
+
+Source: `exeris-kernel-community/src/test/java/eu/exeris/kernel/community/bootstrap/CommunitySubsystemProviderTckTest.java:26-33`
+(quoted).
+
+```java
+@Test
+@DisplayName("priority() == 0 (Community Open-Core slot, inherited from SPI default)")
+void priorityIsCommunitySlot() {
+    // Pins the Community tier slot explicitly — AbstractSubsystemProviderTck only enforces
+    // priority() >= 0, so an accidental future override to the Enterprise slot (100) would
+    // otherwise pass. Mirrors the config provider side's isEqualTo(0) discipline.
+    assertThat(new CommunitySubsystemProvider().priority()).isEqualTo(0);
+}
+```
+
+---
+
+## The Wall — guards your code must pass
+
+`ExerisArchitectureTest` (`exeris-kernel-tck/src/test/java/eu/exeris/kernel/tck/arch/`) is an ArchUnit
+suite, and these are the rules most likely to catch a new provider:
+
+| Rule | Line | What it forbids |
+|:--|:--|:--|
+| `noJavaIoInSpi` | 38 | `java.io` in SPI — use `java.nio` or Panama FFM |
+| `noFilesystemTypesInStorageSpi` | 45 | `java.nio.file` in the blob contract (ADR-056 §9) |
+| `noStructuredTaskScopeInSchedulingSpi` | 55 | the last preview dependency, in scheduling SPI (ADR-057 §2) |
+| `noExecutorsAnywhere` | 69 | `Executors` / `ExecutorService` anywhere |
+| `noCompletableFuture` | 80 | unstructured async |
+| `noThreadLocal` | 89 | `ThreadLocal` — use `ScopedValue` |
+| `noImplLeaksInSpi` | 96 | driver types in SPI (Netty, Hikari, `java.sql`, Nimbus, Kafka) |
+| `noDiFrameworksInSpi` | 107 | Spring / Guice / `jakarta.inject` in SPI |
+| `noDirectArenaInSpi` | 116 | ad-hoc `Arena` — allocate through `MemoryAllocator` |
+| `noUnsafe` | 123 | `sun.misc.Unsafe` — use FFM |
+
+Run it yourself; do not assume CI covered it:
+
+```bash
+mvn -q -pl exeris-kernel-tck -am -Dtest=ExerisArchitectureTest \
+  -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+The reasoning behind each ban is in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md) → *Architectural Guardrails (The Wall)*.
+
+> **One documented tension, so you are not surprised by the poms.** Guidance describes Community as
+> depending on SPI only, but `exeris-kernel-community/pom.xml:81-84` declares a compile dependency on
+> `exeris-kernel-core`. That is deliberate and reconciled in
+> [`docs/modules/03-community.md`](../modules/03-community.md) as *"Controlled Core Access
+> (ADR-008)"*. The pom is the reality; the "SPI only" phrasing is the aspiration for driver code.
+
+---
+
+## Gates before an in-repo PR merges
+
+These apply to providers landing **in this repository**. An out-of-tree provider is bound only by
+the TCK it chooses to run.
+
+- **New SPI interface → an `Abstract*Tck` first.** `CONTRIBUTING.md`: *"If you add a new SPI
+  interface, you must add a corresponding `Abstract*Tck` class in `exeris-kernel-tck` before the PR
+  is mergeable."*
+- **New negative TCK case → prove it is not vacuous.** A case that would also pass against a
+  non-conforming implementation tests nothing. The procedure — a committed meta-test, or a recorded
+  guard mutation — is in
+  [`exeris-kernel-tck/README.md`](../../exeris-kernel-tck/README.md) → *Proving a New Contract Case
+  Is Not Vacuous*.
+- **The test triad:** unit + integration + TCK expansion. A PR touching an SPI boundary with only
+  unit tests is incomplete.
+- **The golden command:** `mvn clean install`. It is lint-gated; `mvn compile` and `mvn test` are not.
+
+---
+
+## Not available today
+
+- **No archetype or scaffolding tool** for a new provider module. Copy the shape from
+  `exeris-kernel-community-kafka`, which is the smallest standalone provider module in the reactor.
+- **No out-of-tree provider is exercised in CI.** The ServiceLoader path is proven by in-repo
+  bindings only, so a packaging-level problem specific to an external jar would not be caught here.
+- **Not every `Abstract*Tck` has a Community binding.** Unbound suites are open contract debt, not a
+  statement that the contract is optional.
+
+---
+
+## See also
+
+- [01 — Platform and Dependencies](./01-platform-and-dependencies.md)
+- [02 — Build an Application](./02-build-an-application.md)
+- [`docs/modules/01-spi.md`](../modules/01-spi.md) — what belongs in SPI and why
+- [`docs/modules/03-community.md`](../modules/03-community.md) — the Community tier's rules
+- [`docs/modules/05-tck.md`](../modules/05-tck.md) — contract-verification architecture
+- [`docs/stability-matrix.md`](../stability-matrix.md) — maturity of each SPI surface
+- [`docs/subsystems/exceptions.md`](../subsystems/exceptions.md) — the full error-code contract

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,70 @@
+# Developer Guides
+
+Task-oriented paths through Exeris Kernel: how to start, in the order you actually need things.
+
+These are **not** the normative documents. [`docs/subsystems/`](../subsystems/) holds the contracts
+and [`docs/adr/`](../adr/) holds the decisions; when a guide touches a contract it links out rather
+than restating it, so there is one place to fix when behaviour changes.
+
+---
+
+## Pick your path
+
+| Guide | Read it when |
+|:--|:--|
+| [01 — Platform and Dependencies](./01-platform-and-dependencies.md) | You need the JDK baseline, the JVM flags, and the Maven coordinates. Start here regardless of which of the other two you want. |
+| [02 — Build an Application](./02-build-an-application.md) | You are writing an application: boot the kernel from your own `main()`, serve HTTP, configure it, test it. |
+| [03 — Implement a Provider](./03-implement-a-provider.md) | You are implementing an SPI contract: a driver, an engine, a provider. |
+
+---
+
+## What these guides promise
+
+Every guide carries a verification header naming the commit it was checked against, and every code
+snippet carries a citation line giving its source file, line range, and whether it was quoted
+verbatim or adapted.
+
+The rule that follows from that: **if a snippet and its source disagree, the source wins and the
+guide is the bug.** Report it or fix it — do not code against the guide.
+
+Where the kernel does not do something yet, the guides say so in a *Not available today* section
+rather than describing an intended future. Nothing here is target-state.
+
+---
+
+## Maintaining these guides
+
+**Citations are `path:line`, and the path is the durable half.** Line ranges rot first; a stale range
+still leads to the right file. Keep the `(quoted)` / `(adapted)` marker accurate — it tells the next
+reader whether a diff is drift or deliberate trimming.
+
+**Prefer sources with teeth.** When the same behaviour can be shown from a test body or from prose,
+quote the test: an API change stops it compiling, so someone has to touch it. Production code is the
+next best thing; javadoc is the weakest, because nothing breaks when it goes stale.
+
+**Check that every cited path still exists** after a refactor that moves files:
+
+```bash
+grep -ohE '[A-Za-z0-9_./-]+\.(java|xml|md):[0-9]+' docs/guides/*.md \
+  | cut -d: -f1 | sort -u \
+  | while read -r p; do [ -e "$p" ] || echo "MISSING: $p"; done
+```
+
+This catches renames and deletions — the common real failure. It does **not** verify that a line
+range still contains what the guide claims; that needs a human, and it is the one step worth doing by
+hand when a subsystem changes.
+
+Keep the snippet count low. Every snippet is a maintenance liability, so the question for each one is
+whether deleting it and linking instead would lose the reader.
+
+---
+
+## Where these guides stop
+
+- [`docs/subsystems/`](../subsystems/) — the normative contract for each subsystem
+- [`docs/modules/`](../modules/) — what each reactor module is and may depend on
+- [`docs/architecture.md`](../architecture.md) — The Wall, the layer model, the request path
+- [`docs/stability-matrix.md`](../stability-matrix.md) — how far you can lean on a given SPI surface
+- [`docs/support-matrix.md`](../support-matrix.md) — supported database, broker, TLS, HTTP versions
+- [`docs/ROADMAP.md`](../ROADMAP.md) — known gaps and what is planned
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — contributing *to* the kernel, as opposed to building on it

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -45,10 +45,12 @@ next best thing; javadoc is the weakest, because nothing breaks when it goes sta
 **Check that every cited path still exists** after a refactor that moves files:
 
 ```bash
-grep -ohE '[A-Za-z0-9_./-]+\.(java|xml|md):[0-9]+' docs/guides/*.md \
+grep -ohE '[A-Za-z0-9_./-]+\.(java|xml|md):[0-9]+' docs/guides/*.md CONTRIBUTING.md \
   | cut -d: -f1 | sort -u \
   | while read -r p; do [ -e "$p" ] || echo "MISSING: $p"; done
 ```
+
+Widen the file list as `path:line` citations spread — the check is only worth as much as its glob.
 
 This catches renames and deletions — the common real failure. It does **not** verify that a line
 range still contains what the guide claims; that needs a human, and it is the one step worth doing by

--- a/docs/modules/06-testkit.md
+++ b/docs/modules/06-testkit.md
@@ -40,7 +40,7 @@ Boots the `http` subsystem on a reserved loopback port with a caller-supplied `H
 
 ```java
 try (EmbeddedHttpEngineFixture fixture = EmbeddedHttpEngineFixtures.kernelBootstrapFixture()) {
-    fixture.start(exchange -> exchange.respond(200, "ok"));
+    fixture.start(exchange -> exchange.respond(HttpStatus.OK));
     int port = fixture.boundPort();
     // drive a real client at 127.0.0.1:port
 }
@@ -151,3 +151,5 @@ data-integrity behaviour.
 - [`03-community.md`](03-community.md) — the providers these fixtures boot.
 - [`05-tck.md`](05-tck.md) — `Abstract*Tck` contract suites. Different job: the TCK verifies a
   *provider* against the contract; the testkit lets a *consumer* run against a real provider.
+- [`guides/02-build-an-application.md`](../guides/02-build-an-application.md) — the consumer-side
+  path these fixtures serve: booting the kernel, serving HTTP, then testing it.

--- a/docs/subsystems/bootstrap.md
+++ b/docs/subsystems/bootstrap.md
@@ -13,7 +13,7 @@
 > callers are responsible for invoking `boot()` and managing JVM shutdown.
 
 **Layer:** L0 (Orchestration)  
-**Status:** Validated Architectural Prototype (TRL‑3) — targeting JDK 26 GA / Valhalla EA
+**Status:** Validated Architectural Prototype (TRL‑3) — JDK 25 LTS baseline / Valhalla-ready carriers
 
 ---
 
@@ -233,7 +233,7 @@ Bootstrap decides the fate of the Kernel:
 - **FAIL_FAST** → Strict Mode (Target Standard). Mandatory for high-density edge environments.
 - **DEGRADE** → Reserved for local dev or emergency maintenance only. Never deploy to production in this mode.
 
-> Exeris targets **JDK 26 LTS** with **Valhalla Readiness (JEP 401 EA Preview)**. The heap-allocation budgets
+> Exeris targets **JDK 25 LTS** with **Valhalla Readiness (JEP 401, preview on JDK 28)**. The heap-allocation budgets
 > in `performance-contract.md` are met today via C2 JIT Escape Analysis scalarisation of `record`/`final class`
 > data carriers. Migration to `value record`/`value class` (requiring `value` keyword) is deferred until
 > JEP 401 reaches mainline GA — at that point, object-header elimination will further reduce memory pressure

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -12,7 +12,7 @@
 
 | Component        | Supported                                  | Notes |
 |:-----------------|:-------------------------------------------|:------|
-| **JDK**          | Java 26 (preview features enabled)         | `--enable-preview`; Loom VTs, Panama FFM, `ScopedValue`, `StructuredTaskScope`. Maven itself must run on JDK 26. |
+| **JDK**          | Java 25 LTS or newer                       | The distributed `0.11.0` artifact is preview-clean — **`--enable-preview` is not required** (ADR-066). Uses Loom VTs, Panama FFM, `ScopedValue`. Pass `--enable-native-access=ALL-UNNAMED` for the FFM transport/crypto paths. The separate `0.11.0-preview` artifact targets the newest JDK and does require the flag — see [guides/01](./guides/01-platform-and-dependencies.md). |
 | **Database**     | PostgreSQL 16                              | Persistence + Flow snapshot store + outbox; validated via Testcontainers `postgres:16`. |
 | **Event broker** | Kafka 3.6 wire (validated on CP 7.6.x)     | Optional — only when the Events subsystem uses the Kafka driver (`exeris-kernel-community-kafka`). |
 | **TLS**          | OpenSSL 3.0 – 4.x (multi-version)          | Community fd-owner TLS engine; 3.x floor retained for FIPS provider compatibility (ADR-008, OpenSSL-4 migration). |

--- a/exeris-kernel-tck/README.md
+++ b/exeris-kernel-tck/README.md
@@ -6,6 +6,10 @@
 ## Overview
 The TCK (Technology Compatibility Kit) ensures that any implementation of Exeris SPIs (Community or Enterprise) adheres to strict performance and safety contracts.
 
+> Implementing a provider and looking for the end-to-end path — SPI interface, `META-INF/services`
+> registration, TCK binding? See
+> [`docs/guides/03-implement-a-provider.md`](../docs/guides/03-implement-a-provider.md).
+
 ## 🧪 Testing Scope
 - **Lifecycle Compliance:** Verifies that subsystems respect topological initialization order.
 - **Memory Safety:** Ensures zero-copy buffers are correctly released via `LoanedBuffer` `retain()`/`release()` through the `MemoryAllocator` SPI.


### PR DESCRIPTION
> **Scoped around #318, no merge-order dependency.** #318 owns the README headline/Requirements and the CONTRIBUTING "Java Version" section; this branch deliberately does not touch them, and its versions are the better ones (it also drops `--enable-preview` from the JFR examples, which this branch never touched). Verified with `git merge-tree`: the two branches merge clean, either order.

## The gap

The repository has a thorough **reference** corpus — 15 subsystem contracts, 34 ADRs, 9 RFCs, two support matrices — and a thorough **build/debug** doc. It has nothing on the **task** axis. There is no path from "I have the dependency" to "a kernel is running and serving my handler", and nothing on writing a provider end to end.

`README.md` contains no Java at all. The only runnable "boot the real kernel" code in the tree is in `docs/modules/06-testkit.md`, framed as test fixtures.

## What this adds

Four pages under `docs/guides/`:

| Page | For |
|:--|:--|
| `01-platform-and-dependencies.md` | Consumer-side JDK baseline, JVM flags, Maven coordinates. States the ADR-066 two-track split once so 02 and 03 do not each re-litigate it. |
| `02-build-an-application.md` | `KernelBootstrap`, the bind-the-handler-**around**-`boot()` rule, routing, configuration, testing against a real kernel. |
| `03-implement-a-provider.md` | The four artifacts every provider needs, worked through `CommunityTelemetryProvider`; discovery and priority, error codes, The Wall guards. |
| `README.md` | Index, and the verification contract the guides hold themselves to. |

Every snippet is quoted or minimally adapted from a cited `path:line` in this repository, each with a caption saying which. Each guide names the commit it was verified against and states that **if a snippet and its source disagree, the source wins and the guide is the bug**. Where the kernel does not do something yet — signal handling, startup config files, hot-reload in Community — the guides say so under *Not available today* rather than describing intent.

## Bugs found while verifying, and fixed here

Writing against source rather than against the docs turned up four things that were simply wrong:

- **`docs/modules/06-testkit.md` does not compile.** The fixture snippet calls `exchange.respond(200, "ok")`; `HttpExchange` has no `(int, String)` overload — the four `respond` forms all take `HttpStatus`.
- **`LazyConstant` is not used.** `architecture.md` credited JEP 526 with backing the singleton config caches. Every occurrence in the tree is javadoc describing the semantic being *mirrored*; the actual mechanism is the Supplier + `AtomicReference` CAS pattern documented in CONTRIBUTING. This was also the only standing argument for a JDK 26 requirement.
- **`CONTRIBUTING.md` "Local Environment" is fiction end to end.** It instructs `docker compose up -d` against a root `docker-compose.yml` provisioning Postgres 16 and Redis 7. There is no compose file, no `JdbcCitadelRepository`, and no Redis dependency in Community. A newcomer following the doc fails on the second step. Replaced with the verified truth: Testcontainers-driven, tagged out of the default build, needs a daemon but no hand-started stack.
- **`subsystems/bootstrap.md` called JDK 26 an LTS.**

Plus `support-matrix.md`'s JDK row — the consumer-facing supported baseline, and the worst of the stale set ("Maven itself must run on JDK 26") — and a Module Map in README that omitted `community-kafka` and `diagnostics-cli`, both real reactor modules.

## How the "you can build an app on this" claim is substantiated

`exeris-kernel-diagnostics-cli` is the proof, and it is deliberately narrow: a reactor module whose only kernel dependency is `exeris-kernel-community` and whose `main()` constructs `KernelBootstrap`, compiled and tested by `mvn clean install` on every run. Its limitation is stated rather than smoothed over — it calls `inspect()`, not `boot()`; `boot()` end-to-end over a real socket is covered separately by `KernelBootstrapHttpEngineFixtureIntegrationTest`. The guide says plainly that resolution from a remote repository is **not** verified, because no `0.11.0` is published.

## Anti-drift

Citations are `path:line` with the path as the durable half, `(quoted)` / `(adapted)` markers, a hard cap on snippet count, and a preference for quoting test bodies over prose (an API change stops a test compiling; nothing breaks when javadoc rots). `docs/guides/README.md` documents a one-liner that checks every cited path still exists — and states its limit: it catches renames, not semantic drift.

That check earned its place immediately: it caught 13 shorthand citations in the guides' own first draft.

## Verification

- Docs-only, confirmed mechanically: `git diff --name-only` against the base returns `.md` files exclusively. Lint, ArchUnit, and TCK gates are therefore **N/A**, not skipped — there is no Java in the diff for them to analyse.
- `exeris-doc-impact-triage` → `DOCS_REVIEW_REQUIRED` (the support-matrix JDK row is a consumer-facing baseline claim), escalated to `exeris-docs-adr-check`, which found three wrong numbers in the guides — a bad line range, an abstract-method count, and an error-domain count. All corrected.
- All relative links resolve; all cited paths exist; load-bearing line ranges spot-checked by hand.
- Public-docs hygiene: no local-only links, no private or cross-repo PR references, no enterprise deep links.

## Deliberately not in scope

`operations/reference-deployment.md` (its numbers were presumably measured on the JDK 26 preview stack, so correcting only the header would assert a baseline the measurements were not taken on — no guide links it), the `SimpleFileConfigProvider` string in three source locations (a runtime-visible message, so `mvn clean install` is its gate — which is exactly what makes it a poor fit for a docs branch; guide 01 documents the mismatch meanwhile), `bootstrap.md` Diagram 1, index unification, and the descriptive "Java 26" mentions in `whitepaper.md` / `persistence.md` / `memory.md` / `01-spi.md`, which state no requirement to a reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)